### PR TITLE
fix: Import into new db format should succeed if repo not previously initalized

### DIFF
--- a/internal/meta/refmeta/import.go
+++ b/internal/meta/refmeta/import.go
@@ -1,6 +1,7 @@
 package refmeta
 
 import (
+	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/cleanup"
@@ -14,7 +15,7 @@ func Import(repo *git.Repo, db meta.DB) error {
 	defer cu.Cleanup()
 
 	repoMeta, err := ReadRepository(repo)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrRepoNotInitialized) {
 		return err
 	}
 	tx.SetRepository(repoMeta)


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
