### PR TITLE
feat(stack sync): auto rebase branches after merge

### DIFF
--- a/cmd/av/fetch.go
+++ b/cmd/av/fetch.go
@@ -29,7 +29,7 @@ var fetchCmd = &cobra.Command{
 			return errors.Wrap(err, "failed to read av branch metadata")
 		}
 
-		client, err := gh.NewClient(config.Av.GitHub.Token)
+		client, err := gh.GetClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/fetch.go
+++ b/cmd/av/fetch.go
@@ -29,7 +29,7 @@ var fetchCmd = &cobra.Command{
 			return errors.Wrap(err, "failed to read av branch metadata")
 		}
 
-		client, err := gh.GetClient(config.Av.GitHub.Token)
+		client, err := getClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/init.go
+++ b/cmd/av/init.go
@@ -32,7 +32,7 @@ var initCmd = &cobra.Command{
 		if config.Av.GitHub.Token == "" {
 			return errors.New("github token must be set")
 		}
-		client, err := gh.NewClient(config.Av.GitHub.Token)
+		client, err := gh.GetClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/init.go
+++ b/cmd/av/init.go
@@ -6,7 +6,6 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/config"
-	"github.com/aviator-co/av/internal/gh"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/spf13/cobra"
 )
@@ -32,7 +31,7 @@ var initCmd = &cobra.Command{
 		if config.Av.GitHub.Token == "" {
 			return errors.New("github token must be set")
 		}
-		client, err := gh.GetClient(config.Av.GitHub.Token)
+		client, err := getClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/config"
+	"github.com/aviator-co/av/internal/gh"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/fatih/color"
 	"github.com/kr/text"
@@ -158,4 +160,15 @@ func getRepo() (*git.Repo, error) {
 		}
 	}
 	return cachedRepo, nil
+}
+
+var once sync.Once
+var lazyGithubClient *gh.Client
+
+func getClient(token string) (*gh.Client, error) {
+	var err error
+	once.Do(func() {
+		lazyGithubClient, err = gh.NewClient(token)
+	})
+	return lazyGithubClient, err
 }

--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -9,7 +9,6 @@ import (
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/config"
-	"github.com/aviator-co/av/internal/gh"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +49,7 @@ Examples:
 		if err != nil {
 			return errors.WrapIf(err, "failed to determine current branch")
 		}
-		client, err := gh.GetClient(config.Av.GitHub.Token)
+		client, err := getClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -50,7 +50,7 @@ Examples:
 		if err != nil {
 			return errors.WrapIf(err, "failed to determine current branch")
 		}
-		client, err := gh.NewClient(config.Av.GitHub.Token)
+		client, err := gh.GetClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -49,7 +49,7 @@ var stackSubmitCmd = &cobra.Command{
 
 		// ensure pull requests for each branch in the stack
 		ctx := context.Background()
-		client, err := gh.GetClient(config.Av.GitHub.Token)
+		client, err := getClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -49,7 +49,7 @@ var stackSubmitCmd = &cobra.Command{
 
 		// ensure pull requests for each branch in the stack
 		ctx := context.Background()
-		client, err := gh.NewClient(config.Av.GitHub.Token)
+		client, err := gh.GetClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -354,6 +354,14 @@ base branch.
 				if err != nil {
 					return err
 				}
+				// force push the updated branch
+				if err := actions.Push(repo, actions.PushOpts{
+					Force:                 actions.ForceWithLease,
+					SkipIfUpstreamNotSet:  true,
+					SkipIfUpstreamMatches: true,
+				}); err != nil {
+					return err
+				}
 				continue loop
 			}
 

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -334,7 +334,7 @@ base branch.
 				}
 				_, _ = fmt.Fprint(os.Stderr,
 					"  - pull request ", colors.UserInput("#", parentMeta.PullRequest.Number),
-					" was merged, this branch should be synced on top of the merge commit:\n",
+					" was merged, syncing branch on top of the merge commit...\n",
 				)
 				// TODO:
 				//     We should do this automatically for the user
@@ -344,7 +344,19 @@ base branch.
 					"        av stack sync --parent ", defaultBranch, "\n",
 				)
 				continue
