### PR TITLE
fix: Don't try to change the base branch of closed PRs

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -282,7 +282,11 @@ base branch.
 		if err != nil {
 			return err
 		}
-		for _, currentBranch := range branchesToSync {
+		for i, currentBranch := range branchesToSync {
+			if i > 0 {
+				// Add spacing in the output between each branch sync
+				_, _ = fmt.Fprint(os.Stderr, "\n\n")
+			}
 			state.CurrentBranch = currentBranch
 			res, err := actions.SyncBranch(ctx, repo, client, repoMeta, actions.SyncBranchOpts{
 				Branch:       currentBranch,

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	"os"
+	"strings"
 )
 
 type SyncBranchOpts struct {
@@ -435,6 +436,20 @@ func syncBranchPushAndUpdatePullRequest(
 		if err != nil {
 			return errors.WrapIff(err, "failed to fetch pull request info for %q", branch.Name)
 		}
+	}
+
+	if pr.State == githubv4.PullRequestStateClosed || pr.State == githubv4.PullRequestStateMerged {
+		_, _ = fmt.Fprint(os.Stderr,
+			"  - ", colors.Warning("WARNING:"),
+			" pull request ", colors.UserInput("#", pr.Number),
+			" is ", colors.UserInput(strings.ToLower(string(pr.State))),
+			", skipping push\n",
+		)
+		_, _ = fmt.Fprint(os.Stderr,
+			"      - re-open the pull request (or create a new one with ",
+			colors.CliCmd("av pr create"), ") to push changes\n",
+		)
+		return nil
 	}
 
 	var rebaseWithDraft bool


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
