### PR TITLE
feat: Add stack metadata to PR on creation

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -147,6 +147,9 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 	}
 
 	trunkBranch, err := meta.Trunk(repo, opts.BranchName)
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to determine trunk branch")
+	}
 	prMeta := WritePRMetadata(PRMetadata{
 		Parent:     prBaseBranch,
 		ParentHead: branchMeta.Parent.Head,

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -146,9 +146,11 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 		opts.Body = firstCommit.Body
 	}
 
+	trunkBranch, err := meta.Trunk(repo, opts.BranchName)
 	prMeta := WritePRMetadata(PRMetadata{
 		Parent:     prBaseBranch,
 		ParentHead: branchMeta.Parent.Head,
+		Trunk:      trunkBranch,
 	})
 	pull, didCreatePR, err := getOrCreatePR(ctx, client, repoMeta, getOrCreatePROpts{
 		baseRefName: prBaseBranch,
@@ -381,6 +383,7 @@ func UpdatePullRequestState(ctx context.Context, repo *git.Repo, client *gh.Clie
 type PRMetadata struct {
 	Parent     string `json:"parent"`
 	ParentHead string `json:"parentHead"`
+	Trunk      string `json:"trunk"`
 }
 
 const PRMetadataCommentStart = "<!-- av pr metadata\n"

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -1,0 +1,21 @@
+package actions_test
+
+import (
+	"github.com/aviator-co/av/internal/actions"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestReadPRMetadata(t *testing.T) {
+	prMeta := actions.PRMetadata{
+		Parent:     "foo",
+		ParentHead: "bar",
+	}
+	prBody := "Hello! This is a cool PR that does some neat things.\n\n" + actions.WritePRMetadata(prMeta)
+	prMeta2, err := actions.ReadPRMetadata(prBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, prMeta.Parent, prMeta2.Parent)
+	assert.Equal(t, prMeta.ParentHead, prMeta2.ParentHead)
+}

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -10,6 +10,7 @@ func TestReadPRMetadata(t *testing.T) {
 	prMeta := actions.PRMetadata{
 		Parent:     "foo",
 		ParentHead: "bar",
+		Trunk:      "baz",
 	}
 	prBody := "Hello! This is a cool PR that does some neat things.\n\n" + actions.WritePRMetadata(prMeta)
 	prMeta2, err := actions.ReadPRMetadata(prBody)
@@ -18,4 +19,5 @@ func TestReadPRMetadata(t *testing.T) {
 	}
 	assert.Equal(t, prMeta.Parent, prMeta2.Parent)
 	assert.Equal(t, prMeta.ParentHead, prMeta2.ParentHead)
+	assert.Equal(t, prMeta.Trunk, prMeta2.Trunk)
 }

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -184,6 +184,14 @@ func ReadAllBranches(repo *git.Repo) (map[string]Branch, error) {
 	return branches, nil
 }
 
+func Trunk(repo *git.Repo, branchName string) (string, error) {
+	branch, _ := ReadBranch(repo, branchName)
+	if branch.Parent.Trunk {
+		return branch.Parent.Name, nil
+	}
+	return Trunk(repo, branch.Parent.Name)
+}
+
 // Find all the ancestor branches of the given branch name and append them to
 // the given slice (in topological order: a comes before b if a is an ancestor
 // of b).


### PR DESCRIPTION
I think this will help us be more robust against weird things happen because we're trying to figure out the users intention based on how the PRs are arranged on GitHub.

This also will mean that we don't have to use the `avbeta-stackedprs` label since we can just read the metadata from the PR comment. I think this will be necessary to avoid accidentally injecting stacked PRs functionality into existing dev workflows.

This is what it looks like:
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/773453/186551027-286331f3-e587-4ddd-97ae-884aea5418fc.png">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":""}
```
-->
