### PR TITLE
feat: Stop applying avbeta-stackedprs label

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -230,18 +230,6 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 	if err := meta.WriteBranch(repo, branchMeta); err != nil {
 		return nil, err
 	}
-
-	// add the avbeta-stackedprs label to enable Aviator server-side stacked
-	// PRs functionality
-	if err := client.AddIssueLabels(ctx, gh.AddIssueLabelInput{
-		Owner:      repoMeta.Owner,
-		Repo:       repoMeta.Name,
-		Number:     pull.Number,
-		LabelNames: []string{"avbeta-stackedprs"},
-	}); err != nil {
-		return nil, errors.WrapIf(err, "adding avbeta-stackedprs label")
-	}
-
 	var action string
 	if didCreatePR {
 		action = "created"


### PR DESCRIPTION
We've been using the embedded metadata in the PR description for a few months on the server side now, so there's no need to add the `avbeta-stackedprs` label anymore.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
