### PR TITLE
[MER-670] Implement git.Repo.ListRefs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,14 @@ require (
 	emperror.dev/errors v0.8.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
+	github.com/stretchr/testify v1.3.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/internal/git/const.go
+++ b/internal/git/const.go
@@ -16,7 +16,7 @@ const (
 
 // UpstreamStatus is the status of a git ref (usually a branch) relative to its
 // upstream.
-type UpstreamStatus = string
+type UpstreamStatus string
 
 // The possible upstream statuses.
 // These match what is returned by Git's `%(upstream:trackshort)` format directive.

--- a/internal/git/const.go
+++ b/internal/git/const.go
@@ -1,0 +1,28 @@
+package git
+
+// Missing is a sentinel zero-value for object id (aka sha).
+// Git treats this value as "this thing doesn't exist".
+// For example, when updating a ref, if the old value is specified as EmptyOid,
+// Git will refuse to update the ref if already exists.
+const Missing = "0000000000000000000000000000000000000000"
+
+// The various types of objects in git.
+const (
+	TypeCommit = "commit"
+	TypeTree   = "tree"
+	TypeBlob   = "blob"
+	TypeTag    = "tag"
+)
+
+// UpstreamStatus is the status of a git ref (usually a branch) relative to its
+// upstream.
+type UpstreamStatus = string
+
+// The possible upstream statuses.
+// These match what is returned by Git's `%(upstream:trackshort)` format directive.
+const (
+	Ahead     UpstreamStatus = ">"
+	Behind    UpstreamStatus = "<"
+	Divergent UpstreamStatus = "<>"
+	InSync    UpstreamStatus = "="
+)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,12 +9,6 @@ import (
 	"strings"
 )
 
-// Missing is a sentinel zero-value for object id (aka sha).
-// Git treats this value as "this thing doesn't exist".
-// For example, when updating a ref, if the old value is specified as EmptyOid,
-// Git will refuse to update the ref if already exists.
-const Missing = "0000000000000000000000000000000000000000"
-
 type Repo struct {
 	repoDir       string
 	defaultBranch string

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,33 @@
+package git_test
+
+import (
+	"github.com/aviator-co/av/internal/git"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os/exec"
+	"testing"
+)
+
+// Initialize a new git repository.
+func initTempRepo(t *testing.T) *git.Repo {
+	dir := t.TempDir()
+	init := exec.Command("git", "init", "--initial-branch=main")
+	init.Dir = dir
+
+	err := init.Run()
+	require.NoError(t, err, "failed to initialize git repository")
+
+	repo, err := git.OpenRepo(dir)
+	require.NoError(t, err, "failed to open repo")
+
+	err = ioutil.WriteFile(dir+"/README.md", []byte("# Hello World"), 0644)
+	require.NoError(t, err, "failed to write README.md")
+
+	_, err = repo.Git("add", "README.md")
+	require.NoError(t, err, "failed to stage README.md")
+
+	_, err = repo.Git("commit", "-m", "Initial commit")
+	require.NoError(t, err, "failed to create initial commit")
+
+	return repo
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -25,6 +25,17 @@ func initTempRepo(t *testing.T) *git.Repo {
 	repo, err := git.OpenRepo(dir)
 	require.NoError(t, err, "failed to open repo")
 
+	settings := map[string]string{
+		"user.name":  "av-test",
+		"user.email": "av-test@nonexistant",
+	}
+	for k, v := range settings {
+		_, err = repo.Git("config", k, v)
+		require.NoErrorf(t, err, "failed to set config %s=%s", k, v)
+	}
+
+	exec.Command("git", "config", "--global", "").Run()
+
 	err = ioutil.WriteFile(dir+"/README.md", []byte("# Hello World"), 0644)
 	require.NoError(t, err, "failed to write README.md")
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -34,8 +34,6 @@ func initTempRepo(t *testing.T) *git.Repo {
 		require.NoErrorf(t, err, "failed to set config %s=%s", k, v)
 	}
 
-	exec.Command("git", "config", "--global", "").Run()
-
 	err = ioutil.WriteFile(dir+"/README.md", []byte("# Hello World"), 0644)
 	require.NoError(t, err, "failed to write README.md")
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2,11 +2,16 @@ package git_test
 
 import (
 	"github.com/aviator-co/av/internal/git"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os/exec"
 	"testing"
 )
+
+func init() {
+	logrus.SetLevel(logrus.DebugLevel)
+}
 
 // Initialize a new git repository.
 func initTempRepo(t *testing.T) *git.Repo {

--- a/internal/git/listrefs.go
+++ b/internal/git/listrefs.go
@@ -1,0 +1,52 @@
+package git
+
+import (
+	"emperror.dev/errors"
+	"strings"
+)
+
+func (r *Repo) ListRefs(showRef *ListRefs) ([]RefInfo, error) {
+	const refInfoPattern = "%(refname)%00" + "%(objecttype)%00" +
+		"%(objectname)%00" + "%(upstream)%00" + "%(upstream:track)"
+	args := []string{"for-each-ref", "--format", refInfoPattern}
+	if len(showRef.Patterns) > 0 {
+		args = append(args, showRef.Patterns...)
+	}
+	out, err := r.Git(args...)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(out, "\n")
+	refs := make([]RefInfo, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "\x00")
+		if len(parts) != 5 {
+			return nil, errors.New("internal error: failed to parse ref info (expected 5 parts)")
+		}
+		refs = append(refs, RefInfo{
+			Name:           parts[0],
+			Type:           parts[1],
+			Oid:            parts[2],
+			Upstream:       parts[3],
+			UpstreamStatus: parts[4],
+		})
+	}
+	return refs, nil
+}
+
+type ListRefs struct {
+	Patterns []string
+}
+
+type RefInfo struct {
+	Name string
+	Type string
+	Oid  string
+	// The name of the upstream ref (e.g., refs/remotes/<remote>/<branch>)
+	Upstream string
+	// The status of the ref relative to the upstream.
+	UpstreamStatus UpstreamStatus
+}

--- a/internal/git/listrefs.go
+++ b/internal/git/listrefs.go
@@ -31,7 +31,7 @@ func (r *Repo) ListRefs(showRef *ListRefs) ([]RefInfo, error) {
 			Type:           parts[1],
 			Oid:            parts[2],
 			Upstream:       parts[3],
-			UpstreamStatus: parts[4],
+			UpstreamStatus: UpstreamStatus(parts[4]),
 		})
 	}
 	return refs, nil

--- a/internal/git/listrefs.go
+++ b/internal/git/listrefs.go
@@ -5,9 +5,31 @@ import (
 	"strings"
 )
 
+type ListRefs struct {
+	Patterns []string
+}
+
+type RefInfo struct {
+	Name string
+	Type string
+	Oid  string
+	// The name of the upstream ref (e.g., refs/remotes/<remote>/<branch>)
+	Upstream string
+	// The status of the ref relative to the upstream.
+	UpstreamStatus UpstreamStatus
+}
+
+// ListRefs lists all refs in the repository (optionally matching a specific
+// pattern).
 func (r *Repo) ListRefs(showRef *ListRefs) ([]RefInfo, error) {
+	// We want a subset of information about each ref, so we can tell Git to
+	// print only specific fields. %00 is a null byte, which is the delimiter
+	// that we split on while parsing the output.
+	// See https://git-scm.com/docs/git-for-each-ref#_field_names for which
+	// fields are available.
 	const refInfoPattern = "%(refname)%00" + "%(objecttype)%00" +
 		"%(objectname)%00" + "%(upstream)%00" + "%(upstream:track)"
+
 	args := []string{"for-each-ref", "--format", refInfoPattern}
 	if len(showRef.Patterns) > 0 {
 		args = append(args, showRef.Patterns...)
@@ -35,18 +57,4 @@ func (r *Repo) ListRefs(showRef *ListRefs) ([]RefInfo, error) {
 		})
 	}
 	return refs, nil
-}
-
-type ListRefs struct {
-	Patterns []string
-}
-
-type RefInfo struct {
-	Name string
-	Type string
-	Oid  string
-	// The name of the upstream ref (e.g., refs/remotes/<remote>/<branch>)
-	Upstream string
-	// The status of the ref relative to the upstream.
-	UpstreamStatus UpstreamStatus
 }

--- a/internal/git/listrefs_test.go
+++ b/internal/git/listrefs_test.go
@@ -1,0 +1,24 @@
+package git_test
+
+import (
+	"github.com/aviator-co/av/internal/git"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestRepo_ListRefs(t *testing.T) {
+	repo := initTempRepo(t)
+	refs, err := repo.ListRefs(&git.ListRefs{
+		Patterns: []string{"refs/heads/*"},
+	})
+	require.NoError(t, err)
+	require.Len(t, refs, 1, "expected exactly one ref (main)")
+
+	main := refs[0]
+	assert.Equal(t, "refs/heads/main", main.Name)
+	assert.Equal(t, "commit", main.Type)
+	assert.NotEmpty(t, main.Oid)
+	assert.Empty(t, main.Upstream)
+	assert.Empty(t, main.UpstreamStatus)
+}


### PR DESCRIPTION
This is preparation for being able to run `av pr` -- we want to be able to figure out what refs already have remote tracking information.

Also added a test case! Yay!