### PR TITLE
fix: Parse EDITOR with shell syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	emperror.dev/errors v0.8.1
 	github.com/fatih/color v1.13.0
 	github.com/golangci/golangci-lint v1.48.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/text v0.2.0
 	github.com/segmentio/golines v0.10.0
 	github.com/shurcooL/githubv4 v0.0.0-20220115235240-a14260e6f8a2

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.6.2 h1:uGQ9xI8/pgc9iOoCe7kWQgRE6SBTrCGmTSf0LrEtY7c=

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -6,11 +6,43 @@ import (
 )
 
 func TestEditor(t *testing.T) {
-	res, err := Launch(nil, Config{
-		Text:          "Hello world!\n\nBonjour le monde!\n; This is a comment\n",
-		CommentPrefix: ";",
-		Command:       "true",
-	})
-	require.NoError(t, err, "failed to launch editor")
-	require.Equal(t, "Hello world!\n\nBonjour le monde!\n", res)
+	type test struct {
+		name    string
+		command string
+		in      string
+		out     string
+		error   bool
+	}
+	for _, tt := range []test{
+		{
+			name:    "with comments",
+			command: "true",
+			in:      "Hello world!\n\nBonjour le monde!\n%% This is a commend\n",
+			out:     "Hello world!\n\nBonjour le monde!\n",
+		},
+		{
+			name:    "command with flags",
+			command: "sed -i -e 's/Hello/Hi/'",
+			in:      "Hello world!\n\nBonjour le monde!\n",
+			out:     "Hi world!\n\nBonjour le monde!\n",
+		},
+		{
+			name:    "error",
+			command: "true",
+			in:      "Hello world!\n\nBonjour le monde!\n",
+			error:   true,
+		},
+	} {
+		res, err := Launch(nil, Config{
+			Text:          tt.in,
+			CommentPrefix: "%%",
+			Command:       tt.command,
+		})
+		if tt.error {
+			require.Error(t, err, "expected error while executing `%s`", tt.command)
+			continue
+		}
+		require.NoError(t, err, "failed to launch editor `%s`", tt.command)
+		require.Equal(t, tt.out, res)
+	}
 }

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -28,7 +28,7 @@ func TestEditor(t *testing.T) {
 		},
 		{
 			name:    "error",
-			command: "true",
+			command: "false",
 			in:      "Hello world!\n\nBonjour le monde!\n",
 			error:   true,
 		},


### PR DESCRIPTION
Fixing a bug reported by a customer.

Now we parse the result of `EDITOR`/`GIT_EDITOR` with shell syntax.

This is what [GitHub's `hub` CLI does](https://github.com/github/hub/issues/721) as well as what Git itself does:
```
$ git help var
...
       GIT_EDITOR
           Text editor for use by Git commands. The value is meant to be interpreted by the shell when it is used. Examples: ~/bin/vi, $SOME_ENVIRONMENT_VARIABLE,
           "C:\Program Files\Vim\gvim.exe" --nofork. The order of preference is the $GIT_EDITOR environment variable, then core.editor configuration, then $VISUAL,
           then $EDITOR, and then the default chosen at compile time, which is usually vi.
...
```

This PR adds some tests and I'm actually submitting the PR with `EDITOR="code --wait" av pr create --draft`. Notably, it doesn't support the `$SOME_ENVIRONMENT_VARIABLE` syntax for the editor, but that's probably fine (at least for now).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
