### PR TITLE
fix: Fetch latest remote state before av stack sync

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -287,6 +287,7 @@ base branch.
 			// the remote branches are up-to-date.
 			// Since `git fetch` doesn't actually update any local refs (it
 			// only updates the origin/** refs), it should be safe to do.
+			_, _ = fmt.Fprint(os.Stderr, "Fetching latest git refs from origin...\n")
 			if _, err := repo.Git("fetch", "origin"); err != nil {
 				return errors.WrapIff(err, "failed to fetch latest git refs from origin")
 			}

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -280,10 +280,20 @@ base branch.
 			branchesToSync = append(branchesToSync, nextBranches...)
 			state.Branches = branchesToSync
 		}
-		// Either way (--continue or not), we sync all subsequent branches
 
+		if !stackSyncFlags.NoFetch {
+			// Fetch the latest Git information from the origin.
+			// This is important to make sure that we can tell whether or not
+			// the remote branches are up-to-date.
+			// Since `git fetch` doesn't actually update any local refs (it
+			// only updates the origin/** refs), it should be safe to do.
+			if _, err := repo.Git("fetch", "origin"); err != nil {
+				return errors.WrapIff(err, "failed to fetch latest git refs from origin")
+			}
+		}
+
+		// Either way (--continue or not), we sync all subsequent branches
 		logrus.WithField("branches", branchesToSync).Debug("determined branches to sync")
-		//var resErr error
 		client, err := getClient(config.Av.GitHub.Token)
 		if err != nil {
 			return err

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -67,7 +67,6 @@ func (b *Branch) UnmarshalJSON(bytes []byte) error {
 		return err
 	}
 
-	logrus.Debugf("parsed branch metadata: %s => %#+v %#+v", bytes, d, b)
 	return nil
 }
 


### PR DESCRIPTION
This fixes a bug where we wouldn't always push when we should if we don't have up-to-date information about the state of the remote. We don't always push since each `git push` can take a few seconds and doing it for every single branch in a stack during an `av stack sync` would take too long.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
