### PR TITLE
fix: Use the remote tracking branch for the sync

### DIFF
--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -162,7 +162,10 @@ func syncBranchRebase(
 			return nil, errors.WrapIff(err, "failed to fetch trunk branch %q from origin", trunk)
 		}
 
-		trunkHead, err := repo.RevParse(&git.RevParse{Rev: trunk})
+		// NOTE: Strictly speaking, if a user doesn't use the default refspec (e.g. fetch is
+		// not +refs/heads/*:refs/remotes/origin/*, the remote tracking branch is not
+		// origin/$TRUNK. As we just fetched from a remote, it'd be safe to use FETCH_HEAD.
+		trunkHead, err := repo.RevParse(&git.RevParse{Rev: "origin/" + trunk})
 		if err != nil {
 			return nil, errors.WrapIff(err, "failed to get HEAD of %q", trunk)
 		}


### PR DESCRIPTION
If a PR is based on "main", it should be rebased on top of
"origin/main", not local "main" branch.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
