### PR TITLE
feat: Save PR message if creation fails

### DIFF
--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -34,7 +34,7 @@ func getRepo() (*git.Repo, error) {
 }
 
 func getDB(repo *git.Repo) (meta.DB, error) {
-	dbPath := path.Join(repo.GitDir(), "av", "av.db")
+	dbPath := path.Join(repo.AvDir(), "av.db")
 	existingStat, _ := os.Stat(dbPath)
 	db, err := jsonfiledb.OpenPath(dbPath)
 	if err != nil {

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -337,7 +337,7 @@ const stackSyncStateFile = "stack-sync.state.json"
 
 func readStackSyncState(repo *git.Repo) (stackSyncState, error) {
 	var state stackSyncState
-	data, err := os.ReadFile(path.Join(repo.GitDir(), "av", stackSyncStateFile))
+	data, err := os.ReadFile(path.Join(repo.AvDir(), stackSyncStateFile))
 	if err != nil {
 		return state, err
 	}
@@ -348,7 +348,7 @@ func readStackSyncState(repo *git.Repo) (stackSyncState, error) {
 }
 
 func writeStackSyncState(repo *git.Repo, state *stackSyncState) error {
-	avDir := path.Join(repo.GitDir(), "av")
+	avDir := repo.AvDir()
 	if _, err := os.Stat(avDir); err != nil {
 		if !os.IsNotExist(err) {
 			return err

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/aviator-co/av/internal/utils/cleanup"
 	"github.com/aviator-co/av/internal/utils/sanitize"
 	"os"
 	"path/filepath"
@@ -130,9 +129,6 @@ func CreatePullRequest(
 	if !ok {
 		return nil, ErrRepoNotInitialized
 	}
-
-	var cu cleanup.Cleanup
-	defer cu.Cleanup()
 
 	_, _ = fmt.Fprint(os.Stderr,
 		"Creating pull request for branch ", colors.UserInput(opts.BranchName), ":",

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -236,7 +236,7 @@ func CreatePullRequest(
 		}
 
 		// If a saved pull request description exists, use that.
-		saveFile := filepath.Join(os.TempDir(), fmt.Sprintf("av-pr-%s.md", sanitize.FileName(opts.BranchName)))
+		saveFile := filepath.Join(repo.AvTmpDir(), fmt.Sprintf("av-pr-%s.md", sanitize.FileName(opts.BranchName)))
 		if _, err := os.Stat(saveFile); err == nil {
 			contents, err := os.ReadFile(saveFile)
 			if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -38,6 +38,18 @@ func (r *Repo) GitDir() string {
 	return path.Join(r.repoDir, ".git")
 }
 
+func (r *Repo) AvDir() string {
+	return path.Join(r.GitDir(), "av")
+}
+
+func (r *Repo) AvTmpDir() string {
+	dir := path.Join(r.AvDir(), "tmp")
+	// Try to create the directory, but swallow the error since it will
+	// ultimately be surfaced when trying to create a file in the directory.
+	_ = os.MkdirAll(dir, 0755)
+	return dir
+}
+
 func (r *Repo) DefaultBranch() (string, error) {
 	ref, err := r.Git("symbolic-ref", "refs/remotes/origin/HEAD")
 	if err != nil {

--- a/internal/meta/jsonfiledb/db.go
+++ b/internal/meta/jsonfiledb/db.go
@@ -16,7 +16,7 @@ type DB struct {
 }
 
 func RepoPath(repo *git.Repo) string {
-	return path.Join(repo.GitDir(), "av", "av.db")
+	return path.Join(repo.AvDir(), "av.db")
 }
 
 func OpenRepo(repo *git.Repo) (*DB, error) {

--- a/internal/utils/sanitize/filename.go
+++ b/internal/utils/sanitize/filename.go
@@ -1,0 +1,24 @@
+package sanitize
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	fileNameMax = 100
+)
+
+var (
+	filenameReplacePattern = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+)
+
+func FileName(name string) string {
+	name = strings.ToLower(name)
+	name = filenameReplacePattern.ReplaceAllString(name, "-")
+	if len(name) > fileNameMax {
+		name = name[:fileNameMax]
+	}
+	name = strings.Trim(name, "-")
+	return name
+}

--- a/internal/utils/sanitize/filename_test.go
+++ b/internal/utils/sanitize/filename_test.go
@@ -1,0 +1,25 @@
+package sanitize
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFileName(t *testing.T) {
+	for _, tt := range []struct{ Input, Output string }{
+		{"", ""},
+		{"  hello    world ", "hello-world"},
+		{"hello world", "hello-world"},
+		{"hello-world", "hello-world"},
+		{"hello_world", "hello-world"},
+		{"hello-world-123", "hello-world-123"},
+		{"hello-/-world-123!!!", "hello-world-123"},
+	} {
+		name := fmt.Sprintf("%q=>%q", tt.Input, tt.Output)
+		t.Run(name, func(t *testing.T) {
+			if got := FileName(tt.Input); got != tt.Output {
+				t.Errorf("FileName() = %q, want %q", got, tt.Output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Saves the pull request description (entered via editor) to a temporary file if creating the pull request fails. It will re-use the title/description if the user tries to re-create the PR (also just logs the file path to the console in case they want that).

The most common cause of this error (in my experience) is expired auth tokens and/or the base branch of a stack having been deleted on GitHub. (we should provide a better experience for the latter but that's outside the scope of this PR)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
