### PR TITLE
fix: Do not use set-upstream

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -111,7 +111,7 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 		logrus.Debug("pushing latest changes")
 
 		_, _ = fmt.Fprint(os.Stderr,
-			"  - pushing to origin's ", color.CyanString("%s", opts.BranchName),
+			"  - pushing to ", color.CyanString("origin/%s", opts.BranchName),
 			"\n",
 		)
 		if _, err := repo.Git(pushFlags...); err != nil {

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -105,24 +105,13 @@ func CreatePullRequest(ctx context.Context, repo *git.Repo, client *gh.Client, o
 			pushFlags = append(pushFlags, "--force-with-lease")
 		}
 
-		// Check if the upstream is set. If not, we set it during push.
-		// TODO: Should we store this somewhere? I think currently things will
-		//       break if the upstream name is not the same name as the local
-		upstream, err := repo.RevParse(&git.RevParse{
-			SymbolicFullName: true,
-			Rev:              fmt.Sprintf("%s@{u}", opts.BranchName),
-		})
-		if err != nil {
-			// Set the upstream branch
-			upstream = "origin/" + opts.BranchName
-			pushFlags = append(pushFlags, "--set-upstream", "origin", opts.BranchName)
-		} else {
-			upstream = strings.TrimPrefix(upstream, "refs/remotes/")
-		}
-		logrus.WithField("upstream", upstream).Debug("pushing latest changes")
+		// NOTE: This assumes that the user use the default push strategy (simple). It would
+		// be rare to use the upstream strategy.
+		pushFlags = append(pushFlags, "origin", opts.BranchName)
+		logrus.Debug("pushing latest changes")
 
 		_, _ = fmt.Fprint(os.Stderr,
-			"  - pushing to ", color.CyanString("%s", upstream),
+			"  - pushing to origin's ", color.CyanString("%s", opts.BranchName),
 			"\n",
 		)
 		if _, err := repo.Git(pushFlags...); err != nil {

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -2,8 +2,11 @@ package actions
 
 import (
 	"context"
-	"emperror.dev/errors"
 	"fmt"
+	"os"
+	"strings"
+
+	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/gh"
 	"github.com/aviator-co/av/internal/git"
@@ -13,8 +16,6 @@ import (
 	"github.com/aviator-co/av/internal/utils/sliceutils"
 	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
-	"os"
-	"strings"
 )
 
 type SyncBranchOpts struct {
@@ -464,9 +465,9 @@ func syncBranchPushAndUpdatePullRequest(
 	}
 
 	if err := Push(repo, PushOpts{
-		Force:                 ForceWithLease,
-		SkipIfUpstreamNotSet:  true,
-		SkipIfUpstreamMatches: true,
+		Force:                        ForceWithLease,
+		SkipIfRemoteBranchNotExist:   true,
+		SkipIfRemoteBranchIsUpToDate: true,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Each local git branch can have an optional upstream branch. While the
name looks like the push destination of the branch, it's not. Unless
user specifically configure so, `git push` pushes a branch to the same
name branch on the remote (the simple strategy as described in `man 1
git-push`). This explains the behavior in the TODO comment in
internal/actions/pr.go "I think currently things will break if the
upstream name is not the same name as the local", because git's default
strategy is pushing to the same branch, not to the upstream branch.

The upstream branch is rather used when doing `git rebase`. Without an
argument, it rebases to the upstream branch. Likewise, when `git pull`
does the rebase, it'll rebase to the upstream branch. In many cases, if
a PR is rebased, the intention would be to rebase to the trunk branch
(master/main), not the same branch on the remote.

Based on this, it's not necessary for av-cli to modify the branch
upstream. It's not related to git-push (in most of the cases). Leaving
it intact should allow users to choose whichever branch that makes sense
to them (I personally use origin/main because it makes `git rebase`
easy).

This should not affect most of the users. Most of them won't notice
the change. The only case they are affected is (1) They do not use `av
pr create` but use `av stack sync` by some means creating a branch
metadata and (2) set the upstream branch to a different name manually
and (3) pushing to a different name branch manually or setting
"upstream" strategy explicitly in the git config. Again, it's very
unlikely this happens because `av pr create` did follow the "simple"
strategy rule, which is git's default, and in order for a user to be
affected by this change, they somehow need to get around it to use the
"upstream" strategy.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
