### PR TITLE
feat: allow editing a PR description

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -117,6 +117,6 @@ func init() {
 	)
 	prCreateCmd.Flags().BoolVar(
 		&prCreateFlags.Edit, "edit", false,
-		"open the editor for editing always",
+		"always open an editor to edit the pull request title and description",
 	)
 }

--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -23,6 +23,7 @@ var prCreateFlags struct {
 	NoPush bool
 	Title  string
 	Body   string
+	Edit   bool
 }
 var prCreateCmd = &cobra.Command{
 	Use:   "create",
@@ -77,6 +78,7 @@ Examples:
 				//       unify config and flags (the latter should always
 				//       override the former).
 				Draft: prCreateFlags.Draft || config.Av.PullRequest.Draft,
+				Edit:  prCreateFlags.Edit,
 			},
 		); err != nil {
 			return err
@@ -112,5 +114,9 @@ func init() {
 	prCreateCmd.Flags().StringVarP(
 		&prCreateFlags.Body, "body", "b", "",
 		"body of the pull request to create (a value of - will read from stdin)",
+	)
+	prCreateCmd.Flags().BoolVar(
+		&prCreateFlags.Edit, "edit", false,
+		"open the editor for editing always",
 	)
 }


### PR DESCRIPTION
Previously, if there's an existing PR, an editor pops open, but the
content is discarded anyway. Now it won't opens an editor in such case.

With the new flag `--edit`, an editor opens for an existing PR. The
content is pre-filled with the existing PR description and updated
contents are reflected to the PR.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
