### PR TITLE
refactor: Address golangci issues and introduce goimports

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,8 +3,9 @@ linters:
     - exhaustive
     - importas
     - gofmt
+    - goimports
     - gosec
-    - structcheck
+    - unused
     - tagliatelle
     - wastedassign
 

--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -65,7 +65,7 @@ Examples:
 		body := prCreateFlags.Body
 		// Special case: ready body from stdin
 		if prCreateFlags.Body == "-" {
-			bodyBytes, err := ioutil.ReadAll(os.Stdin)
+			bodyBytes, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return errors.Wrap(err, "failed to read body from stdin")
 			}

--- a/cmd/av/stack_reparent.go
+++ b/cmd/av/stack_reparent.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var stackReparentCmd = &cobra.Command{

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/exp/slices"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -20,6 +18,7 @@ import (
 	"github.com/kr/text"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
 )
 
 // stackSyncConfig contains the configuration for a sync operation.
@@ -332,7 +331,7 @@ const stackSyncStateFile = "stack-sync.state.json"
 
 func readStackSyncState(repo *git.Repo) (stackSyncState, error) {
 	var state stackSyncState
-	data, err := ioutil.ReadFile(path.Join(repo.GitDir(), "av", stackSyncStateFile))
+	data, err := os.ReadFile(path.Join(repo.GitDir(), "av", stackSyncStateFile))
 	if err != nil {
 		return state, err
 	}
@@ -367,7 +366,7 @@ func writeStackSyncState(repo *git.Repo, state *stackSyncState) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path.Join(avDir, stackSyncStateFile), data, 0644)
+	return os.WriteFile(path.Join(avDir, stackSyncStateFile), data, 0644)
 }
 
 func init() {

--- a/cmd/av/version.go
+++ b/cmd/av/version.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/aviator-co/av/internal/config"
 	"github.com/spf13/cobra"
 )

