### PR TITLE
feat(stacks): add av stack submit command

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -46,6 +46,10 @@ Examples:
 		if err != nil {
 			return err
 		}
+		branchName, err := repo.CurrentBranchName()
+		if err != nil {
+			return errors.WrapIf(err, "failed to determine current branch")
+		}
 		client, err := gh.NewClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err
@@ -64,10 +68,11 @@ Examples:
 		if _, err := actions.CreatePullRequest(
 			context.Background(), repo, client,
 			actions.CreatePullRequestOpts{
-				Title:  prCreateFlags.Title,
-				Body:   body,
-				NoPush: prCreateFlags.NoPush,
-				Force:  prCreateFlags.Force,
+				BranchName: branchName,
+				Title:      prCreateFlags.Title,
+				Body:       body,
+				NoPush:     prCreateFlags.NoPush,
+				Force:      prCreateFlags.Force,
 				// TODO: this means we can't override with --draft=false if the
 				//       config has draft=true. We need to figure out how to
 				//       unify config and flags (the latter should always

--- a/cmd/av/stack.go
+++ b/cmd/av/stack.go
@@ -16,6 +16,7 @@ func init() {
 		stackPrevCmd,
 		stackReparentCmd,
 		stackSyncCmd,
+		stackSubmitCmd,
 		stackTreeCmd,
 	)
 }

--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -34,7 +34,7 @@ var stackNextCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		subsequentBranches, err := subsequentBranches(branches, currentBranch)
+		subsequentBranches, err := meta.SubsequentBranches(branches, currentBranch)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/stack_prev.go
+++ b/cmd/av/stack_prev.go
@@ -34,7 +34,7 @@ var stackPrevCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		previousBranches, err := previousBranches(branches, currentBranch)
+		previousBranches, err := meta.PreviousBranches(branches, currentBranch)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -14,7 +14,7 @@ import (
 
 var stackSubmitCmd = &cobra.Command{
 	Use:   "submit",
-	Short: "create pull requests for the current stack",
+	Short: "create/synchronize pull requests for the current stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			_ = cmd.Usage()
@@ -42,13 +42,7 @@ var stackSubmitCmd = &cobra.Command{
 				ctx, repo, client,
 				actions.CreatePullRequestOpts{
 					BranchName: currentMeta.Name,
-					// TODO: currently just set things as empty but it might be nice to have an interactive mode
-					//	that would let us set the title and body, etc. per branch in the stack
-					Title:  "",
-					Body:   "",
-					NoPush: false,
-					Force:  false,
-					Draft:  false,
+					Draft:      config.Av.PullRequest.Draft,
 				},
 			)
 			if err != nil {

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -30,6 +30,22 @@ var stackSubmitCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		currentBranch, err := repo.CurrentBranchName()
+		if err != nil {
+			return err
+		}
+		previousBranches, err := meta.PreviousBranches(branches, currentBranch)
+		if err != nil {
+			return err
+		}
+		subsequentBranches, err := meta.SubsequentBranches(branches, currentBranch)
+		if err != nil {
+			return err
+		}
+		var branchesToSubmit []string
+		branchesToSubmit = append(branchesToSubmit, previousBranches...)
+		branchesToSubmit = append(branchesToSubmit, currentBranch)
+		branchesToSubmit = append(branchesToSubmit, subsequentBranches...)
 
 		// ensure pull requests for each branch in the stack
 		ctx := context.Background()
@@ -37,11 +53,11 @@ var stackSubmitCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		for _, currentMeta := range branches {
+		for _, branchName := range branchesToSubmit {
 			result, err := actions.CreatePullRequest(
 				ctx, repo, client,
 				actions.CreatePullRequestOpts{
-					BranchName: currentMeta.Name,
+					BranchName: branchName,
 					Draft:      config.Av.PullRequest.Draft,
 				},
 			)

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -65,7 +65,7 @@ var stackSubmitCmd = &cobra.Command{
 				return err
 			}
 			// make sure the base branch of the PR is up to date if it already exists
-			if !result.Created {
+			if !result.Created && result.Pull.BaseRefName != result.Branch.Parent.Name {
 				if _, err := client.UpdatePullRequest(
 					ctx, githubv4.UpdatePullRequestInput{
 						PullRequestID: githubv4.ID(result.Branch.PullRequest.ID),

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strconv"
+
+	"emperror.dev/errors"
+	"github.com/spf13/cobra"
+)
+
+var stackSubmitCmd = &cobra.Command{
+	Use:   "submit",
+	Short: "create pull requests for the current stack",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var n int = 1
+		if len(args) == 1 {
+			var err error
+			n, err = strconv.Atoi(args[0])
+			if err != nil {
+				return errors.Wrap(err, "invalid number")
+			}
+		} else if len(args) > 1 {
+			_ = cmd.Usage()
+			return errors.New("too many arguments")
+		}
+
+		if n <= 0 {
+			return errors.New("invalid number (must be >= 1)")
+		}
+
+		return errors.New("unimplemented")
+	},
+}

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -1,9 +1,12 @@
 package main
 
 import (
-	"strconv"
+	"context"
 
 	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/config"
+	"github.com/aviator-co/av/internal/gh"
+	"github.com/aviator-co/av/internal/meta"
 	"github.com/spf13/cobra"
 )
 
@@ -11,22 +14,30 @@ var stackSubmitCmd = &cobra.Command{
 	Use:   "submit",
 	Short: "create pull requests for the current stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var n int = 1
-		if len(args) == 1 {
-			var err error
-			n, err = strconv.Atoi(args[0])
-			if err != nil {
-				return errors.Wrap(err, "invalid number")
-			}
-		} else if len(args) > 1 {
+		if len(args) > 0 {
 			_ = cmd.Usage()
-			return errors.New("too many arguments")
+			return errors.New("this command takes no arguments")
 		}
 
-		if n <= 0 {
-			return errors.New("invalid number (must be >= 1)")
+		// Get the all branches in the stack
+		repo, _, err := getRepoInfo()
+		if err != nil {
+			return err
+		}
+		branches, err := meta.ReadAllBranches(repo)
+		if err != nil {
+			return err
 		}
 
-		return errors.New("unimplemented")
+		// ensure pull requests for each branch in the stack
+		ctx := context.Background()
+		client, err := gh.NewClient(config.Av.GitHub.Token)
+		if err != nil {
+			return err
+		}
+		for _, currentMeta := range branches {
+		}
+
+		return nil
 	},
 }

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/gh"
 	"github.com/aviator-co/av/internal/meta"
@@ -36,6 +37,20 @@ var stackSubmitCmd = &cobra.Command{
 			return err
 		}
 		for _, currentMeta := range branches {
+			_, err := actions.CreatePullRequest(
+				ctx, repo, client,
+				actions.CreatePullRequestOpts{
+					BranchName: currentMeta.Name,
+					Title:      "",
+					Body:       "",
+					NoPush:     false,
+					Force:      false,
+					Draft:      false,
+				},
+			)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"context"
-	"emperror.dev/errors"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/gh"
@@ -17,10 +22,6 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"io/ioutil"
-	"os"
-	"path"
-	"strings"
 )
 
 // stackSyncConfig contains the configuration for a sync operation.
@@ -238,14 +239,14 @@ base branch.
 			if err != nil {
 				return err
 			}
-			branchesToSync, err = previousBranches(branches, currentBranch)
+			branchesToSync, err = meta.PreviousBranches(branches, currentBranch)
 			if err != nil {
 				return err
 			}
 			branchesToSync = append(branchesToSync, currentBranch)
 		}
 		// Either way (--continue or not), we sync all subsequent branches.
-		nextBranches, err := subsequentBranches(branches, branchesToSync[len(branchesToSync)-1])
+		nextBranches, err := meta.SubsequentBranches(branches, branchesToSync[len(branchesToSync)-1])
 		if err != nil {
 			return err
 		}
@@ -449,50 +450,6 @@ base branch.
 
 		return nil
 	},
-}
-
-// Find all the ancestor branches of the given branch name and append them to
-// the given slice (in topological order: a comes before b if a is an ancestor
-// of b).
-func previousBranches(branches map[string]meta.Branch, name string) ([]string, error) {
-	current, ok := branches[name]
-	if !ok {
-		return nil, errors.Errorf("branch metadata not found for %q", name)
-	}
-	parent := current.Parent
-	if parent.Trunk {
-		return nil, nil
-	}
-	if parent.Name == name {
-		logrus.Fatalf("invariant error: branch %q is its own parent (this is probably a bug with av)", name)
-	}
-	previous, err := previousBranches(branches, parent.Name)
-	if err != nil {
-		return nil, err
-	}
-	return append(previous, parent.Name), nil
-}
-
-func subsequentBranches(branches map[string]meta.Branch, name string) ([]string, error) {
-	logrus.Debugf("finding subsequent branches for %q", name)
-	var res []string
-	branchMeta, ok := branches[name]
-	if !ok {
-		return nil, fmt.Errorf("branch metadata not found for %q", name)
-	}
-	if len(branchMeta.Children) == 0 {
-		return res, nil
-	}
-	for _, child := range branchMeta.Children {
-		res = append(res, child)
-		desc, err := subsequentBranches(branches, child)
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, desc...)
-	}
-
-	return res, nil
 }
 
 const stackSyncStateFile = "stack-sync.state.json"

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -214,7 +214,6 @@ func getOrCreatePR(ctx context.Context, client *gh.Client, repoMeta meta.Reposit
 		Owner:       repoMeta.Owner,
 		Repo:        repoMeta.Name,
 		HeadRefName: opts.headRefName,
-		BaseRefName: opts.baseRefName,
 		States:      []githubv4.PullRequestState{githubv4.PullRequestStateOpen},
 	})
 	if err != nil {

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -20,9 +20,8 @@ import (
 
 type CreatePullRequestOpts struct {
 	BranchName string
-
-	Title string
-	Body  string
+	Title      string
+	Body       string
 	//LabelNames      []string
 
 	// If true, create the pull request as a GitHub draft PR.

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -36,6 +36,8 @@ type CreatePullRequestOpts struct {
 type CreatePullRequestResult struct {
 	// True if the pull request was created
 	Created bool
+	// The (updated) branch metadata.
+	Branch meta.Branch
 	// The pull request object that was returned from GitHub
 	Pull *gh.PullRequest
 }
@@ -192,7 +194,7 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 		}
 	}
 
-	return &CreatePullRequestResult{didCreatePR, pull}, nil
+	return &CreatePullRequestResult{didCreatePR, branchMeta, pull}, nil
 }
 
 type getOrCreatePROpts struct {

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -2,10 +2,11 @@ package gh
 
 import (
 	"context"
-	"emperror.dev/errors"
 	"fmt"
-	"github.com/shurcooL/githubv4"
 	"strings"
+
+	"emperror.dev/errors"
+	"github.com/shurcooL/githubv4"
 )
 
 type PullRequest struct {
@@ -115,6 +116,18 @@ func (c *Client) CreatePullRequest(ctx context.Context, input githubv4.CreatePul
 		return nil, errors.Wrap(err, "failed to create pull request: github error")
 	}
 	return &mutation.CreatePullRequest.PullRequest, nil
+}
+
+func (c *Client) UpdatePullRequest(ctx context.Context, input githubv4.UpdatePullRequestInput) (*PullRequest, error) {
+	var mutation struct {
+		UpdatePullRequest struct {
+			PullRequest PullRequest
+		} `graphql:"updatePullRequest(input: $input)"`
+	}
+	if err := c.mutate(ctx, &mutation, input, nil); err != nil {
+		return nil, errors.Wrap(err, "failed to create pull request: github error")
+	}
+	return &mutation.UpdatePullRequest.PullRequest, nil
 }
 
 type AddIssueLabelInput struct {

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -125,7 +125,7 @@ func (c *Client) UpdatePullRequest(ctx context.Context, input githubv4.UpdatePul
 		} `graphql:"updatePullRequest(input: $input)"`
 	}
 	if err := c.mutate(ctx, &mutation, input, nil); err != nil {
-		return nil, errors.Wrap(err, "failed to create pull request: github error")
+		return nil, errors.Wrap(err, "failed to update pull request: github error")
 	}
 	return &mutation.UpdatePullRequest.PullRequest, nil
 }


### PR DESCRIPTION
# What Changed
`av stack submit` command was added that pushed the current state of the stack - i.e. creates PRs for every branch that doesn't have them and fixes the base branch of the PRs that already exist to be the correct one.

This covers work for both MER-1024 and MER-1007

# Testing
- created fresh stack locally and ran the command correctly seeing the full stack get submitted
- created fresh stack - create one PR and set the base ref branch to the wrong thing - correctly see the stack submitted and the one wrong base branch get updated.

# Results
Initial PR created for branch `submit3` onto `main` as normal:
<img width="935" alt="Screen Shot 2022-08-03 at 4 09 00 PM" src="https://user-images.githubusercontent.com/107422947/182699900-9bec9725-3921-42bb-bee7-a6bfd0c1b75e.png">
`av stack submit` command called and the three PRs are submitted and in the case of `submit3` corrected:
<img width="941" alt="Screen Shot 2022-08-03 at 4 09 39 PM" src="https://user-images.githubusercontent.com/107422947/182700025-abc0896c-ea4b-4b44-873c-e5b5eb7e815e.png">
<img width="936" alt="Screen Shot 2022-08-03 at 4 09 44 PM" src="https://user-images.githubusercontent.com/107422947/182700039-5f5c913f-8078-4072-8851-db3c2aca2424.png">
<img width="946" alt="Screen Shot 2022-08-03 at 4 46 03 PM" src="https://user-images.githubusercontent.com/107422947/182708512-4bfca2ce-aaa5-457b-a0e9-be582048fcdd.png">