### PR TITLE
feat: Add --skip option to av stack sync

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -67,6 +67,8 @@ var stackSyncFlags struct {
 	Continue bool
 	// If set, abort an in-progress sync operation.
 	Abort bool
+	// If set, skip a commit and continue a previous sync.
+	Skip bool
 }
 
 var stackSyncCmd = &cobra.Command{
@@ -90,8 +92,8 @@ base branch.
 `),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Argument validation
-		if stackSyncFlags.Continue && stackSyncFlags.Abort {
-			return errors.New("cannot use --continue and --abort together")
+		if countBools(stackSyncFlags.Continue, stackSyncFlags.Abort, stackSyncFlags.Skip) > 1 {
+			return errors.New("cannot use --continue, --abort, and --skip together")
 		}
 		if stackSyncFlags.Current && stackSyncFlags.Trunk {
 			return errors.New("cannot use --current and --trunk together")
@@ -114,7 +116,7 @@ base branch.
 		defer tx.Abort()
 
 		// Read any preexisting state.
-		// This is required to allow us to handle --continue/--abort
+		// This is required to allow us to handle --continue/--abort/--skip
 		state, err := readStackSyncState(repo)
 		if err != nil && !os.IsNotExist(err) {
 			return err
@@ -145,21 +147,24 @@ base branch.
 			return nil
 		}
 
-		// Make sure all changes are staged
-		diff, err := repo.Diff(&git.DiffOpts{Quiet: true})
-		if err != nil {
-			return err
-		}
-		if !diff.Empty {
-			return errors.New("refusing to sync: there are unstaged changes in the working tree (use `git add` to stage changes)")
+		if !stackSyncFlags.Skip {
+			// Make sure all changes are staged unless --skip. git rebase --skip will
+			// clean up the changes.
+			diff, err := repo.Diff(&git.DiffOpts{Quiet: true})
+			if err != nil {
+				return err
+			}
+			if !diff.Empty {
+				return errors.New("refusing to sync: there are unstaged changes in the working tree (use `git add` to stage changes)")
+			}
 		}
 
-		if stackSyncFlags.Continue {
+		if stackSyncFlags.Continue || stackSyncFlags.Skip {
 			if state.CurrentBranch == "" {
 				return errors.New("no sync in progress")
 			}
 		} else {
-			// Not a --continue, we're trying to start a new sync from scratch.
+			// Not a --continue/--skip, we're trying to start a new sync from scratch.
 			if state.CurrentBranch != "" {
 				return errors.New("a sync is already in progress: use --continue or --abort")
 			}
@@ -201,8 +206,8 @@ base branch.
 				NewParent:      state.Config.Parent,
 				NewParentTrunk: state.Config.Parent == defaultBranch,
 			}
-			if stackSyncFlags.Continue {
-				res, err = actions.ReparentContinue(repo, tx, opts)
+			if stackSyncFlags.Continue || stackSyncFlags.Skip {
+				res, err = actions.ReparentSkipContinue(repo, tx, opts, stackSyncFlags.Skip)
 			} else {
 				res, err = actions.Reparent(repo, tx, opts)
 			}
@@ -295,6 +300,7 @@ base branch.
 				Push:         !state.Config.NoPush,
 				Continuation: state.Continuation,
 				ToTrunk:      state.Config.Trunk,
+				Skip:         stackSyncFlags.Skip,
 			})
 			if err != nil {
 				return err
@@ -395,8 +401,22 @@ func init() {
 		&stackSyncFlags.Abort, "abort", false,
 		"abort an in-progress sync",
 	)
+	stackSyncCmd.Flags().BoolVar(
+		&stackSyncFlags.Skip, "skip", false,
+		"skip the current commit and continue an in-progress sync",
+	)
 	stackSyncCmd.Flags().StringVar(
 		&stackSyncFlags.Parent, "parent", "",
 		"parent branch to rebase onto",
 	)
+}
+
+func countBools(bs ...bool) int {
+	var ret int
+	for _, b := range bs {
+		if b {
+			ret += 1
+		}
+	}
+	return ret
 }

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -25,6 +25,7 @@ type SyncBranchOpts struct {
 	// If specified, synchronize the branch against the latest version of the
 	// trunk branch. This value is ignored if the branch is not a stack root.
 	ToTrunk bool
+	Skip    bool
 
 	Continuation *SyncBranchContinuation
 }
@@ -368,9 +369,13 @@ func syncBranchContinue(
 	opts SyncBranchOpts,
 	branch meta.Branch,
 ) (*SyncBranchResult, error) {
-	rebase, err := repo.RebaseParse(git.RebaseOpts{
-		Continue: true,
-	})
+	var rebaseOpts git.RebaseOpts
+	if opts.Skip {
+		rebaseOpts.Skip = true
+	} else {
+		rebaseOpts.Continue = true
+	}
+	rebase, err := repo.RebaseParse(rebaseOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -16,6 +16,8 @@ type RebaseOpts struct {
 	Continue bool
 	// Optional (mutually exclusive with all other options)
 	Abort bool
+	// Optional (mutually exclusive with all other options)
+	Skip bool
 	// Optional
 	// If set, use `git rebase --onto <upstream> ...`
 	Onto string
@@ -41,6 +43,10 @@ func (r *Repo) Rebase(opts RebaseOpts) (*Output, error) {
 	} else if opts.Abort {
 		return r.Run(&RunOpts{
 			Args: []string{"rebase", "--abort"},
+		})
+	} else if opts.Skip {
+		return r.Run(&RunOpts{
+			Args: []string{"rebase", "--skip"},
 		})
 	}
 	if opts.Onto != "" {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
