### PR TITLE
Implement av stack reparent command

### DIFF
--- a/cmd/av/stack.go
+++ b/cmd/av/stack.go
@@ -14,6 +14,7 @@ func init() {
 		stackBranchCmd,
 		stackNextCmd,
 		stackPrevCmd,
+		stackReparentCmd,
 		stackSyncCmd,
 		stackTreeCmd,
 	)

--- a/cmd/av/stack_reparent.go
+++ b/cmd/av/stack_reparent.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/sliceutils"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+var stackReparentCmd = &cobra.Command{
+	Use:   "reparent <new-parent>",
+	Short: "change the stack parent of the current branch",
+	Long: strings.TrimSpace(`
+Change the stack parent of the current branch.
+
+This command can be used to add and/or remove a branch from a stack.
+`),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			_ = cmd.Usage()
+			return errors.New("expected exactly one argument")
+		}
+		newParent := args[0]
+
+		repo, err := getRepo()
+		if err != nil {
+			return err
+		}
+		branch, err := repo.CurrentBranchName()
+		if err != nil {
+			return errors.WrapIf(err, "failed to determine current branch")
+		}
+		diff, err := repo.Diff(&git.DiffOpts{Commit: "HEAD", Quiet: true})
+		if err != nil {
+			return err
+		}
+		if !diff.Empty {
+			return errors.New("refusing to re-parent: there are un-committed changes")
+		}
+		defaultBranch, err := repo.DefaultBranch()
+		if err != nil {
+			return errors.WrapIf(err, "failed to determine default branch")
+		}
+
+		// Check that the parent branch actually exists
+		if _, err := repo.RevParse(&git.RevParse{Rev: newParent}); err != nil {
+			return errors.Errorf("parent branch %q does not exist", newParent)
+		}
+
+		branchMeta, _ := meta.ReadBranch(repo, branch)
+
+		// We might need to rebase the branch on top of the new parent. This
+		// requires a special rebase command because the "normal" rebase command
+		// (without --onto) will consider every commit in the current branch when
+		// figuring out what to be played on top of the new parent. So, for example,
+		// if we have a stack that looks like B1->B2->B3 with corresponding commits
+		// C1->C2->C3, and we want to reparent B3 onto B1, we want to only play C3
+		// on top of C1 (and completely ignore C2).
+		// If we do `git rebase B1`, Git will try look at all commits which are
+		// reachable from C3 but not C1, and play them on top of C1. In particular,
+		// it sees that C2 and C3 are reachable from C3, so after the rebase, B3
+		// looks like C1->C2->C3, which is wrong.
+		// Instead, we need to do `git rebase --onto B1 B2 B3` which says to play
+		// the commits that are reachable from B3 but not B2 on top of B1.
+		if oldParent := branchMeta.Parent; oldParent != "" {
+			// TODO: We might get a rebase conflict during this, which we'll need to
+			// 		handle gracefully.
+			_, err := repo.Git("rebase", "--onto", newParent, oldParent, branch)
+			if err != nil {
+				return errors.WrapIff(err, "failed to rebase %q on top of %q", branch, newParent)
+			}
+
+			oldParentMeta, ok := meta.ReadBranch(repo, oldParent)
+			if ok {
+				oldParentMeta.Children = sliceutils.DeleteElement(oldParentMeta.Children, branch)
+				if err := meta.WriteBranch(repo, oldParentMeta); err != nil {
+					return errors.WrapIff(err, "failed to write branch meta for %q", oldParent)
+				}
+			}
+		}
+
+		if newParent == defaultBranch {
+			branchMeta.Parent = ""
+		} else {
+			branchMeta.Parent = newParent
+			parentMeta, _ := meta.ReadBranch(repo, newParent)
+			parentMeta.Children = append(parentMeta.Children, branch)
+			if err := meta.WriteBranch(repo, parentMeta); err != nil {
+				return errors.WrapIff(err, "failed to write branch meta for %q", newParent)
+			}
+		}
+		if err := meta.WriteBranch(repo, branchMeta); err != nil {
+			return errors.WrapIff(err, "failed to write branch meta for %q", branch)
+		}
+
+		return nil
+	},
+}

--- a/e2e_tests/av.go
+++ b/e2e_tests/av.go
@@ -65,6 +65,14 @@ func Av(t *testing.T, args ...string) AvOutput {
 	return output
 }
 
