### PR TITLE
feat: Delete the merged branches in stack sync

### DIFF
--- a/internal/actions/msg.go
+++ b/internal/actions/msg.go
@@ -13,7 +13,7 @@ import (
 func msgRebaseResult(rebase *git.RebaseResult) {
 	switch rebase.Status {
 	case git.RebaseAlreadyUpToDate:
-		_, _ = fmt.Fprint(os.Stderr, "  - already up to date\n")
+		_, _ = fmt.Fprint(os.Stderr, "  - already up-to-date\n")
 	case git.RebaseUpdated:
 		_, _ = fmt.Fprint(os.Stderr, "  - ", colors.Success("rebased without conflicts"), "\n")
 	case git.RebaseConflict:


### PR DESCRIPTION
This is a relatively large change. Previously, av stack sync didn't touch the
already merged branches. This changes this behavior and it always rebases the
merged branches. After the rebase, if it's sure that the changes are fully
merged (no leftovers that haven't merged yet), it automatically deletes the
branch and the child branches are reparented.

This addresses https://github.com/aviator-co/av/issues/78.




<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
