### PR TITLE
fix: trim the comments properly

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -202,7 +202,7 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 		res, err := editor.Launch(repo, editor.Config{
 			Text:           editorText,
 			TmpFilePattern: "pr-*.md",
-			CommentPrefix:  "%% ",
+			CommentPrefix:  "%%",
 		})
 		if err != nil {
 			return nil, errors.WrapIf(err, "failed to launch text editor")


### PR DESCRIPTION
The comment prefix doesn't have to have a space. This should trim the
comments properly when a comment line doesn't contain anything but '%%'.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
