### PR TITLE
fix: Correct case of JSON meta serialization

### DIFF
--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -81,7 +81,7 @@ type PullRequest struct {
 	// The web URL for the pull request.
 	Permalink string `json:"permalink"`
 	// The state of the pull request (open, closed, or merged).
-	State githubv4.PullRequestState
+	State githubv4.PullRequestState `json:"state"`
 }
 
 // GetNumber returns the number of the pull request or zero if the PullRequest is nil.


### PR DESCRIPTION
For consistency, serialize `pullRequest.state` rather than `pullRequest.State`.

This isn't backwards incompatible because when JSON is unmarshalled, it's unmarshaled in a case insensitive way.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"","parentHead":"","trunk":""}
```
-->
