### PR TITLE
fix: Set the parent when creating a PR

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -176,6 +176,7 @@ func CreatePullRequest(
 			Name:  defaultBranch,
 			Trunk: true,
 		}
+		branchMeta.Parent = parentState
 	}
 	prCompareRef := parentState.Name
 	var parentMeta meta.Branch


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
