### PR TITLE
fix: Update base branch during av stack sync

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,14 @@ type GitHub struct {
 type PullRequest struct {
 	Draft       bool
 	OpenBrowser bool
+	// If true, the pull request will be converted to a draft if the base branch
+	// needs to be changed after the pull request has been changed. This avoids
+	// accidentally adding lots of unnecessary auto-added reviewers (via GitHub's
+	// CODEOWNERS feature) to the pull request while the PR is in a transient
+	// state.
+	// If not set, the value should be considered true iff there is a CODEOWNERS
+	// file in the repository.
+	RebaseWithDraft *bool
 }
 
 var Av = struct {

--- a/internal/utils/ghutils/ghutils.go
+++ b/internal/utils/ghutils/ghutils.go
@@ -1,0 +1,14 @@
+package ghutils
+
+import (
+	"github.com/aviator-co/av/internal/git"
+	"os"
+	"path"
+)
+
+func HasCodeowners(repo *git.Repo) bool {
+	if stat, _ := os.Stat(path.Join(repo.Dir(), ".github/CODEOWNERS")); stat != nil {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/773453/192597089-327bafbe-19fd-45d1-853a-e9084820f72d.png">

I don't like the diverging-convering logic of this where we have the `syncBranchUpdateNewTrunk` being called from `syncBranchRebase` **and** `syncBranchContinue`. Might try to think about how to do it better in the future, but this is probably fine for now.
