### PR TITLE
feat: Use remote tracking branch if it's trunk

### DIFF
--- a/e2e_tests/stack_reparent_test.go
+++ b/e2e_tests/stack_reparent_test.go
@@ -42,6 +42,22 @@ func TestStackSyncReparent(t *testing.T) {
 	Cmd(t, "git", "log")
 }
 
+func TestStackSyncReparentTrunk(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.Dir())
+
+	RequireAv(t, "stack", "branch", "foo")
+	gittest.CommitFile(t, repo, "foo.txt", []byte("foo"))
+
+	RequireAv(t, "stack", "branch", "bar")
+	gittest.CommitFile(t, repo, "bar.txt", []byte("bar"))
+
+	// Delete the local main. av should use the remote tracking branch.
+	Cmd(t, "git", "branch", "-D", "main")
+
+	RequireAv(t, "stack", "sync", "--parent", "main", "--no-fetch", "--no-push")
+}
+
 func requireFileContent(t *testing.T, file string, expected string, args ...any) {
 	actual, err := os.ReadFile(file)
 	if err != nil {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
