### PR TITLE
fix: Fix av CLI not re-parenting children

### DIFF
--- a/e2e_tests/stack_sync_merge_commit_test.go
+++ b/e2e_tests/stack_sync_merge_commit_test.go
@@ -1,6 +1,8 @@
 package e2e_tests
 
 import (
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/aviator-co/av/internal/git"
@@ -17,28 +19,32 @@ func TestStackSyncMergeCommit(t *testing.T) {
 	// Our stack looks like:
 	//     stack-1: main -> 1a -> 2b
 	//     stack-2:                \ -> 2a -> 2b
+	//     stack-3:			                   \ -> 3a -> 3b
 	require.Equal(t, 0, Cmd(t, "git", "checkout", "-b", "stack-1").ExitCode)
 	gittest.CommitFile(t, repo, "my-file", []byte("1a\n"), gittest.WithMessage("Commit 1a"))
 	gittest.CommitFile(t, repo, "my-file", []byte("1a\n1b\n"), gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")
 	gittest.CommitFile(t, repo, "my-file", []byte("1a\n1b\n2a\n"), gittest.WithMessage("Commit 2a"))
 	gittest.CommitFile(t, repo, "my-file", []byte("1a\n1b\n2a\n2b\n"), gittest.WithMessage("Commit 2b"))
+	RequireAv(t, "stack", "branch", "stack-3")
+	gittest.CommitFile(t, repo, "my-file", []byte("1a\n1b\n2a\n2b\n3a\n"), gittest.WithMessage("Commit 3a"))
+	gittest.CommitFile(t, repo, "my-file", []byte("1a\n1b\n2a\n2b\n3a\n3b\n"), gittest.WithMessage("Commit 3b"))
 
 	// Everything up to date now, so this should be a no-op.
 	require.Equal(t, 0, Av(t, "stack", "sync", "--no-fetch", "--no-push").ExitCode)
 
 	// We simulate a merge here so that our history looks like:
-	//     main:    X            / -> 1S
-	//     stack-1:  \ -> 1a -> 2b
+	//     main:    X                         / -> 1S
+	//     stack-1:  \ -> 1a -> 2b           /
 	//     stack-2:              \ -> 2a -> 2b
-	// where 1S is the squash-merge commit of 2b onto main. Note that since it's
-	// a squash commit, 1S is not a *merge commit* in the Git definition.
+	// where 2S is the squash-merge commit of 2b onto main. Note that since it's
+	// a squash commit, 2S is not a *merge commit* in the Git definition.
 	var squashCommit string
 	gittest.WithCheckoutBranch(t, repo, "main", func() {
 		oldHead, err := repo.RevParse(&git.RevParse{Rev: "HEAD"})
 		require.NoError(t, err, "failed to get HEAD")
 
-		RequireCmd(t, "git", "merge", "--squash", "stack-1")
+		RequireCmd(t, "git", "merge", "--squash", "stack-2")
 		// `git merge --squash` doesn't actually create the commit, so we have to
 		// do that separately.
 		RequireCmd(t, "git", "commit", "--no-edit")
@@ -54,24 +60,32 @@ func TestStackSyncMergeCommit(t *testing.T) {
 	db, err := jsonfiledb.OpenRepo(repo)
 	require.NoError(t, err, "failed to open repo db")
 	tx := db.WriteTx()
-	stack1Meta, _ := tx.Branch("stack-1")
-	stack1Meta.MergeCommit = squashCommit
-	tx.SetBranch(stack1Meta)
+	stack2Meta, _ := tx.Branch("stack-2")
+	stack2Meta.MergeCommit = squashCommit
+	tx.SetBranch(stack2Meta)
 	require.NoError(t, tx.Commit())
 
 	require.Equal(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", "stack-1", "stack-2").ExitCode,
+		Cmd(t, "git", "merge-base", "--is-ancestor", "stack-2", "stack-3").ExitCode,
 		"HEAD of stack-1 should be an ancestor of HEAD of stack-2 before running sync",
 	)
 	require.NotEqual(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", squashCommit, "stack-2").ExitCode,
+		Cmd(t, "git", "merge-base", "--is-ancestor", squashCommit, "stack-3").ExitCode,
 		"squash commit of stack-1 should not be an ancestor of HEAD of stack-1 before running sync",
 	)
 
 	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
 
-	require.Equal(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", squashCommit, "stack-2").ExitCode,
-		"squash commit of stack-1 should be an ancestor of HEAD of stack-1 after running sync",
+	assert.Equal(t, 0,
+		Cmd(t, "git", "merge-base", "--is-ancestor", squashCommit, "stack-3").ExitCode,
+		"squash commit of stack-2 should be an ancestor of HEAD of stack-3 after running sync",
+	)
+	assert.Equal(t,
+		meta.BranchState{
+			Name:  "main",
+			Trunk: true,
+		},
+		GetStoredParentBranchState(t, repo, "stack-3"),
+		"stack-3 should be re-rooted onto main",
 	)
 }


### PR DESCRIPTION
I think this bug was introduced in #103. I see how it happened and it suggests to me that the code is a little bit hard to follow at the moment. There's room to clean it up so that bugs like this don't reoccur. I don't think the version of `av` with this bug present has been released.

The test I added fails without this change (and I noticed this issue locally).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
