### PR TITLE
[MER-871] Improve upgrade message formatting, fix v prefix issue in released version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,10 +10,16 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - "-X 'github.com/aviator-co/av/internal/config.Version={{ .Version }}'"
+      - "-X 'github.com/aviator-co/av/internal/config.Version=v{{ .Version }}'"
 
 # Create a GitHub release on the av repo
 release: {}
+
+archives:
+  - replacements:
+      amd64: x86_64
+      darwin: macos
+
 
 # Push to the homebrew tap
 brews:

--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -125,7 +125,7 @@ func checkCliVersion() {
 	}
 	logrus.WithField("latest", latest).Debug("fetched latest released version")
 	if semver.Compare(config.Version, latest) < 0 {
-		c := color.New(color.Bold, color.FgMagenta)
+		c := color.New(color.Faint, color.Bold)
 		_, _ = fmt.Fprint(
 			os.Stderr,
 			c.Sprint(">> A new version of av is available: "),


### PR DESCRIPTION
As seen from two different terminals (Hyper with solarized theme and then from JetBrains built in terminal):

<img width="695" alt="image" src="https://user-images.githubusercontent.com/773453/171960104-48ca0ac1-b140-48ac-98d6-f44e5bdce6ae.png">
<img width="958" alt="Screen Shot 2022-06-03 at 3 03 21 PM" src="https://user-images.githubusercontent.com/773453/171960141-5744765d-8563-45b7-96e1-7888fafb1028.png">

