### PR TITLE
refactor: Return a continuation directly

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -294,7 +294,7 @@ base branch.
 				_, _ = fmt.Fprint(os.Stderr, "\n\n")
 			}
 			state.CurrentBranch = currentBranch
-			res, err := actions.SyncBranch(ctx, repo, client, tx, actions.SyncBranchOpts{
+			cont, err := actions.SyncBranch(ctx, repo, client, tx, actions.SyncBranchOpts{
 				Branch:       currentBranch,
 				Fetch:        !state.Config.NoFetch,
 				Push:         !state.Config.NoPush,
@@ -305,8 +305,8 @@ base branch.
 			if err != nil {
 				return err
 			}
-			if res.Status == git.RebaseConflict {
-				state.Continuation = res.Continuation
+			if cont != nil {
+				state.Continuation = cont
 				if err := writeStackSyncState(repo, &state); err != nil {
 					return errors.Wrap(err, "failed to write stack sync state")
 				}

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -446,8 +446,6 @@ type UpdatePullRequestResult struct {
 	// True if the pull request information changed (e.g., a new pull request
 	// was found or if the pull request changed state)
 	Changed bool
-	// The (updated) branch metadata.
-	Branch meta.Branch
 	// The pull request object that was returned from GitHub
 	Pull *gh.PullRequest
 }
@@ -490,7 +488,7 @@ func UpdatePullRequestState(
 			return nil, errors.New("GitHub reported no pull requests for branch but local metadata has pull request")
 		}
 
-		return &UpdatePullRequestResult{false, branch, nil}, nil
+		return &UpdatePullRequestResult{false, nil}, nil
 	}
 
 	// The latest info for the pull request that we have stored in local metadata
@@ -572,7 +570,7 @@ func UpdatePullRequestState(
 	}
 
 	tx.SetBranch(branch)
-	return &UpdatePullRequestResult{changed, branch, newPull}, nil
+	return &UpdatePullRequestResult{changed, newPull}, nil
 }
 
 type PRMetadata struct {


### PR DESCRIPTION
The rebase status is not that relevant to the callers; it only needs the
continuation. Branch is also not needed as it can be obtained from tx.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