+			} else if ok && parentMeta.PullRequest != nil && parentMeta.PullRequest.State == githubv4.PullRequestStateClosed {
+				// pull requests are closed on fast-forward so look for a closing commit
+				defaultBranch, err := repo.DefaultBranch()
+				if err != nil {
+					return errors.Wrap(err, "failed to determine default branch")
+				}
+				_, _ = fmt.Fprint(os.Stderr,
+					"  - pull request ", colors.UserInput("#", parentMeta.PullRequest.Number),
+					" was closed, checking for closing commit...\n",
+				)
+				continue
 			}
+
 			_, _ = fmt.Fprint(os.Stderr,
 				"  - syncing ", colors.UserInput(currentBranch),
 				" on top of ", colors.UserInput(currentMeta.Parent.Name), "... ",

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -336,6 +336,7 @@ base branch.
 				if err != nil {
 					return err
 				}
+
 				// rebase onto the merge commit from the old parent
 				_, err = repo.Rebase(git.RebaseOpts{
 					Onto:     parentMeta.MergeCommit,
@@ -355,6 +356,11 @@ base branch.
 					return err
 				}
 				// force push the updated branch
+				if _, err = repo.CheckoutBranch(&git.CheckoutBranch{
+					Name: currentBranch,
+				}); err != nil {
+					return err
+				}
 				if err := actions.Push(repo, actions.PushOpts{
 					Force:                 actions.ForceWithLease,
 					SkipIfUpstreamNotSet:  true,

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/aviator-co/av/internal/utils/stringutils"
 	"github.com/kr/text"
-	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -253,8 +252,6 @@ base branch.
 		branchesToSync = append(branchesToSync, nextBranches...)
 
 		ctx := context.Background()
-		var ghClient *gh.Client // lazy init only if needed
-
 		logrus.WithField("branches", branchesToSync).Debug("determined branches to sync")
 		var resErr error
 	loop:
@@ -274,12 +271,9 @@ base branch.
 			)
 
 			if !state.Config.NoFetch {
-				if ghClient == nil {
-					var err error
-					ghClient, err = gh.NewClient(config.Av.GitHub.Token)
-					if err != nil {
-						return err
-					}
+				ghClient, err := gh.GetClient(config.Av.GitHub.Token)
+				if err != nil {
+					return err
 				}
 				update, err := actions.UpdatePullRequestState(ctx, repo, ghClient, repoMeta, currentBranch)
 				if err != nil {
@@ -287,17 +281,16 @@ base branch.
 				}
 				branches[currentBranch] = update.Branch
 				currentMeta = update.Branch
+			}
 
-				if update.Pull != nil && update.Pull.Merged && len(currentMeta.Children) > 0 {
-					// Not sure if we should always do this, but seems like a relatively
-					// safe bet (that we don't need to sync branches that have been merged).
-					_, _ = fmt.Fprint(os.Stderr,
-						"  - pull request ", colors.UserInput("#", update.Pull.Number),
-						" for branch ", colors.UserInput(currentBranch),
-						" was merged, skipping sync...\n",
-					)
-					continue
-				}
+			// if we have found a related commit in trunk for the PR then skip syncing
+			if currentMeta.TrunkCommit != nil && len(currentMeta.Children) > 0 {
+				_, _ = fmt.Fprint(os.Stderr,
+					"  - pull request ", colors.UserInput("#", currentMeta.PullRequest.Number),
+					" for branch ", colors.UserInput(currentBranch),
+					" was merged, skipping sync...\n",
+				)
+				continue loop
 			}
 
 			parentState := currentMeta.Parent
@@ -327,34 +320,32 @@ base branch.
 			})
 
 			parentMeta, ok := branches[parentState.Name]
-			if ok && parentMeta.PullRequest != nil && parentMeta.PullRequest.State == githubv4.PullRequestStateMerged {
+			if ok && parentMeta.TrunkCommit != nil {
 				defaultBranch, err := repo.DefaultBranch()
 				if err != nil {
 					return errors.Wrap(err, "failed to determine default branch")
 				}
 				_, _ = fmt.Fprint(os.Stderr,
 					"  - pull request ", colors.UserInput("#", parentMeta.PullRequest.Number),
-					" was merged, syncing branch on top of the merge commit...\n",
+					" was merged, syncing branch on top of the trunk commit...\n",
 				)
-				// TODO:
-				//     We should do this automatically for the user
-				_, _ = colors.CliCmdC.Fprint(os.Stderr,
-					"        git fetch origin ", defaultBranch, ":", defaultBranch, "\n",
-					"        git checkout ", currentBranch, "\n",
-					"        av stack sync --parent ", defaultBranch, "\n",
-				)
-				continue
-			} else if ok && parentMeta.PullRequest != nil && parentMeta.PullRequest.State == githubv4.PullRequestStateClosed {
-				// pull requests are closed on fast-forward so look for a closing commit
-				defaultBranch, err := repo.DefaultBranch()
+				// update the default branch
+				_, err = repo.Git("fetch", "origin", fmt.Sprint(defaultBranch, ":", defaultBranch))
 				if err != nil {
-					return errors.Wrap(err, "failed to determine default branch")
+					return err
 				}
-				_, _ = fmt.Fprint(os.Stderr,
-					"  - pull request ", colors.UserInput("#", parentMeta.PullRequest.Number),
-					" was closed, checking for closing commit...\n",
-				)
-				continue
+				// we run the following to auto rebase
+				// git rebase --onto <new-parent> <old-parent> <until>
+				// git rebase --onto trunk-commit parent-head current-head
+				_, err = repo.Rebase(git.RebaseOpts{
+					Onto:     *parentMeta.TrunkCommit,
+					Upstream: parentMeta.Name,
+					Branch:   currentBranch,
+				})
+				if err != nil {
+					return err
+				}
+				continue loop
 			}
 
 			_, _ = fmt.Fprint(os.Stderr,

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -12,7 +12,6 @@ import (
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/config"
-	"github.com/aviator-co/av/internal/gh"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/stacks"
@@ -271,7 +270,7 @@ base branch.
 			)
 
 			if !state.Config.NoFetch {
-				ghClient, err := gh.GetClient(config.Av.GitHub.Token)
+				ghClient, err := getClient(config.Av.GitHub.Token)
 				if err != nil {
 					return err
 				}

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -347,11 +347,14 @@ base branch.
 					return err
 				}
 				// now that we have rebased onto trunk - update current branch
-				actions.ReparentWriteMetaData(repo, actions.ReparentOpts{
+				err = actions.ReparentWriteMetaData(repo, actions.ReparentOpts{
 					Branch:         currentBranch,
 					NewParent:      defaultBranch,
 					NewParentTrunk: true,
 				})
+				if err != nil {
+					return err
+				}
 				continue loop
 			}
 

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -28,6 +28,8 @@ type CreatePullRequestOpts struct {
 	Draft bool
 	// If true, do not push the branch to GitHub
 	NoPush bool
+	// If true, force push the branch to GitHub
+	ForcePush bool
 	// If true, create a PR even if we think one already exists
 	Force bool
 }
@@ -53,8 +55,12 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 		"Creating pull request for branch ", colors.UserInput(opts.BranchName), ":",
 		"\n",
 	)
-	if !opts.NoPush {
+	if !opts.NoPush || opts.ForcePush {
 		pushFlags := []string{"push"}
+
+		if opts.ForcePush {
+			pushFlags = append(pushFlags, "--force")
+		}
 
 		// Check if the upstream is set. If not, we set it during push.
 		// TODO: Should we store this somewhere? I think currently things will

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -341,10 +341,9 @@ func UpdatePullRequestState(ctx context.Context, repo *git.Repo, client *gh.Clie
 				Repo:   repoMeta.Name,
 				Number: currentPull.Number,
 			}
-			switch currentPull.State {
-			case githubv4.PullRequestStateMerged:
+			if currentPull.State == githubv4.PullRequestStateMerged {
 				oid, err = client.PullRequestMergeCommit(ctx, opts)
-			case githubv4.PullRequestStateClosed:
+			} else if currentPull.State == githubv4.PullRequestStateClosed {
 				oid, err = client.PullRequestFastForwardCommit(ctx, opts)
 			}
 			if err != nil {

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -334,22 +334,7 @@ func UpdatePullRequestState(ctx context.Context, repo *git.Repo, client *gh.Clie
 	} else {
 		// openPull is nil so the PR should be merged or closed
 		if currentPull != nil {
-			var oid *string
-			var err error
-			var opts = gh.PullRequestByNumberInput{
-				Owner:  repoMeta.Owner,
-				Repo:   repoMeta.Name,
-				Number: currentPull.Number,
-			}
-			if currentPull.State == githubv4.PullRequestStateMerged {
-				oid, err = client.PullRequestMergeCommit(ctx, opts)
-			} else if currentPull.State == githubv4.PullRequestStateClosed {
-				oid, err = client.PullRequestFastForwardCommit(ctx, opts)
-			}
-			if err != nil {
-				return nil, errors.WrapIf(err, "querying GitHub pull requests")
-			}
-			branch.TrunkCommit = oid
+			branch.MergeCommit = currentPull.MergeCommit()
 			branch.PullRequest = &meta.PullRequest{
 				ID:        currentPull.ID,
 				Number:    currentPull.Number,

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -334,7 +334,7 @@ func UpdatePullRequestState(ctx context.Context, repo *git.Repo, client *gh.Clie
 	} else {
 		// openPull is nil so the PR should be merged or closed
 		if currentPull != nil {
-			branch.MergeCommit = currentPull.MergeCommit()
+			branch.MergeCommit = currentPull.GetMergeCommit()
 			branch.PullRequest = &meta.PullRequest{
 				ID:        currentPull.ID,
 				Number:    currentPull.Number,

--- a/internal/actions/push.go
+++ b/internal/actions/push.go
@@ -1,14 +1,15 @@
 package actions
 
 import (
-	"emperror.dev/errors"
 	"fmt"
+	"os"
+	"strings"
+
+	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/kr/text"
 	"github.com/sirupsen/logrus"
-	"os"
-	"strings"
 )
 
 type ForceOpt int

--- a/internal/actions/reparent.go
+++ b/internal/actions/reparent.go
@@ -1,15 +1,16 @@
 package actions
 
 import (
-	"emperror.dev/errors"
 	"fmt"
+	"os"
+	"strings"
+
+	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/aviator-co/av/internal/utils/sliceutils"
 	"github.com/sirupsen/logrus"
-	"os"
-	"strings"
 )
 
 type ReparentOpts struct {
@@ -114,7 +115,7 @@ func ReparentContinue(repo *git.Repo, opts ReparentOpts) (*ReparentResult, error
 			"no rebase in progress -- assuming rebase was completed (not aborted)",
 			"\n",
 		)
-		if err := reparentWriteMetadata(repo, opts); err != nil {
+		if err := ReparentWriteMetaData(repo, opts); err != nil {
 			return nil, err
 		}
 		return &ReparentResult{Success: true}, nil
@@ -122,7 +123,7 @@ func ReparentContinue(repo *git.Repo, opts ReparentOpts) (*ReparentResult, error
 	return handleReparentRebaseOutput(repo, opts, output)
 }
 
-func reparentWriteMetadata(repo *git.Repo, opts ReparentOpts) error {
+func ReparentWriteMetaData(repo *git.Repo, opts ReparentOpts) error {
 	branch := opts.Branch
 	newParentName := opts.NewParent
 	branchMeta, _ := meta.ReadBranch(repo, branch)
@@ -172,7 +173,7 @@ func handleReparentRebaseOutput(repo *git.Repo, opts ReparentOpts, output *git.O
 		return &ReparentResult{Success: false, Hint: string(output.Stderr)}, nil
 	}
 
-	if err := reparentWriteMetadata(repo, opts); err != nil {
+	if err := ReparentWriteMetaData(repo, opts); err != nil {
 		return nil, err
 	}
 	return &ReparentResult{Success: true}, nil

--- a/internal/actions/reparent.go
+++ b/internal/actions/reparent.go
@@ -115,7 +115,7 @@ func ReparentContinue(repo *git.Repo, opts ReparentOpts) (*ReparentResult, error
 			"no rebase in progress -- assuming rebase was completed (not aborted)",
 			"\n",
 		)
-		if err := ReparentWriteMetaData(repo, opts); err != nil {
+		if err := reparentWriteMetadata(repo, opts); err != nil {
 			return nil, err
 		}
 		return &ReparentResult{Success: true}, nil
@@ -123,7 +123,7 @@ func ReparentContinue(repo *git.Repo, opts ReparentOpts) (*ReparentResult, error
 	return handleReparentRebaseOutput(repo, opts, output)
 }
 
-func ReparentWriteMetaData(repo *git.Repo, opts ReparentOpts) error {
+func reparentWriteMetadata(repo *git.Repo, opts ReparentOpts) error {
 	branch := opts.Branch
 	newParentName := opts.NewParent
 	branchMeta, _ := meta.ReadBranch(repo, branch)
@@ -173,7 +173,7 @@ func handleReparentRebaseOutput(repo *git.Repo, opts ReparentOpts, output *git.O
 		return &ReparentResult{Success: false, Hint: string(output.Stderr)}, nil
 	}
 
-	if err := ReparentWriteMetaData(repo, opts); err != nil {
+	if err := reparentWriteMetadata(repo, opts); err != nil {
 		return nil, err
 	}
 	return &ReparentResult{Success: true}, nil

--- a/internal/gh/client.go
+++ b/internal/gh/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"sync"
 	"time"
 
 	"emperror.dev/errors"
@@ -23,9 +22,6 @@ type Client struct {
 
 const githubApiBaseUrl = "https://api.github.com"
 
-var once sync.Once
-var client *Client // lazy init
-
 func NewClient(token string) (*Client, error) {
 	if token == "" {
 		return nil, errors.Errorf("no GitHub token provided (do you need to configure one?)")
@@ -35,14 +31,6 @@ func NewClient(token string) (*Client, error) {
 	)
 	httpClient := oauth2.NewClient(context.Background(), src)
 	return &Client{httpClient, githubv4.NewClient(httpClient)}, nil
-}
-
-func GetClient(token string) (*Client, error) {
-	var err error
-	once.Do(func() {
-		client, err = NewClient(token)
-	})
-	return client, err
 }
 
 func (c *Client) query(ctx context.Context, query any, variables map[string]any) (reterr error) {

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -15,19 +15,19 @@ type PullRequest struct {
 	Author struct {
 		Login string
 	}
-	HeadRefName string
-	HeadRefOID  string
-	BaseRefName string
-	IsDraft     bool
-	Mergeable   githubv4.MergeableState
-	Merged      bool
-	Permalink   string
-	State       githubv4.PullRequestState
-	Title       string
-	MergeCommit struct {
+	HeadRefName         string
+	HeadRefOID          string
+	BaseRefName         string
+	IsDraft             bool
+	Mergeable           githubv4.MergeableState
+	Merged              bool
+	Permalink           string
+	State               githubv4.PullRequestState
+	Title               string
+	PRIVATE_MergeCommit struct {
 		Oid string
-	}
-	TimeLineItems struct {
+	} `graphql:"mergeCommit"`
+	PRIVATE_TimelineItems struct {
 		Nodes []struct {
 			ClosedEvent struct {
 				Closer struct {
@@ -56,9 +56,9 @@ func (p *PullRequest) GetMergeCommit() string {
 	if p.State == githubv4.PullRequestStateOpen {
 		return ""
 	} else if p.State == githubv4.PullRequestStateMerged {
-		return p.MergeCommit.Oid
-	} else if p.State == githubv4.PullRequestStateClosed && len(p.TimeLineItems.Nodes) != 0 {
-		return p.TimeLineItems.Nodes[0].ClosedEvent.Closer.Commit.Oid
+		return p.PRIVATE_MergeCommit.Oid
+	} else if p.State == githubv4.PullRequestStateClosed && len(p.PRIVATE_TimelineItems.Nodes) != 0 {
+		return p.PRIVATE_TimelineItems.Nodes[0].ClosedEvent.Closer.Commit.Oid
 	}
 	return ""
 }

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -24,11 +24,10 @@ type PullRequest struct {
 	Permalink   string
 	State       githubv4.PullRequestState
 	Title       string
-	// private
-	mergeCommit struct {
+	MergeCommit struct {
 		Oid string
 	}
-	timeLineItems struct {
+	TimeLineItems struct {
 		Nodes []struct {
 			ClosedEvent struct {
 				Closer struct {
@@ -53,13 +52,13 @@ func (p *PullRequest) BaseBranchName() string {
 	return strings.TrimPrefix(p.BaseRefName, "refs/heads/")
 }
 
-func (p *PullRequest) MergeCommit() string {
+func (p *PullRequest) GetMergeCommit() string {
 	if p.State == githubv4.PullRequestStateOpen {
 		return ""
 	} else if p.State == githubv4.PullRequestStateMerged {
-		return p.mergeCommit.Oid
-	} else if p.State == githubv4.PullRequestStateClosed && len(p.timeLineItems.Nodes) != 0 {
-		return p.timeLineItems.Nodes[0].ClosedEvent.Closer.Commit.Oid
+		return p.MergeCommit.Oid
+	} else if p.State == githubv4.PullRequestStateClosed && len(p.TimeLineItems.Nodes) != 0 {
+		return p.TimeLineItems.Nodes[0].ClosedEvent.Closer.Commit.Oid
 	}
 	return ""
 }

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -233,13 +233,3 @@ func (c *Client) RepoPullRequests(ctx context.Context, opts RepoPullRequestOpts)
 		PullRequests: query.Repository.PullRequests.Nodes,
 	}, nil
 }
-
-type PullRequestByNumberInput struct {
-	Owner  string
-	Repo   string
-	Number int64
-}
-
-type Commit struct {
-	Oid string
-}

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -30,11 +30,15 @@ type PullRequest struct {
 	}
 	timeLineItems struct {
 		Nodes []struct {
-			Closer struct {
-				Oid string
-			} `graphql:"... on Commit"`
-		} `graphql:"... on ClosedEvent"`
-	} `graphql:"timelineItems(last: 10, itemType: CLOSED_EVENT)"`
+			ClosedEvent struct {
+				Closer struct {
+					Commit struct {
+						Oid string
+					} `graphql:"... on Commit"`
+				}
+			} `graphql:"... on ClosedEvent"`
+		}
+	} `graphql:"timelineItems(last: 10, itemTypes: CLOSED_EVENT)"`
 }
 
 func (p *PullRequest) HeadBranchName() string {
@@ -55,7 +59,7 @@ func (p *PullRequest) MergeCommit() string {
 	} else if p.State == githubv4.PullRequestStateMerged {
 		return p.mergeCommit.Oid
 	} else if p.State == githubv4.PullRequestStateClosed && len(p.timeLineItems.Nodes) != 0 {
-		return p.timeLineItems.Nodes[0].Closer.Oid
+		return p.timeLineItems.Nodes[0].ClosedEvent.Closer.Commit.Oid
 	}
 	return ""
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,9 +2,6 @@ package git
 
 import (
 	"bytes"
-	"emperror.dev/errors"
-	"github.com/sirupsen/logrus"
-	giturls "github.com/whilp/git-urls"
 	"io"
 	"net/url"
 	"os"
@@ -12,6 +9,10 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"emperror.dev/errors"
+	"github.com/sirupsen/logrus"
+	giturls "github.com/whilp/git-urls"
 )
 
 type Repo struct {
@@ -152,6 +153,9 @@ type CheckoutBranch struct {
 	// Specifies the "-b" flag to git.
 	// The checkout will fail if the branch already exists.
 	NewBranch bool
+	// Specifies the ref that new branch will have HEAD at
+	// Requires the "-b" flag to be specified
+	NewHeadRef string
 }
 
 // CheckoutBranch performs a checkout of the given branch and returns the name
@@ -171,6 +175,9 @@ func (r *Repo) CheckoutBranch(opts *CheckoutBranch) (string, error) {
 		args = append(args, "-b")
 	}
 	args = append(args, opts.Name)
+	if opts.NewBranch && opts.NewHeadRef != "" {
+		args = append(args, opts.NewHeadRef)
+	}
 	res, err := r.Run(&RunOpts{
 		Args: args,
 	})

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -27,6 +27,10 @@ type Branch struct {
 
 	// The associated pull request information, if any.
 	PullRequest *PullRequest `json:"pullRequest,omitempty"`
+
+	// The commit onto the trunk branch, if any
+	// This will be the merge commit if the PR was merged
+	TrunkCommit *string `json:"trunkCommit,omitempty"`
 }
 
 func (b *Branch) IsStackRoot() bool {

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -37,6 +37,14 @@ func (b *Branch) IsStackRoot() bool {
 	return b.Parent.Trunk
 }
 
+func GetStackRoot(repo *git.Repo, name string) Branch {
+	current, _ := ReadBranch(repo, name)
+	if current.Parent.Trunk {
+		return current
+	}
+	return GetStackRoot(repo, current.Parent.Name)
+}
+
 func (b *Branch) UnmarshalJSON(bytes []byte) error {
 	// We have to do a bit of backwards-compatible trickery here to support the
 	// fact that "parent" used to be a string field and now it's a struct

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -28,21 +28,12 @@ type Branch struct {
 	// The associated pull request information, if any.
 	PullRequest *PullRequest `json:"pullRequest,omitempty"`
 
-	// The commit onto the trunk branch, if any
-	// This will be the merge commit if the PR was merged
-	TrunkCommit *string `json:"trunkCommit,omitempty"`
+	// The merge commit onto the trunk branch, if any
+	MergeCommit string `json:"mergeCommit,omitempty"`
 }
 
 func (b *Branch) IsStackRoot() bool {
 	return b.Parent.Trunk
-}
-
-func GetStackRoot(repo *git.Repo, name string) Branch {
-	current, _ := ReadBranch(repo, name)
-	if current.Parent.Trunk {
-		return current
-	}
-	return GetStackRoot(repo, current.Parent.Name)
 }
 
 func (b *Branch) UnmarshalJSON(bytes []byte) error {


### PR DESCRIPTION
# What changed
- when a stack is partially merged, a stack sync call will now `auto-rebase` onto the trunk commit `tc`
  - if `tc` is the HEAD of trunk, then we simply reparent to trunk
  - if `tc` is not the HEAD of trunk, then we create a new branch with its HEAD at `tc` and reparent to that branch so that stacks continue to work as normal
- added new client pull request functions that access the commit `oid` for both the standard `MERGE` case, as well as the `FAST FORWARD` case.
- added new `GetClient` function that lazy inits the GitHub client with `sync.Once` - switched all functions to use this method but left the old `NewClient` method present if we need it for some reason.

# Testing
Ran the following as a test:
- locally created a stack with three branches stacked on each other: <img width="852" alt="Screen Shot 2022-08-17 at 4 25 58 PM" src="https://user-images.githubusercontent.com/107422947/185241389-57105fa0-b3d1-443f-b425-5263f72e8a85.png">
- ran `stack submit` to create PRs for the full stack: <img width="929" alt="Screen Shot 2022-08-17 at 4 23 36 PM" src="https://user-images.githubusercontent.com/107422947/185241514-74c9c42e-f2bf-45ed-b854-3146408920a3.png">
- ran `/aviator stack merge` on the second PR in the stack leaving the 3rd PR needing to be reparented: <img width="921" alt="Screen Shot 2022-08-17 at 4 28 58 PM" src="https://user-images.githubusercontent.com/107422947/185241747-e6011be2-2e77-4991-98c6-f0bc500edb52.png">
- locally ran `stack sync` and saw the 3rd PR in the stack get auto-rebased: <img width="855" alt="Screen Shot 2022-08-17 at 4 34 52 PM" src="https://user-images.githubusercontent.com/107422947/185241824-11ece446-ec40-45d3-a6fc-010dcf0f8449.png">
- this also updated the local state: <img width="846" alt="Screen Shot 2022-08-17 at 4 39 53 PM" src="https://user-images.githubusercontent.com/107422947/185241865-84c485a9-3727-4993-b7f1-2c03b61693ed.png">
- ran `git push --force-with-lease origin mq-test-619133-3` manually because this wasn't yet part of the auto-rebase process (although it now has been added as a step in the code)
- ran `stack submit` and correctly see the PR updated to be on top of `main`: <img width="879" alt="Screen Shot 2022-08-17 at 4 53 49 PM" src="https://user-images.githubusercontent.com/107422947/185243357-2514c4e9-8bae-43ab-b7c4-43131c97d88e.png">