+func RequireAv(t *testing.T, args ...string) AvOutput {
+	output := Av(t, args...)
+	if output.ExitCode != 0 {
+		logrus.Panicf("av %s: exited with %v", args, output.ExitCode)
+	}
+	return output
+}
+
 func Chdir(t *testing.T, dir string) {
 	current, err := os.Getwd()
 	if err != nil {

--- a/e2e_tests/stack_reparent_test.go
+++ b/e2e_tests/stack_reparent_test.go
@@ -1,0 +1,48 @@
+package e2e_tests
+
+import (
+	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"testing"
+)
+
+func TestStackSyncReparent(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.Dir())
+
+	RequireAv(t, "stack", "branch", "foo")
+	gittest.CommitFile(t, repo, "foo.txt", []byte("foo"))
+	requireFileContent(t, "foo.txt", "foo")
+
+	RequireAv(t, "stack", "branch", "bar")
+	gittest.CommitFile(t, repo, "bar.txt", []byte("bar"))
+	requireFileContent(t, "bar.txt", "bar")
+	requireFileContent(t, "foo.txt", "foo")
+
+	RequireAv(t, "stack", "branch", "spam")
+	gittest.CommitFile(t, repo, "spam.txt", []byte("spam"))
+	requireFileContent(t, "spam.txt", "spam")
+
+	// Now, re-parent spam on top of bar (should be relatively a no-op)
+	RequireAv(t, "stack", "reparent", "bar")
+	requireFileContent(t, "spam.txt", "spam")
+	requireFileContent(t, "bar.txt", "bar", "bar.txt should still be set after reparenting onto same branch")
+
+	// Now, re-parent spam on top of foo
+	RequireAv(t, "stack", "reparent", "foo")
+	currentBranch, err := repo.CurrentBranchName()
+	require.NoError(t, err)
+	require.Equal(t, "spam", currentBranch, "branch should be set to original branch (spam) after reparenting onto foo")
+	requireFileContent(t, "spam.txt", "spam")
+	requireFileContent(t, "foo.txt", "foo", "foo.txt should be set after reparenting onto foo branch")
+	require.NoFileExists(t, "bar.txt", "bar.txt should not exist after reparenting onto foo branch")
+}
+
+func requireFileContent(t *testing.T, file string, expected string, args ...any) {
+	actual, err := ioutil.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, expected, string(actual), args...)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,8 @@ require (
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.7.1
 	github.com/whilp/git-urls v1.0.0
-	golang.org/x/mod v0.4.1
+	golang.org/x/exp v0.0.0-20220518171630-0b5c67f07fdf
+	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220518171630-0b5c67f07fdf h1:oXVg4h2qJDd9htKxb5SCpFBHLipW6hXmL3qpUixS2jw=
+golang.org/x/exp v0.0.0-20220518171630-0b5c67f07fdf/go.mod h1:yh0Ynu2b5ZUe3MQfp2nM0ecK7wsgouWTDN0FNeJuIys=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -246,8 +248,9 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"testing"
 )
@@ -15,7 +16,15 @@ func init() {
 
 // NewTempRepo initializes a new git repository with reasonable defaults.
 func NewTempRepo(t *testing.T) *git.Repo {
-	dir := t.TempDir()
+	var dir string
+	if os.Getenv("AV_TEST_PRESERVE_TEMP_REPO") != "" {
+		var err error
+		dir, err = os.MkdirTemp("", "repo")
+		require.NoError(t, err)
+		logrus.Infof("created git test repo: %s", dir)
+	} else {
+		dir = t.TempDir()
+	}
 	init := exec.Command("git", "init", "--initial-branch=main")
 	init.Dir = dir
 

--- a/internal/utils/sliceutils/sliceutils.go
+++ b/internal/utils/sliceutils/sliceutils.go
@@ -1,0 +1,12 @@
+package sliceutils
+
+// DeleteElement deletes the first element in the slice that equals the given
+// value.
+func DeleteElement[T comparable](slice []T, element T) []T {
+	for i := range slice {
+		if slice[i] == element {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+	return slice
+}


### PR DESCRIPTION
I originally wanted to do `av stack sync --parent <newparent>`, but it was different enough from a sync that I made it its own command. I'm still not 100% set on that but... 🤷.

Also, it's possible for there to be a rebase conflict during this. It's possible to get into an undesirable state if you then abort that rebase (because av thinks the parent is `<newparent>` but the git branch is still based on `<oldparent>`).

Nonetheless, I think I'd like to merge this as is and think about that limitation a bit later.