### PR TITLE
fix: Don't push branch if PR hasn't been created yet

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -257,12 +257,20 @@ base branch.
 		logrus.WithField("branches", branchesToSync).Debug("determined branches to sync")
 		var resErr error
 	loop:
-		for _, currentBranch := range branchesToSync {
+		for i, currentBranch := range branchesToSync {
 			state.CurrentBranch = currentBranch
 			currentMeta, ok := branches[currentBranch]
 			if !ok {
 				return errors.Errorf("stack metadata not found for branch %q", currentBranch)
 			}
+
+			if i > 0 {
+				_, _ = fmt.Fprint(os.Stderr, "\n")
+			}
+			_, _ = fmt.Fprint(os.Stderr,
+				colors.FaintC.Sprintf("[%d/%d] ", i+1, len(branchesToSync)),
+				"Synchronizing branch ", colors.UserInput(currentBranch), ":\n",
+			)
 
 			if !state.Config.NoFetch {
 				if ghClient == nil {
@@ -302,12 +310,12 @@ base branch.
 				}); err != nil {
 					return errors.WrapIff(err, "failed to check out branch %q", currentBranch)
 				}
-				if !state.Config.NoPush {
-					if err := actions.Push(repo, actions.PushOpts{
-						Force: actions.ForceWithLease,
-					}); err != nil {
-						return err
-					}
+				if err := actions.Push(repo, actions.PushOpts{
+					Force:                 actions.ForceWithLease,
+					SkipIfUpstreamNotSet:  true,
+					SkipIfUpstreamMatches: true,
+				}); err != nil {
+					return err
 				}
 				continue
 			}
@@ -412,12 +420,12 @@ base branch.
 				logrus.Panicf("invariant error: unknown sync result: %v", res)
 			}
 
-			if !state.Config.NoPush {
-				if err := actions.Push(repo, actions.PushOpts{
-					Force: actions.ForceWithLease,
-				}); err != nil {
-					return err
-				}
+			if err := actions.Push(repo, actions.PushOpts{
+				Force:                 actions.ForceWithLease,
+				SkipIfUpstreamNotSet:  true,
+				SkipIfUpstreamMatches: true,
+			}); err != nil {
+				return err
 			}
 		}
 
@@ -438,7 +446,7 @@ base branch.
 			return errors.Wrap(err, "failed to reset stack sync state")
 		}
 
-		_, _ = fmt.Fprintf(os.Stderr, "Stack sync complete\n")
+		_, _ = fmt.Fprint(os.Stderr, "\n", colors.Success("Stack sync complete!\n"))
 
 		// Return to the starting branch when we're done
 		if _, err := repo.CheckoutBranch(&git.CheckoutBranch{

--- a/internal/git/err.go
+++ b/internal/git/err.go
@@ -1,0 +1,15 @@
+package git
+
+import (
+	"emperror.dev/errors"
+	"os/exec"
+	"strings"
+)
+
+func StderrMatches(err error, target string) bool {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return strings.Contains(string(exitErr.Stderr), target)
+	}
+	return false
+}

--- a/internal/utils/colors/colorutils.go
+++ b/internal/utils/colors/colorutils.go
@@ -6,8 +6,9 @@ var (
 	CliCmdC          = color.New(color.FgMagenta)
 	SuccessC         = color.New(color.FgGreen)
 	FailureC         = color.New(color.FgRed)
-	TroubleshootingC = color.New(color.Reset)
+	TroubleshootingC = color.New(color.Faint)
 	UserInputC       = color.New(color.FgCyan)
+	FaintC           = color.New(color.Faint)
 )
 
 var (
@@ -16,4 +17,5 @@ var (
 	Failure         = FailureC.Sprint
 	Troubleshooting = TroubleshootingC.Sprint
 	UserInput       = UserInputC.Sprint
+	Faint           = FaintC.Sprint
 )


### PR DESCRIPTION
Also optimizes no not push during `av stack sync` if the remote tracking branch is already up to date. Ideally, this wouldn't be necessary, but `git push` is a bit slow even if theres nothing to do.
<img width="711" alt="image (1)" src="https://user-images.githubusercontent.com/773453/182498926-3fe768d2-211c-40fc-b56b-e30d8ada6535.png">

