### PR TITLE
feat: Support detached HEAD in stack tree

### DIFF
--- a/cmd/av/stack_tree.go
+++ b/cmd/av/stack_tree.go
@@ -29,9 +29,14 @@ var stackTreeCmd = &cobra.Command{
 			return err
 		}
 
-		currentBranch, err := repo.CurrentBranchName()
-		if err != nil {
+		var currentBranch string
+		if dh, err := repo.DetachedHead(); err != nil {
 			return err
+		} else if !dh {
+			currentBranch, err = repo.CurrentBranchName()
+			if err != nil {
+				return err
+			}
 		}
 
 		// TODO[polish]:

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -144,6 +144,19 @@ func (r *Repo) GitStdin(args []string, stdin io.Reader) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// DetachedHead returns true if the repository is in the detached HEAD.
+func (r *Repo) DetachedHead() (bool, error) {
+	ret, err := r.Run(&RunOpts{
+		Args: []string{
+			"symbolic-ref", "--quiet", "HEAD",
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return ret.ExitCode == 1, nil
+}
+
 // CurrentBranchName returns the name of the current branch.
 // The name is return in "short" format -- i.e., without the "refs/heads/" prefix.
 // IMPORTANT: This function will return an error if the repository is currently


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