--- a/e2e_tests/av.go
+++ b/e2e_tests/av.go
@@ -2,15 +2,16 @@ package e2e_tests
 
 import (
 	"bytes"
-	"emperror.dev/errors"
 	"fmt"
-	"github.com/kr/text"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"emperror.dev/errors"
+	"github.com/kr/text"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 var avCmdPath string

--- a/e2e_tests/helpers.go
+++ b/e2e_tests/helpers.go
@@ -1,9 +1,10 @@
 package e2e_tests
 
 import (
+	"testing"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func RequireCurrentBranchName(t *testing.T, repo *git.Repo, name string) {

--- a/e2e_tests/stack_branch_test.go
+++ b/e2e_tests/stack_branch_test.go
@@ -1,10 +1,11 @@
 package e2e_tests
 
 import (
+	"testing"
+
 	"github.com/aviator-co/av/internal/git/gittest"
 	"github.com/aviator-co/av/internal/meta/jsonfiledb"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestStackBranchMove(t *testing.T) {

--- a/e2e_tests/stack_reparent_test.go
+++ b/e2e_tests/stack_reparent_test.go
@@ -1,10 +1,11 @@
 package e2e_tests
 
 import (
+	"os"
+	"testing"
+
 	"github.com/aviator-co/av/internal/git/gittest"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"testing"
 )
 
 func TestStackSyncReparent(t *testing.T) {
@@ -42,7 +43,7 @@ func TestStackSyncReparent(t *testing.T) {
 }
 
 func requireFileContent(t *testing.T, file string, expected string, args ...any) {
-	actual, err := ioutil.ReadFile(file)
+	actual, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/e2e_tests/stack_sync_amend_test.go
+++ b/e2e_tests/stack_sync_amend_test.go
@@ -1,10 +1,11 @@
 package e2e_tests
 
 import (
-	"github.com/aviator-co/av/internal/git/gittest"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSyncAfterAmendingCommit(t *testing.T) {

--- a/e2e_tests/stack_sync_merge_commit_test.go
+++ b/e2e_tests/stack_sync_merge_commit_test.go
@@ -1,11 +1,12 @@
 package e2e_tests
 
 import (
+	"testing"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/git/gittest"
 	"github.com/aviator-co/av/internal/meta/jsonfiledb"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestStackSyncMergeCommit(t *testing.T) {

--- a/e2e_tests/stack_sync_test.go
+++ b/e2e_tests/stack_sync_test.go
@@ -1,15 +1,15 @@
 package e2e_tests
 
 import (
-	"github.com/aviator-co/av/internal/git"
-	"github.com/aviator-co/av/internal/git/gittest"
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"regexp"
 	"testing"
+
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHelp(t *testing.T) {
@@ -93,7 +93,7 @@ func TestStackSync(t *testing.T) {
 		"stack sync --continue should return non-zero exit code if conflicts have not been resolved",
 	)
 	// resolve the conflict
-	err := ioutil.WriteFile(filepath.Join(repo.Dir(), "my-file"), []byte("1a\n1b\n2a\n"), 0644)
+	err := os.WriteFile(filepath.Join(repo.Dir(), "my-file"), []byte("1a\n1b\n2a\n"), 0644)
 	require.NoError(t, err)
 	_, err = repo.Git("add", "my-file")
 	require.NoError(t, err, "failed to stage file")

--- a/internal/actions/msg.go
+++ b/internal/actions/msg.go
@@ -2,11 +2,12 @@ package actions
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/kr/text"
-	"os"
-	"strings"
 )
 
 func msgRebaseResult(rebase *git.RebaseResult) {

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -2,10 +2,11 @@ package actions_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/aviator-co/av/internal/actions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestReadPRMetadata(t *testing.T) {

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -19,9 +19,9 @@ import (
 )
 
 type SyncBranchOpts struct {
-	Branch  string
-	Fetch bool
-	Push  bool
+	Branch string
+	Fetch  bool
+	Push   bool
 	// If specified, synchronize the branch against the latest version of the
 	// trunk branch. This value is ignored if the branch is not a stack root.
 	ToTrunk bool
@@ -80,7 +80,6 @@ func SyncBranch(
 				_, _ = fmt.Fprint(os.Stderr, colors.Failure("      - error: ", err.Error()), "\n")
 				return nil, errors.Wrap(err, "failed to fetch latest PR info")
 			}
-			branch = update.Branch
 			pull = update.Pull
 			if update.Changed {
 				_, _ = fmt.Fprint(os.Stderr, "      - found updated pull request: ", colors.UserInput(update.Pull.Permalink), "\n")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"os"
+
 	"emperror.dev/errors"
 	"github.com/spf13/viper"
-	"os"
 )
 
 type GitHub struct {

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -28,7 +27,7 @@ func FetchLatestVersion() (string, error) {
 	stat, _ := os.Stat(cacheFile)
 
 	if stat != nil && time.Since(stat.ModTime()) <= (24*time.Hour) {
-		data, err := ioutil.ReadFile(cacheFile)
+		data, err := os.ReadFile(cacheFile)
 		if err != nil {
 			return "", err
 		}
@@ -55,7 +54,7 @@ func FetchLatestVersion() (string, error) {
 		return "", err
 	}
 
-	if err := ioutil.WriteFile(cacheFile, []byte(data.Name), os.ModePerm); err != nil {
+	if err := os.WriteFile(cacheFile, []byte(data.Name), os.ModePerm); err != nil {
 		return "", err
 	}
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -3,13 +3,14 @@ package editor
 import (
 	"bufio"
 	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/kballard/go-shellquote"
 	"github.com/sirupsen/logrus"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 type Config struct {

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -1,8 +1,9 @@
 package editor
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestEditor(t *testing.T) {

--- a/internal/gh/client.go
+++ b/internal/gh/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -108,7 +108,7 @@ func (c *Client) restPost(ctx context.Context, endpoint string, body interface{}
 	}
 	defer res.Body.Close()
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return errors.Wrap(err, "failed to read response body")
 	}

--- a/internal/gh/repository.go
+++ b/internal/gh/repository.go
@@ -2,9 +2,10 @@ package gh
 
 import (
 	"context"
+	"strings"
+
 	"emperror.dev/errors"
 	"github.com/shurcooL/githubv4"
-	"strings"
 )
 
 type Repository struct {

--- a/internal/git/catfile.go
+++ b/internal/git/catfile.go
@@ -2,9 +2,10 @@ package git
 
 import (
 	"bytes"
-	"emperror.dev/errors"
 	"fmt"
 	"io"
+
+	"emperror.dev/errors"
 )
 
 type GetRefs struct {

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,8 +1,9 @@
 package git
 
 import (
-	"emperror.dev/errors"
 	"os/exec"
+
+	"emperror.dev/errors"
 )
 
 type DiffOpts struct {

--- a/internal/git/err.go
+++ b/internal/git/err.go
@@ -1,9 +1,10 @@
 package git
 
 import (
-	"emperror.dev/errors"
 	"os/exec"
 	"strings"
+
+	"emperror.dev/errors"
 )
 
 func StderrMatches(err error, target string) bool {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,9 +1,10 @@
 package git_test
 
 import (
+	"testing"
+
 	"github.com/aviator-co/av/internal/git/gittest"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestOrigin(t *testing.T) {

--- a/internal/git/gittest/checkout.go
+++ b/internal/git/gittest/checkout.go
@@ -1,9 +1,10 @@
 package gittest
 
 import (
+	"testing"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func CheckoutBranch(t *testing.T, repo *git.Repo, branch string) string {

--- a/internal/git/gittest/commit.go
+++ b/internal/git/gittest/commit.go
@@ -2,11 +2,12 @@ package gittest
 
 import (
 	"fmt"
-	"github.com/aviator-co/av/internal/git"
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
+
+	"github.com/aviator-co/av/internal/git"
+	"github.com/stretchr/testify/require"
 )
 
 type commitFileOpts struct {
@@ -28,16 +29,16 @@ func WithAmend() CommitFileOpt {
 	}
 }
 
-func CommitFile(t *testing.T, repo *git.Repo, filename string, body []byte, os ...CommitFileOpt) {
+func CommitFile(t *testing.T, repo *git.Repo, filename string, body []byte, cfOpts ...CommitFileOpt) {
 	opts := commitFileOpts{
 		msg: fmt.Sprintf("Write %s", filename),
 	}
-	for _, o := range os {
+	for _, o := range cfOpts {
 		o(&opts)
 	}
 
 	filepath := path.Join(repo.Dir(), filename)
-	err := ioutil.WriteFile(filepath, body, 0644)
+	err := os.WriteFile(filepath, body, 0644)
 	require.NoError(t, err, "failed to write file: %s", filename)
 
 	_, err = repo.Git("add", filepath)

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -1,15 +1,15 @@
 package gittest
 
 import (
+	"os"
+	"os/exec"
+	"testing"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/meta/jsonfiledb"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"testing"
 )
 
 func init() {
@@ -48,7 +48,7 @@ func NewTempRepo(t *testing.T) *git.Repo {
 	_, err = repo.Git("remote", "add", "origin", "git@github.com:aviator-co/nonexistent-repo.git", "--master=main")
 	require.NoError(t, err, "failed to set remote")
 
-	err = ioutil.WriteFile(dir+"/README.md", []byte("# Hello World"), 0644)
+	err = os.WriteFile(dir+"/README.md", []byte("# Hello World"), 0644)
 	require.NoError(t, err, "failed to write README.md")
 
 	_, err = repo.Git("add", "README.md")

--- a/internal/git/listrefs.go
+++ b/internal/git/listrefs.go
@@ -1,8 +1,9 @@
 package git
 
 import (
-	"emperror.dev/errors"
 	"strings"
+
+	"emperror.dev/errors"
 )
 
 type ListRefs struct {

--- a/internal/git/listrefs_test.go
+++ b/internal/git/listrefs_test.go
@@ -1,11 +1,12 @@
 package git_test
 
 import (
+	"testing"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/git/gittest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestRepo_ListRefs(t *testing.T) {

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -1,9 +1,10 @@
 package git
 
 import (
-	"github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 type RebaseOpts struct {

--- a/internal/git/show.go
+++ b/internal/git/show.go
@@ -2,9 +2,10 @@ package git
 
 import (
 	"bytes"
+	"strings"
+
 	"emperror.dev/errors"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 type CommitInfoOpts struct {
@@ -21,7 +22,7 @@ type CommitInfo struct {
 func (c CommitInfo) BodyWithPrefix(prefix string) []string {
 	var lines []string
 	for _, line := range strings.Split(strings.TrimSpace(c.Body), "\n") {
-		lines = append(lines, prefix + line)
+		lines = append(lines, prefix+line)
 	}
 	return lines
 }

--- a/internal/stacks/sync.go
+++ b/internal/stacks/sync.go
@@ -1,10 +1,11 @@
 package stacks
 
 import (
-	"emperror.dev/errors"
 	"fmt"
-	"github.com/aviator-co/av/internal/git"
 	"strings"
+
+	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/git"
 )
 
 type SyncStatus int

--- a/internal/stacks/sync_test.go
+++ b/internal/stacks/sync_test.go
@@ -1,13 +1,14 @@
 package stacks_test
 
 import (
+	"os"
+	"path"
+	"testing"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/git/gittest"
 	"github.com/aviator-co/av/internal/stacks"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"path"
-	"testing"
 )
 
 func TestSyncBranch_NoConflicts(t *testing.T) {
@@ -44,7 +45,7 @@ func TestSyncBranch_NoConflicts(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, stacks.SyncUpdated, res.Status)
 
-		data, err := ioutil.ReadFile(path.Join(repo.Dir(), "file1.txt"))
+		data, err := os.ReadFile(path.Join(repo.Dir(), "file1.txt"))
 		require.NoError(t, err)
 		require.Equal(t, "file1 updated", string(data), "file1 should have been updated after stack sync")
 	}

--- a/internal/utils/cleanup/cleanup_test.go
+++ b/internal/utils/cleanup/cleanup_test.go
@@ -1,8 +1,9 @@
 package cleanup_test
 
 import (
-	"github.com/aviator-co/av/internal/utils/cleanup"
 	"testing"
+
+	"github.com/aviator-co/av/internal/utils/cleanup"
 )
 
 func TestCleanup(t *testing.T) {

--- a/internal/utils/ghutils/ghutils.go
+++ b/internal/utils/ghutils/ghutils.go
@@ -1,9 +1,10 @@
 package ghutils
 
 import (
-	"github.com/aviator-co/av/internal/git"
 	"os"
 	"path"
+
+	"github.com/aviator-co/av/internal/git"
 )
 
 func HasCodeowners(repo *git.Repo) bool {

--- a/internal/utils/stringutils/removelines_test.go
+++ b/internal/utils/stringutils/removelines_test.go
@@ -1,9 +1,10 @@
 package stringutils_test
 
 import (
+	"testing"
+
 	"github.com/aviator-co/av/internal/utils/stringutils"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestRemoveLines(t *testing.T) {


### PR DESCRIPTION
* Address io/ioutil deprecation. Replace it with os and io equivalents.
* Add goimports as import statements flips occasionally
* Replace deprecated structcheck with unused
* Run gofmt for all

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
