### PR TITLE
feat(stacks): added shortcut flag to stack prev and stack next

### DIFF
--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -18,23 +18,12 @@ var stackNextFlags struct {
 }
 
 var stackNextCmd = &cobra.Command{
-	Use:   "next <n> or next --last",
+	Use:   "next [<n>|--last]",
 	Short: "checkout the next branch in the stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var n int = 1
-		if len(args) == 1 && !stackNextFlags.Last {
-			var err error
-			n, err = strconv.Atoi(args[0])
-			if err != nil {
-				return errors.New("invalid number")
-			}
-		} else if len(args) > 1 {
+		if len(args) > 1 {
 			_ = cmd.Usage()
 			return errors.New("too many arguments")
-		}
-
-		if n <= 0 {
-			return errors.New("invalid number (must be >= 1)")
 		}
 
 		// Get the subsequent branches so we can checkout the nth one
@@ -55,24 +44,29 @@ var stackNextCmd = &cobra.Command{
 			return err
 		}
 
-		// confirm we can in fact do the operation given current branch state
-		if len(subsequentBranches) == 0 && !stackNextFlags.Last {
-			return errors.New("there is no next branch")
-		} else if len(subsequentBranches) == 0 && stackNextFlags.Last {
-			_, _ = fmt.Fprint(os.Stderr, "already on last branch in stack\n")
-			return nil
-		}
-		if n > len(subsequentBranches) {
-			return fmt.Errorf("invalid number (there are only %d subsequent branches in the stack)", len(subsequentBranches))
+		var branchToCheckout string
+		if !stackNextFlags.Last {
+			if len(subsequentBranches) == 0 {
+				return errors.New("there is no next branch")
+			}
+			n, err := strconv.Atoi(args[0])
+			if err != nil {
+				return errors.New("invalid number (unable to parse)")
+			}
+			if n <= 0 {
+				return errors.New("invalid number (must be >= 1)")
+			}
+			if n > len(subsequentBranches) {
+				return fmt.Errorf("invalid number (there are only %d subsequent branches in the stack)", len(subsequentBranches))
+			}
+			branchToCheckout = subsequentBranches[n-1]
+		} else {
+			if len(subsequentBranches) == 0 {
+				return errors.New("already on last branch in stack\n")
+			}
+			branchToCheckout = subsequentBranches[len(subsequentBranches)-1]
 		}
 
-		// if we are trying to go to the last branch then set things
-		if stackNextFlags.Last {
-			n = len(subsequentBranches)
-		}
-
-		// checkout nth branch
-		var branchToCheckout = subsequentBranches[n-1]
 		if _, err := repo.CheckoutBranch(&git.CheckoutBranch{
 			Name: branchToCheckout,
 		}); err != nil {

--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -12,12 +12,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var stackNextFlags struct {
+	// should we go to the last
+	Last bool
+}
+
 var stackNextCmd = &cobra.Command{
-	Use:   "next <n>",
+	Use:   "next <n> or next --last",
 	Short: "checkout the next branch in the stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var n int = 1
-		if len(args) == 1 {
+		if len(args) == 1 && !stackNextFlags.Last {
 			var err error
 			n, err = strconv.Atoi(args[0])
 			if err != nil {
@@ -58,6 +63,11 @@ var stackNextCmd = &cobra.Command{
 			return fmt.Errorf("invalid number (there are only %d subsequent branches in the stack)", len(subsequentBranches))
 		}
 
+		// if we are trying to go to the last branch then set things
+		if stackNextFlags.Last {
+			n = len(subsequentBranches)
+		}
+
 		// checkout nth branch
 		var branchToCheckout = subsequentBranches[n-1]
 		if _, err := repo.CheckoutBranch(&git.CheckoutBranch{
@@ -70,4 +80,11 @@ var stackNextCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func init() {
+	stackNextCmd.Flags().BoolVar(
+		&stackNextFlags.Last, "last", false,
+		"go to the last branch in the current stack",
+	)
 }

--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -56,8 +56,11 @@ var stackNextCmd = &cobra.Command{
 		}
 
 		// confirm we can in fact do the operation given current branch state
-		if len(subsequentBranches) == 0 {
+		if len(subsequentBranches) == 0 && !stackNextFlags.Last {
 			return errors.New("there is no next branch")
+		} else if len(subsequentBranches) == 0 && stackNextFlags.Last {
+			_, _ = fmt.Fprint(os.Stderr, "already on last branch in stack\n")
+			return nil
 		}
 		if n > len(subsequentBranches) {
 			return fmt.Errorf("invalid number (there are only %d subsequent branches in the stack)", len(subsequentBranches))

--- a/cmd/av/stack_prev.go
+++ b/cmd/av/stack_prev.go
@@ -56,8 +56,11 @@ var stackPrevCmd = &cobra.Command{
 		}
 
 		// confirm we can in fact do the operation given current branch state
-		if len(previousBranches) == 0 {
+		if len(previousBranches) == 0 && !stackPrevFlags.First {
 			return errors.New("there is no previous branch")
+		} else if len(previousBranches) == 0 && stackPrevFlags.First {
+			_, _ = fmt.Fprint(os.Stderr, "already on first branch in stack\n")
+			return nil
 		}
 		if n > len(previousBranches) {
 			return fmt.Errorf("invalid number (there are only %d previous branches in the stack)", len(previousBranches))

--- a/cmd/av/stack_prev.go
+++ b/cmd/av/stack_prev.go
@@ -66,7 +66,7 @@ var stackPrevCmd = &cobra.Command{
 			return fmt.Errorf("invalid number (there are only %d previous branches in the stack)", len(previousBranches))
 		}
 
-		// if we are trying to go to the last branch then set things
+		// if we are trying to go to the first branch then set things
 		if stackPrevFlags.First {
 			n = len(previousBranches)
 		}

--- a/cmd/av/stack_prev.go
+++ b/cmd/av/stack_prev.go
@@ -12,12 +12,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var stackPrevFlags struct {
+	// should we go to the first
+	First bool
+}
+
 var stackPrevCmd = &cobra.Command{
-	Use:   "prev <n>",
+	Use:   "prev <n> or prev --first",
 	Short: "checkout the previous branch in the stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var n int = 1
-		if len(args) == 1 {
+		if len(args) == 1 && !stackPrevFlags.First {
 			var err error
 			n, err = strconv.Atoi(args[0])
 			if err != nil {
@@ -58,6 +63,11 @@ var stackPrevCmd = &cobra.Command{
 			return fmt.Errorf("invalid number (there are only %d previous branches in the stack)", len(previousBranches))
 		}
 
+		// if we are trying to go to the last branch then set things
+		if stackPrevFlags.First {
+			n = len(previousBranches)
+		}
+
 		// checkout nth previous branch
 		var branchToCheckout = previousBranches[len(previousBranches)-n]
 		if _, err := repo.CheckoutBranch(&git.CheckoutBranch{
@@ -70,4 +80,11 @@ var stackPrevCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func init() {
+	stackPrevCmd.Flags().BoolVar(
+		&stackPrevFlags.First, "first", false,
+		"go to the first branch in the current stack",
+	)
 }


### PR DESCRIPTION
# What changed
added `--first` and `--last` shortcuts to `av stack prev` and `av stack next` respectively.

# Testing
Tested locally creating a stack of branches `blah1`, `blah2`, and finally `blah3` and then ran the following commands to show things working:
<img width="858" alt="Screen Shot 2022-08-01 at 4 11 00 PM" src="https://user-images.githubusercontent.com/107422947/182236421-ff8c3681-319d-48c7-a6bc-154d844b3a22.png">