### PR TITLE
feat: Show the commit message body

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -270,7 +270,9 @@ type prBodyTemplateData struct {
 	Commits []git.CommitInfo
 }
 
-var prBodyTemplate = template.Must(template.New("prBody").Parse(`%% Creating pull request for branch '{{ .Branch }}'
+var templateFuncs = template.FuncMap{"trimSpace": strings.TrimSpace}
+
+var prBodyTemplate = template.Must(template.New("prBody").Funcs(templateFuncs).Parse(`%% Creating pull request for branch '{{ .Branch }}'
 %% Lines starting with '%%' will be ignored and an empty message aborts the
 %% creation of the pull request.
 
@@ -283,6 +285,11 @@ var prBodyTemplate = template.Must(template.New("prBody").Parse(`%% Creating pul
 %% This branch includes the following commits:
 {{- range $c := .Commits }}
 %%     {{ $c.ShortHash }}    {{ $c.Subject }}
+{{- if trimSpace $c.Body }}
+{{- range $line := $c.BodyWithPrefix "%%         " }}
+{{ trimSpace $line }}
+{{- end }}
+{{- end }}
 {{- end }}
 `))
 

--- a/internal/git/show.go
+++ b/internal/git/show.go
@@ -18,6 +18,14 @@ type CommitInfo struct {
 	Body      string
 }
 
+func (c CommitInfo) BodyWithPrefix(prefix string) []string {
+	var lines []string
+	for _, line := range strings.Split(strings.TrimSpace(c.Body), "\n") {
+		lines = append(lines, prefix + line)
+	}
+	return lines
+}
+
 func (r *Repo) CommitInfo(opts CommitInfoOpts) (*CommitInfo, error) {
 	// Need --quiet to suppress the diff that would otherwise be printed at the
 	// end


### PR DESCRIPTION
Currently we show the commit message subjects (the first line of the
message) as the comment in the PR message editor. This shows the message
body as well. This is useful when there are multiple commits or when
there is a PR template (.github/PULL_REQUEST_TEMPLATE.md) exists.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
