### PR TITLE
fix: Don't un-draft PRs during re-parent

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -149,7 +149,6 @@ base branch.
 			return errors.New("refusing to sync: there are unstaged changes in the working tree (use `git add` to stage changes)")
 		}
 
-		var currentBranch string
 		if stackSyncFlags.Continue {
 			if state.CurrentBranch == "" {
 				return errors.New("no sync in progress")
@@ -166,12 +165,13 @@ base branch.
 			// conflict (and this command will not work).
 			// Since we're *not* continuing a sync, we assume we're not in
 			// detached HEAD and so this is a reasonable thing to do.
-			currentBranch, err = repo.CurrentBranchName()
+			var err error
+			state.CurrentBranch, err = repo.CurrentBranchName()
 			if err != nil {
 				return err
 			}
 
-			state.OriginalBranch = currentBranch
+			state.OriginalBranch = state.CurrentBranch
 			state.Config = stackSyncConfig{
 				stackSyncFlags.Current,
 				stackSyncFlags.Trunk,
@@ -192,7 +192,7 @@ base branch.
 				return err
 			}
 			opts := actions.ReparentOpts{
-				Branch:         currentBranch,
+				Branch:         state.CurrentBranch,
 				NewParent:      state.Config.Parent,
 				NewParentTrunk: state.Config.Parent == defaultBranch,
 			}


### PR DESCRIPTION
Fixing this as reported by a customer.

Before this, we would actually un-draft (aka _mark ready for review_) PRs that were in a draft state if we were re-parenting the PR.

Incidentally, while fixing that bug, I realized that we actually were never transitioning PR's to a draft state at all when they should have been.

With this PR, I verified that now:
* PRs that should be switched to draft during re-parent (to avoid adding unnecessary codeowners) actually are
* PRs that are in a draft state when the re-parent runs continue to stay draft PRs

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
