### PR TITLE
fix: Update recorded parent's HEAD after rebase

### DIFF
--- a/e2e_tests/helpers.go
+++ b/e2e_tests/helpers.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/meta/jsonfiledb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,4 +13,12 @@ func RequireCurrentBranchName(t *testing.T, repo *git.Repo, name string) {
 	currentBranch, err := repo.CurrentBranchName()
 	require.NoError(t, err, "failed to determine current branch name")
 	require.Equal(t, name, currentBranch, "expected current branch to be %q, got %q", name, currentBranch)
+}
+
+func GetStoredParentBranchState(t *testing.T, repo *git.Repo, name string) meta.BranchState {
+	// We shouldn't do this as part of an E2E test, but it's hard to ensure otherwise.
+	db, err := jsonfiledb.OpenRepo(repo)
+	require.NoError(t, err, "failed to open repo db")
+	br, _ := db.ReadTx().Branch(name)
+	return br.Parent
 }

--- a/e2e_tests/stack_sync_test.go
+++ b/e2e_tests/stack_sync_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta"
 	"github.com/stretchr/testify/require"
 )
 
@@ -126,6 +127,25 @@ func TestStackSync(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 4, len(revs))
+
+	stack1Commit, err := repo.RevParse(&git.RevParse{Rev: "stack-1"})
+	require.NoError(t, err)
+
+	stack2Commit, err := repo.RevParse(&git.RevParse{Rev: "stack-2"})
+	require.NoError(t, err)
+
+	require.Equal(t, meta.BranchState{
+		Name:  "main",
+		Trunk: true,
+	}, GetStoredParentBranchState(t, repo, "stack-1"))
+	require.Equal(t, meta.BranchState{
+		Name: "stack-1",
+		Head: stack1Commit,
+	}, GetStoredParentBranchState(t, repo, "stack-2"))
+	require.Equal(t, meta.BranchState{
+		Name: "stack-2",
+		Head: stack2Commit,
+	}, GetStoredParentBranchState(t, repo, "stack-3"))
 }
 
 func TestStackSyncAbort(t *testing.T) {

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -359,6 +359,10 @@ func syncBranchRebase(
 	}
 	msgRebaseResult(rebase)
 
+	branch.Parent = parentState
+	branch.Parent.Head = parentHead
+	tx.SetBranch(branch)
+
 	//nolint:exhaustive
 	switch rebase.Status {
 	case git.RebaseConflict:


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
