### PR TITLE
Add ability to create draft PRs with av pr create

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -19,6 +19,7 @@ var prCmd = &cobra.Command{
 
 var prCreateFlags struct {
 	Base   string
+	Draft  bool
 	Force  bool
 	NoPush bool
 	Title  string
@@ -67,6 +68,11 @@ Examples:
 				Body:   body,
 				NoPush: prCreateFlags.NoPush,
 				Force:  prCreateFlags.Force,
+				// TODO: this means we can't override with --draft=false if the
+				//       config has draft=true. We need to figure out how to
+				//       unify config and flags (the latter should always
+				//       override the former).
+				Draft: prCreateFlags.Draft || config.Av.PullRequest.Draft,
 			},
 		); err != nil {
 			return err
@@ -82,6 +88,10 @@ func init() {
 	prCreateCmd.Flags().StringVar(
 		&prCreateFlags.Base, "base", "",
 		"base branch to create the pull request against",
+	)
+	prCreateCmd.Flags().BoolVar(
+		&prCreateFlags.Draft, "draft", false,
+		"create the pull request in draft mode",
 	)
 	prCreateCmd.Flags().BoolVar(
 		&prCreateFlags.Force, "force", false,

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -23,6 +23,8 @@ type CreatePullRequestOpts struct {
 	Body  string
 	//LabelNames      []string
 
+	// If true, create the pull request as a GitHub draft PR.
+	Draft bool
 	// If true, do not push the branch to GitHub
 	NoPush bool
 	// If true, create a PR even if we think one already exists
@@ -165,6 +167,7 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 		HeadRefName:  githubv4.String(currentBranch),
 		Title:        githubv4.String(opts.Title),
 		Body:         gh.Ptr(githubv4.String(opts.Body)),
+		Draft:        gh.Ptr(githubv4.Boolean(opts.Draft)),
 	})
 	if err != nil {
 		return nil, err
@@ -197,7 +200,7 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 		"\n",
 	)
 
-	if config.Av.OpenBrowser {
+	if config.Av.PullRequest.OpenBrowser {
 		if err := browser.Open(pull.Permalink); err != nil {
 			fmt.Fprint(os.Stderr,
 				"  - couldn't open browser ",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,11 +10,18 @@ type GitHub struct {
 	BaseUrl string
 }
 
-var Av = struct {
+type PullRequest struct {
+	Draft       bool
 	OpenBrowser bool
+}
+
+var Av = struct {
+	PullRequest PullRequest
 	GitHub      GitHub
 }{
-	OpenBrowser: true,
+	PullRequest: PullRequest{
+		OpenBrowser: true,
+	},
 	GitHub: GitHub{
 		BaseUrl: "https://github.com",
 	},


### PR DESCRIPTION
Created this PR as a draft with
```
av pr create --draft
```

Also, since we haven't released #36 I thought it made sense to put all of that kind of thing underneath a `pullRequests` config section.