### PR TITLE
[MER-867] Add default PR title from commit subject

### DIFF
--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/sirupsen/logrus"
@@ -13,9 +12,9 @@ func getRepoInfo() (*git.Repo, *meta.Repository, error) {
 		return nil, nil, err
 	}
 
-	repoMeta, ok := meta.ReadRepository(repo)
-	if !ok {
-		return nil, nil, errors.New("this repository is not initialized for us with av: please run `av init`")
+	repoMeta, err := meta.ReadRepository(repo)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	logrus.Debugf("loaded repository metadata: %+v", repoMeta)

--- a/cmd/av/init.go
+++ b/cmd/av/init.go
@@ -22,8 +22,8 @@ var initCmd = &cobra.Command{
 		}
 
 		if !initFlags.Force {
-			_, ok := meta.ReadRepository(repo)
-			if ok {
+			_, err := meta.ReadRepository(repo)
+			if err == nil {
 				return errors.New("repository is already initialized for use with av")
 			}
 		}

--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -3,13 +3,9 @@ package main
 import (
 	"context"
 	"emperror.dev/errors"
-	"fmt"
+	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/gh"
-	"github.com/aviator-co/av/internal/git"
-	"github.com/aviator-co/av/internal/meta"
-	"github.com/shurcooL/githubv4"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
@@ -44,83 +40,10 @@ Examples:
     > EOF
 `),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// arg validation
-		if prCreateFlags.Title == "" {
-			return errors.New("title is required")
-		}
-
-		repo, repoMeta, err := getRepoInfo()
+		repo, err := getRepo()
 		if err != nil {
 			return err
 		}
-
-		currentBranch, err := repo.CurrentBranchName()
-		if err != nil {
-			return errors.WrapIf(err, "failed to determine current branch")
-		}
-
-		if !prCreateFlags.NoPush {
-			pushFlags := []string{"push"}
-
-			// Check if the upstream is set. If not, we set it during push.
-			upstream, err := repo.RevParse(&git.RevParse{
-				SymbolicFullName: true,
-				Rev:              "HEAD@{u}",
-			})
-			if err != nil {
-				// Set the upstream branch
-				upstream = "refs/remotes/origin/" + currentBranch
-				pushFlags = append(pushFlags, "--set-upstream", "origin", currentBranch)
-			}
-			logrus.WithField("upstream", upstream).Debug("pushing latest changes")
-			if _, err := repo.Git(pushFlags...); err != nil {
-				return errors.WrapIf(err, "failed to push")
-			}
-		}
-
-		// TODO:
-		//     It would be nice to be able to auto-detect that a PR has been
-		//     opened for a given PR without using av. We might need to do this
-		//     when creating PRs for a whole stack (e.g., when running `av pr`
-		//     on stack branch 3, we should make sure PRs exist for 1 and 2).
-		branchMeta, ok := meta.ReadBranch(repo, currentBranch)
-		if ok && branchMeta.PullRequest != nil && !prCreateFlags.Force {
-			return errors.Errorf("This branch already has an associated pull request: %s", branchMeta.PullRequest.Permalink)
-		}
-
-		// figure this out based on whether or not we're on a stacked branch
-		var prBaseBranch string
-		if ok && branchMeta.Parent != "" {
-			prBaseBranch = branchMeta.Parent
-			// check if the base branch also has an associated PR
-			baseMeta, ok := meta.ReadBranch(repo, prBaseBranch)
-			if !ok {
-				return errors.WrapIff(err, "failed to read branch metadata for %q", prBaseBranch)
-			}
-			if baseMeta.PullRequest == nil {
-				// TODO:
-				//     We should automagically create PRs for every branch in the stack
-				return errors.Errorf(
-					"base branch %q does not have an associated pull request "+
-						"(create one by checking out the branch and running `av pr create`)",
-					prBaseBranch,
-				)
-			}
-		} else {
-			defaultBranch, err := repo.DefaultBranch()
-			if err != nil {
-				return errors.WrapIf(err, "failed to determine default branch")
-			}
-			if currentBranch == defaultBranch {
-				return errors.Errorf(
-					"cannot create pull request for default branch %q "+
-						"(did you mean to checkout a different branch before running this command?)",
-					defaultBranch,
-				)
-			}
-			prBaseBranch = defaultBranch
-		}
-
 		client, err := gh.NewClient(config.GitHub.Token)
 		if err != nil {
 			return err
@@ -128,35 +51,25 @@ Examples:
 
 		body := prCreateFlags.Body
 		// Special case: ready body from stdin
-		if body == "-" {
+		if prCreateFlags.Body == "-" {
 			bodyBytes, err := ioutil.ReadAll(os.Stdin)
 			if err != nil {
 				return errors.Wrap(err, "failed to read body from stdin")
 			}
-			body = string(bodyBytes)
+			prCreateFlags.Body = string(bodyBytes)
 		}
 
-		pull, err := client.CreatePullRequest(context.Background(), githubv4.CreatePullRequestInput{
-			RepositoryID: githubv4.ID(repoMeta.ID),
-			BaseRefName:  githubv4.String(prBaseBranch),
-			HeadRefName:  githubv4.String(currentBranch),
-			Title:        githubv4.String(prCreateFlags.Title),
-			Body:         gh.Ptr(githubv4.String(body)),
-		})
-		if err != nil {
+		if _, err := actions.CreatePullRequest(
+			context.Background(), repo, client,
+			actions.CreatePullRequestOpts{
+				Title:    prCreateFlags.Title,
+				Body:     body,
+				SkipPush: prCreateFlags.NoPush,
+				Force:    prCreateFlags.Force,
+			},
+		); err != nil {
 			return err
 		}
-
-		branchMeta.PullRequest = &meta.PullRequest{
-			Number:    pull.Number,
-			ID:        pull.ID,
-			Permalink: pull.Permalink,
-		}
-		if err := meta.WriteBranch(repo, branchMeta); err != nil {
-			return err
-		}
-
-		_, _ = fmt.Printf("Created pull request: %s\n", pull.Permalink)
 		return nil
 	},
 }
@@ -177,9 +90,6 @@ func init() {
 		&prCreateFlags.NoPush, "no-push", false,
 		"don't push the latest changes to the remote",
 	)
-	// TODO:
-	//     Want to automatically determine the title of the PR, probably using
-	//     the headline of the first commit.
 	prCreateCmd.Flags().StringVarP(
 		&prCreateFlags.Title, "title", "t", "",
 		"title of the pull request to create",
@@ -188,5 +98,4 @@ func init() {
 		&prCreateFlags.Body, "body", "b", "",
 		"body of the pull request to create (a value of - will read from stdin)",
 	)
-	_ = prCreateCmd.MarkFlagRequired("title")
 }

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -134,6 +134,16 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 		opts.Title = firstCommit.Subject
 	}
 	if opts.Body == "" {
+		// Commits bodies are often in a fixed-width format (e.g., 80 characters
+		// wide) so most newlines should actually be spaces. Unfortunately,
+		// GitHub renders newlines in the commit body (which goes against the
+		// Markdown spec, but whatever) which makes it a little bit weird to
+		// directly include in the PR body. We could convert singe newlines to
+		// spaces to make GitHub happy, but that's not trivial without using a
+		// full-on Markdown parser (e.g., "foo\nbar" should become "foo bar" but
+		// "foo\n* bar" should stay the same).
+		// Maybe someday we can invest in making this better, but it's not the
+		// end of the world.
 		opts.Body = firstCommit.Body
 	}
 

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -1,0 +1,166 @@
+package actions
+
+import (
+	"context"
+	"emperror.dev/errors"
+	"fmt"
+	"github.com/aviator-co/av/internal/gh"
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/fatih/color"
+	"github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
+	"os"
+	"strings"
+)
+
+type CreatePullRequestOpts struct {
+	Title string
+	Body  string
+	//Labels      []string
+
+	// If true, do not push the branch to GitHub
+	SkipPush bool
+	// If true, create a PR even if we think one already exists
+	Force bool
+}
+
+// CreatePullRequest creates a pull request on GitHub for the current branch, if
+// one doesn't already exist.
+func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, opts CreatePullRequestOpts) (*gh.PullRequest, error) {
+	repoMeta, err := meta.ReadRepository(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	currentBranch, err := repo.CurrentBranchName()
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to determine current branch")
+	}
+
+	if !opts.SkipPush {
+		pushFlags := []string{"push"}
+
+		// Check if the upstream is set. If not, we set it during push.
+		// TODO: Should we store this somewhere? I think currently things will
+		//       break if the upstream name is not the same name as the local
+		upstream, err := repo.RevParse(&git.RevParse{
+			SymbolicFullName: true,
+			Rev:              "HEAD@{u}",
+		})
+		if err != nil {
+			// Set the upstream branch
+			upstream = "origin/" + currentBranch
+			pushFlags = append(pushFlags, "--set-upstream", "origin", currentBranch)
+		} else {
+			upstream = strings.TrimPrefix(upstream, "refs/remotes/")
+		}
+		logrus.WithField("upstream", upstream).Debug("pushing latest changes")
+
+		_, _ = fmt.Fprint(os.Stderr,
+			"  - pushing branch ", color.CyanString("%s", currentBranch),
+			" to GitHub (", color.CyanString("%s", upstream), ")...",
+			"\n",
+		)
+		if _, err := repo.Git(pushFlags...); err != nil {
+			return nil, errors.WrapIf(err, "failed to push")
+		}
+	}
+
+	// TODO:
+	//     It would be nice to be able to auto-detect that a PR has been
+	//     opened for a given PR without using av. We might need to do this
+	//     when creating PRs for a whole stack (e.g., when running `av pr`
+	//     on stack branch 3, we should make sure PRs exist for 1 and 2).
+	branchMeta, ok := meta.ReadBranch(repo, currentBranch)
+	if ok && branchMeta.PullRequest != nil && !opts.Force {
+		_, _ = fmt.Fprint(os.Stderr,
+			"  - ", color.RedString("ERROR: "),
+			"branch ", color.CyanString("%s", currentBranch),
+			" already has an associated pull request: ",
+			color.CyanString("%s", branchMeta.PullRequest.Permalink),
+			"\n",
+		)
+		return nil, errors.New("this branch already has an associated pull request")
+	}
+
+	// figure this out based on whether or not we're on a stacked branch
+	var prBaseBranch string
+	if ok && branchMeta.Parent != "" {
+		prBaseBranch = branchMeta.Parent
+		// check if the base branch also has an associated PR
+		baseMeta, ok := meta.ReadBranch(repo, prBaseBranch)
+		if !ok {
+			return nil, errors.WrapIff(err, "failed to read branch metadata for %q", prBaseBranch)
+		}
+		if baseMeta.PullRequest == nil {
+			// TODO:
+			//     We should automagically create PRs for every branch in the stack
+			return nil, errors.Errorf(
+				"base branch %q does not have an associated pull request "+
+					"(create one by checking out the branch and running `av pr create`)",
+				prBaseBranch,
+			)
+		}
+	} else {
+		defaultBranch, err := repo.DefaultBranch()
+		if err != nil {
+			return nil, errors.WrapIf(err, "failed to determine repository default branch")
+		}
+		if currentBranch == defaultBranch {
+			return nil, errors.Errorf(
+				"cannot create pull request for default branch %q "+
+					"(did you mean to checkout a different branch before running this command?)",
+				defaultBranch,
+			)
+		}
+		prBaseBranch = defaultBranch
+	}
+
+	commitsList, err := repo.Git("rev-list", "--reverse", fmt.Sprintf("%s..HEAD", prBaseBranch))
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to determine commits to include in PR")
+	}
+	if commitsList == "" {
+		return nil, errors.Errorf("no commits between %q and %q", prBaseBranch, currentBranch)
+	}
+	commits := strings.Split(commitsList, "\n")
+	firstCommit, err := repo.CommitInfo(git.CommitInfoOpts{Rev: commits[0]})
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to read first commit")
+	}
+
+	if opts.Title == "" {
+		opts.Title = firstCommit.Subject
+	}
+	if opts.Body == "" {
+		opts.Body = firstCommit.Body
+	}
+
+	pull, err := client.CreatePullRequest(ctx, githubv4.CreatePullRequestInput{
+		RepositoryID: githubv4.ID(repoMeta.ID),
+		BaseRefName:  githubv4.String(prBaseBranch),
+		HeadRefName:  githubv4.String(currentBranch),
+		Title:        githubv4.String(opts.Title),
+		Body:         gh.Ptr(githubv4.String(opts.Body)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	branchMeta.PullRequest = &meta.PullRequest{
+		Number:    pull.Number,
+		ID:        pull.ID,
+		Permalink: pull.Permalink,
+	}
+	if err := meta.WriteBranch(repo, branchMeta); err != nil {
+		return nil, err
+	}
+
+	_, _ = fmt.Fprintln(os.Stderr,
+		"  - Created pull request for branch ", color.CyanString("%s", currentBranch),
+		" (into branch ", color.CyanString("%s", prBaseBranch), "): ",
+		color.CyanString("%s", pull.Permalink),
+	)
+	return pull, nil
+}

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -157,10 +157,11 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 		return nil, err
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr,
-		"  - Created pull request for branch ", color.CyanString("%s", currentBranch),
+	_, _ = fmt.Fprint(os.Stderr,
+		"  - created pull request for branch ", color.CyanString("%s", currentBranch),
 		" (into branch ", color.CyanString("%s", prBaseBranch), "): ",
 		color.CyanString("%s", pull.Permalink),
+		"\n",
 	)
 	return pull, nil
 }

--- a/internal/git/show.go
+++ b/internal/git/show.go
@@ -1,0 +1,33 @@
+package git
+
+import (
+	"bytes"
+	"emperror.dev/errors"
+	"fmt"
+)
+
+type CommitInfoOpts struct {
+	Rev string
+}
+
+type CommitInfo struct {
+	Hash    string
+	Subject string
+	Body    string
+}
+
+func (r *Repo) CommitInfo(opts CommitInfoOpts) (*CommitInfo, error) {
+	res, err := r.Git("show", "--format=%H%n%s%n%b", opts.Rev)
+	if err != nil {
+		return nil, err
+	}
+	var info CommitInfo
+	buf := bytes.NewBufferString(res)
+	if _, err := fmt.Fscanf(buf, "%s\n%s\n", &info.Hash, &info.Subject); err != nil {
+		return nil, errors.WrapIff(err, "failed to read output of git show")
+	}
+	// Note: buf.ReadString returns error iff buffer doesn't contain the delimiter,
+	// which is expected, so we just ignore the error.
+	info.Body, _ = buf.ReadString('\000')
+	return &info, nil
+}

--- a/internal/meta/repository.go
+++ b/internal/meta/repository.go
@@ -19,21 +19,23 @@ type Repository struct {
 	Name string `json:"name"`
 }
 
+var ErrRepoNotInitialized = errors.New("this repository not initialized: please run `av init`")
+
 // ReadRepository reads repository metadata from the git repo.
 // Returns the metadata and a boolean indicating if the metadata was found.
-func ReadRepository(repo *git.Repo) (Repository, bool) {
+func ReadRepository(repo *git.Repo) (Repository, error) {
 	var meta Repository
 
 	metaPath := path.Join(repo.Dir(), ".git", "av", "repo-metadata.json")
 	data, err := ioutil.ReadFile(metaPath)
 	if err != nil {
-		return meta, false
+		return meta, ErrRepoNotInitialized
 	}
 	if err := json.Unmarshal(data, &meta); err != nil {
 		logrus.WithError(err).Error("repository metadata file is corrupt - ignoring")
-		return meta, false
+		return meta, ErrRepoNotInitialized
 	}
-	return meta, true
+	return meta, nil
 }
 
 // WriteRepository writes repository metadata to the git repo.


### PR DESCRIPTION
This also moves a lot of the code that was in `./cmd/av/pr.go` into a new folder:
`./internal/actions`. The reason for this is to be able to extract out certain
things that we'll need to do in multiple contexts (in this case, I want to be
able to implement an `av stack submit` command, which will involve opening a PR
for every branch in the stack).

That code is mostly unchanged, except for the bit where we now read the subject
and body from the commit in order to populate the PR title/body. I'm going to
submit this PR using this strategy, so... wish me luck! 🤞