### PR TITLE
refactor: Create meta.DB interface

### DIFF
--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -17,7 +17,7 @@ type Branch struct {
 	// The branch name associated with this stack.
 	// Not stored in JSON because the name can always be derived from the name
 	// of the git ref.
-	Name string `json:"-"`
+	Name string `json:"name"`
 
 	// Information about the parent branch.
 	Parent BranchState `json:"parent,omitempty"`
@@ -60,13 +60,9 @@ func (b *Branch) UnmarshalJSON(bytes []byte) error {
 		return err
 	}
 
-	// Copy over all the data that we unmarshalled into BranchAlias. This is
-	// everything except since Parent which we'll handle next. We need to take
-	// special care to copy name since it won't be defined on BranchAlias (since
-	// Name is not serialized to JSON). Instead we expect that the struct is
-	// always initialized with the name defined, so we have to copy it over here.
-	// (Doing just "*b = ..." will result in us erasing the name.)
-	d.BranchAlias.Name = b.Name
+	if b.Name != "" {
+		d.BranchAlias.Name = b.Name
+	}
 	*b = Branch(d.BranchAlias)
 
 	// Parse the parent information (which can either be a string or a JSON)

--- a/internal/meta/db.go
+++ b/internal/meta/db.go
@@ -8,6 +8,8 @@ type DB interface {
 // ReadTx is a transaction that can be used to read from the database.
 // It presents a consistent view of the underlying database.
 type ReadTx interface {
+	// Repository returns the repository information.
+	Repository() (Repository, bool)
 	// Branch returns the branch with the given name. If no such branch exists,
 	// the second return value is false.
 	Branch(name string) (Branch, bool)
@@ -28,4 +30,6 @@ type WriteTx interface {
 	Commit() error
 	// SetBranch sets the given branch in the database.
 	SetBranch(branch Branch)
+	// SetRepository sets the repository information in the database.
+	SetRepository(repository Repository)
 }

--- a/internal/meta/db.go
+++ b/internal/meta/db.go
@@ -1,0 +1,26 @@
+package meta
+
+type DB interface {
+	ReadTx
+	// WithTx runs the given function in a transaction. The transaction is
+	// committed when the function returns (unless it has been aborted by
+	// calling WriteTx.Abort).
+	WithTx(func(tx WriteTx)) error
+}
+
+type ReadTx interface {
+	// Branch returns the branch with the given name. If no such branch exists,
+	// the second return value is false.
+	Branch(name string) (Branch, bool)
+	// AllBranches returns a map of all branches in the database.
+	AllBranches() map[string]Branch
+}
+
+// WriteTx is a transaction that can be used to modify the database.
+type WriteTx interface {
+	ReadTx
+	// Abort aborts the transaction (no changes will be committed).
+	Abort()
+	// SetBranch sets the given branch in the database.
+	SetBranch(branch Branch)
+}

--- a/internal/meta/db.go
+++ b/internal/meta/db.go
@@ -1,13 +1,12 @@
 package meta
 
 type DB interface {
-	ReadTx
-	// WithTx runs the given function in a transaction. The transaction is
-	// committed when the function returns (unless it has been aborted by
-	// calling WriteTx.Abort).
-	WithTx(func(tx WriteTx)) error
+	ReadTx() ReadTx
+	WriteTx() WriteTx
 }
 
+// ReadTx is a transaction that can be used to read from the database.
+// It presents a consistent view of the underlying database.
 type ReadTx interface {
 	// Branch returns the branch with the given name. If no such branch exists,
 	// the second return value is false.
@@ -20,7 +19,13 @@ type ReadTx interface {
 type WriteTx interface {
 	ReadTx
 	// Abort aborts the transaction (no changes will be committed).
+	// The transaction cannot be used after it has been aborted.
 	Abort()
+	// Commit commits the transaction (all changes will be committed).
+	// If an error is returned, the data could not be commited.
+	// The transaction cannot be used after it has been committed (even if an
+	// error is returned).
+	Commit() error
 	// SetBranch sets the given branch in the database.
 	SetBranch(branch Branch)
 }

--- a/internal/meta/jsonfiledb/db.go
+++ b/internal/meta/jsonfiledb/db.go
@@ -2,11 +2,14 @@ package jsonfiledb
 
 import (
 	"github.com/aviator-co/av/internal/meta"
+	"sync"
 )
 
 type DB struct {
-	*state
 	filepath string
+
+	stateMu sync.Mutex
+	state   *state
 }
 
 // Open opens a JSON file database at the given path.
@@ -16,24 +19,24 @@ func Open(filepath string) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	db := &DB{state, filepath}
+	db := &DB{filepath, sync.Mutex{}, state}
 	return db, nil
 }
 
-func (d *DB) WithTx(fn func(tx meta.WriteTx)) error {
-	// Make a copy of the state.
-	// Since all of the properties are immutable trees, this is effectively a
-	// deep copy.
-	tx := &writeTx{state: d.state.copy()}
-	fn(tx)
-	if tx.aborted {
-		return nil
-	}
-	if err := tx.state.write(d.filepath); err != nil {
-		return err
-	}
-	d.state = &tx.state
-	return nil
+func (d *DB) ReadTx() meta.ReadTx {
+	// Acquire the lock in order to safely access and copy state, but we don't
+	// need to hold the lock for the entire duration of the read transaction.
+	d.stateMu.Lock()
+	defer d.stateMu.Unlock()
+	return &readTx{d.state.copy()}
+}
+
+func (d *DB) WriteTx() meta.WriteTx {
+	// For a write transaction, we acquire the lock until the transaction is
+	// aborted/committed in order to prevent other transactions from modifying
+	// the state.
+	d.stateMu.Lock()
+	return &writeTx{d, readTx{d.state.copy()}}
 }
 
 var (

--- a/internal/meta/jsonfiledb/db.go
+++ b/internal/meta/jsonfiledb/db.go
@@ -1,0 +1,41 @@
+package jsonfiledb
+
+import (
+	"github.com/aviator-co/av/internal/meta"
+)
+
+type DB struct {
+	*state
+	filepath string
+}
+
+// Open opens a JSON file database at the given path.
+// If the file does not exist, it is created.
+func Open(filepath string) (*DB, error) {
+	state, err := readState(filepath)
+	if err != nil {
+		return nil, err
+	}
+	db := &DB{state, filepath}
+	return db, nil
+}
+
+func (d *DB) WithTx(fn func(tx meta.WriteTx)) error {
+	// Make a copy of the state.
+	// Since all of the properties are immutable trees, this is effectively a
+	// deep copy.
+	tx := &writeTx{state: d.state.copy()}
+	fn(tx)
+	if tx.aborted {
+		return nil
+	}
+	if err := tx.state.write(d.filepath); err != nil {
+		return err
+	}
+	d.state = &tx.state
+	return nil
+}
+
+var (
+	_ meta.DB = &DB{}
+)

--- a/internal/meta/jsonfiledb/db_test.go
+++ b/internal/meta/jsonfiledb/db_test.go
@@ -3,6 +3,7 @@ package jsonfiledb_test
 import (
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/meta/jsonfiledb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -13,32 +14,35 @@ func TestJSONFileDB(t *testing.T) {
 	db, err := jsonfiledb.Open(tempfile)
 	require.NoError(t, err, "db open should succeed if state file does not exist")
 
-	if _, ok := db.Branch("foo"); ok {
+	if _, ok := db.ReadTx().Branch("foo"); ok {
 		t.Error("non existent branch should not be found")
 	}
 
-	err = db.WithTx(func(tx meta.WriteTx) {
-		tx.SetBranch(meta.Branch{Name: "foo"})
-	})
-	require.NoError(t, err, "tx commit should succeed")
+	tx := db.WriteTx()
+	tx.SetBranch(meta.Branch{Name: "foo"})
+	require.NoError(t, tx.Commit(), "tx commit should succeed")
 
-	err = db.WithTx(func(tx meta.WriteTx) {
-		tx.SetBranch(meta.Branch{Name: "bar"})
-		tx.Abort()
-	})
-	require.NoError(t, err, "aborted tx should not return error")
-	if _, ok := db.Branch("bar"); ok {
+	tx = db.WriteTx()
+	tx.SetBranch(meta.Branch{Name: "bar"})
+	bar, ok := tx.Branch("bar")
+	if !ok {
+		t.Error("modifications should be visible within a transaction")
+	}
+	assert.Equal(t, "bar", bar.Name, "branch name should match")
+	tx.Abort()
+
+	if _, ok := db.ReadTx().Branch("bar"); ok {
 		t.Error("aborted tx should not commit changes")
 	}
 
-	foo, ok := db.Branch("foo")
+	foo, ok := db.ReadTx().Branch("foo")
 	require.True(t, ok, "branch should be found")
 	require.Equal(t, "foo", foo.Name, "branch name should match")
 
 	// Re-open the database and cause it to re-read from disk
 	db, err = jsonfiledb.Open(tempfile)
 	require.NoError(t, err, "db open should succeed if state file exists")
-	foo, ok = db.Branch("foo")
+	foo, ok = db.ReadTx().Branch("foo")
 	require.True(t, ok, "branch should be found after re-open")
 	require.Equal(t, "foo", foo.Name, "branch name should match")
 }

--- a/internal/meta/jsonfiledb/db_test.go
+++ b/internal/meta/jsonfiledb/db_test.go
@@ -1,0 +1,44 @@
+package jsonfiledb_test
+
+import (
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/meta/jsonfiledb"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestJSONFileDB(t *testing.T) {
+	tempfile := t.TempDir() + "/db.json"
+
+	db, err := jsonfiledb.Open(tempfile)
+	require.NoError(t, err, "db open should succeed if state file does not exist")
+
+	if _, ok := db.Branch("foo"); ok {
+		t.Error("non existent branch should not be found")
+	}
+
+	err = db.WithTx(func(tx meta.WriteTx) {
+		tx.SetBranch(meta.Branch{Name: "foo"})
+	})
+	require.NoError(t, err, "tx commit should succeed")
+
+	err = db.WithTx(func(tx meta.WriteTx) {
+		tx.SetBranch(meta.Branch{Name: "bar"})
+		tx.Abort()
+	})
+	require.NoError(t, err, "aborted tx should not return error")
+	if _, ok := db.Branch("bar"); ok {
+		t.Error("aborted tx should not commit changes")
+	}
+
+	foo, ok := db.Branch("foo")
+	require.True(t, ok, "branch should be found")
+	require.Equal(t, "foo", foo.Name, "branch name should match")
+
+	// Re-open the database and cause it to re-read from disk
+	db, err = jsonfiledb.Open(tempfile)
+	require.NoError(t, err, "db open should succeed if state file exists")
+	foo, ok = db.Branch("foo")
+	require.True(t, ok, "branch should be found after re-open")
+	require.Equal(t, "foo", foo.Name, "branch name should match")
+}

--- a/internal/meta/jsonfiledb/readtx.go
+++ b/internal/meta/jsonfiledb/readtx.go
@@ -1,0 +1,21 @@
+package jsonfiledb
+
+import (
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/maputils"
+)
+
+type readTx struct {
+	state state
+}
+
+var _ meta.ReadTx = &readTx{}
+
+func (tx *readTx) Branch(name string) (branch meta.Branch, ok bool) {
+	branch, ok = tx.state.Branches[name]
+	return
+}
+
+func (tx *readTx) AllBranches() map[string]meta.Branch {
+	return maputils.Copy(tx.state.Branches)
+}

--- a/internal/meta/jsonfiledb/readtx.go
+++ b/internal/meta/jsonfiledb/readtx.go
@@ -11,11 +11,15 @@ type readTx struct {
 
 var _ meta.ReadTx = &readTx{}
 
+func (tx *readTx) Repository() (meta.Repository, bool) {
+	return tx.state.RepositoryState, tx.state.RepositoryState.ID != ""
+}
+
 func (tx *readTx) Branch(name string) (branch meta.Branch, ok bool) {
-	branch, ok = tx.state.Branches[name]
+	branch, ok = tx.state.BranchState[name]
 	return
 }
 
 func (tx *readTx) AllBranches() map[string]meta.Branch {
-	return maputils.Copy(tx.state.Branches)
+	return maputils.Copy(tx.state.BranchState)
 }

--- a/internal/meta/jsonfiledb/state.go
+++ b/internal/meta/jsonfiledb/state.go
@@ -1,0 +1,59 @@
+package jsonfiledb
+
+import (
+	"emperror.dev/errors"
+	"encoding/json"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/maputils"
+	"os"
+)
+
+func readState(filepath string) (*state, error) {
+	data, err := os.ReadFile(filepath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if len(data) == 0 {
+		data = []byte("{}")
+	}
+	var state state
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, errors.WrapIff(err, "failed to read av state file %q", filepath)
+	}
+	return &state, nil
+}
+
+type state struct {
+	Branches map[string]meta.Branch `json:"branches"`
+}
+
+var _ meta.ReadTx = &state{}
+
+func (d *state) Branch(name string) (meta.Branch, bool) {
+	branch, ok := d.Branches[name]
+	return branch, ok
+}
+
+func (d *state) AllBranches() map[string]meta.Branch {
+	return maputils.Copy(d.Branches)
+}
+
+func (d *state) copy() state {
+	return state{
+		maputils.Copy(d.Branches),
+	}
+}
+
+func (d *state) write(filepath string) error {
+	f, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return errors.WrapIff(err, "failed to write av state file")
+	}
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(d); err != nil {
+		_ = f.Close()
+		return errors.WrapIff(err, "failed to write av state file")
+	}
+	return f.Close()
+}

--- a/internal/meta/jsonfiledb/state.go
+++ b/internal/meta/jsonfiledb/state.go
@@ -24,23 +24,14 @@ func readState(filepath string) (*state, error) {
 }
 
 type state struct {
-	Branches map[string]meta.Branch `json:"branches"`
-}
-
-var _ meta.ReadTx = &state{}
-
-func (d *state) Branch(name string) (meta.Branch, bool) {
-	branch, ok := d.Branches[name]
-	return branch, ok
-}
-
-func (d *state) AllBranches() map[string]meta.Branch {
-	return maputils.Copy(d.Branches)
+	BranchState     map[string]meta.Branch `json:"branches"`
+	RepositoryState meta.Repository        `json:"repository"`
 }
 
 func (d *state) copy() state {
 	return state{
-		maputils.Copy(d.Branches),
+		maputils.Copy(d.BranchState),
+		d.RepositoryState,
 	}
 }
 

--- a/internal/meta/jsonfiledb/writetx.go
+++ b/internal/meta/jsonfiledb/writetx.go
@@ -1,0 +1,18 @@
+package jsonfiledb
+
+import "github.com/aviator-co/av/internal/meta"
+
+type writeTx struct {
+	state
+	aborted bool
+}
+
+func (tx *writeTx) SetBranch(branch meta.Branch) {
+	tx.Branches[branch.Name] = branch
+}
+
+func (tx *writeTx) Abort() {
+	tx.aborted = true
+}
+
+var _ meta.WriteTx = &writeTx{}

--- a/internal/meta/jsonfiledb/writetx.go
+++ b/internal/meta/jsonfiledb/writetx.go
@@ -7,8 +7,12 @@ type writeTx struct {
 	readTx
 }
 
+func (tx *writeTx) SetRepository(repository meta.Repository) {
+	tx.state.RepositoryState = repository
+}
+
 func (tx *writeTx) SetBranch(branch meta.Branch) {
-	tx.state.Branches[branch.Name] = branch
+	tx.state.BranchState[branch.Name] = branch
 }
 
 func (tx *writeTx) Abort() {

--- a/internal/utils/maputils/copy.go
+++ b/internal/utils/maputils/copy.go
@@ -1,0 +1,10 @@
+package maputils
+
+// Copy returns a (shallow) copy of the given map.
+func Copy[K comparable, T any](m map[K]T) map[K]T {
+	c := make(map[K]T, len(m))
+	for k, v := range m {
+		c[k] = v
+	}
+	return c
+}


### PR DESCRIPTION
This is just the first PR in what will probably be a few. This one adds a basic database interface that just stores everything as a big `map` (which is probably fine for our scale of data) and writes to/reads from a JSON file as the persistence mechanism.

Wanted to open this now and get some feedback. In the next PR, I'll probably implement writing to refs while also writing to the JSON database. After that, the annoying change of having to plumb the database through everywhere.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
