### PR TITLE
feat: Include parent pull in stack metadata, update metadata on stack submit

### DIFF
--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -1,8 +1,10 @@
 package actions_test
 
 import (
+	"fmt"
 	"github.com/aviator-co/av/internal/actions"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -10,14 +12,46 @@ func TestReadPRMetadata(t *testing.T) {
 	prMeta := actions.PRMetadata{
 		Parent:     "foo",
 		ParentHead: "bar",
+		ParentPull: 123,
 		Trunk:      "baz",
 	}
-	prBody := "Hello! This is a cool PR that does some neat things.\n\n" + actions.WritePRMetadata(prMeta)
+	prBody := actions.AddPRMetadata("Hello! This is a cool PR that does some neat things.", prMeta)
+	fmt.Println(prBody)
 	prMeta2, err := actions.ReadPRMetadata(prBody)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, prMeta.Parent, prMeta2.Parent)
 	assert.Equal(t, prMeta.ParentHead, prMeta2.ParentHead)
+	assert.Equal(t, prMeta.ParentPull, prMeta2.ParentPull)
 	assert.Equal(t, prMeta.Trunk, prMeta2.Trunk)
+
+	prBody = actions.AddPRMetadata(prBody, actions.PRMetadata{
+		Parent:     "foo2",
+		ParentHead: "bar2",
+		ParentPull: 1234,
+		Trunk:      "baz2",
+	})
+	assert.Contains(t, prBody, "Hello! This is a cool PR that does some neat things.\n\n")
+	prMeta2, err = actions.ReadPRMetadata(prBody)
+	require.NoError(t, err)
+	assert.Equal(t, "foo2", prMeta2.Parent)
+	assert.Equal(t, "bar2", prMeta2.ParentHead)
+}
+
+func TestPRMetadataPreservesBody(t *testing.T) {
+	sampleMeta := actions.PRMetadata{
+		Parent:     "foo",
+		ParentHead: "bar",
+		ParentPull: 123,
+		Trunk:      "baz",
+	}
+	body1 := actions.AddPRMetadata("Hello! This is a cool PR that does some neat things.", sampleMeta)
+	// Add some text to the end of the body (as if someone had edited manually)
+	body1 += "\n\nIt's very neat, actually."
+
+	body2 := actions.AddPRMetadata(body1, sampleMeta)
+	assert.Contains(t, body2, "Hello! This is a cool PR that does some neat things.")
+	assert.Contains(t, body2, "It's very neat, actually.")
+	assert.Contains(t, body2, "\n"+actions.PRMetadataCommentStart)
 }

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -24,6 +24,7 @@ type PullRequest struct {
 	Permalink           string
 	State               githubv4.PullRequestState
 	Title               string
+	Body                string
 	PRIVATE_MergeCommit struct {
 		Oid string
 	} `graphql:"mergeCommit"`


### PR DESCRIPTION
This PR adds `parentPull` to stack metadata. It also will update the metadata whenever `CreatePullRequest` is called (_i.e._, when doing `av pr create` or `av stack submit`).

We'll probably need to detect if things are bad™ on the server side of things and recommend running `av stack submit`, but at least this should make it so that the logic for constructing stacks is more explicit and intentional and consistent and less likely to do unexpected things.



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
