### PR TITLE
fix: Use `git push --force-with-lease` in `av pr create`

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -97,6 +97,11 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 
 		if opts.ForcePush {
 			pushFlags = append(pushFlags, "--force")
+		} else {
+			// Use --force-with-lease to allow pushing branches that have been
+			// rebased but don't overwrite changes if we don't expect them to
+			// be there.
+			pushFlags = append(pushFlags, "--force-with-lease")
 		}
 
 		// Check if the upstream is set. If not, we set it during push.


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
