### PR TITLE
fix: Rebuild the children after deletions

### DIFF
--- a/cmd/av/stack_tidy.go
+++ b/cmd/av/stack_tidy.go
@@ -53,7 +53,6 @@ operates on only av's internal metadata, and it won't delete the actual Git bran
 				br.Parent = newParent
 			}
 		}
-		rebuildChildren(branches)
 
 		nDeleted := 0
 		for name, br := range branches {
@@ -64,6 +63,7 @@ operates on only av's internal metadata, and it won't delete the actual Git bran
 			}
 			tx.SetBranch(*br)
 		}
+		rebuildChildren(branches)
 
 		if err := tx.Commit(); err != nil {
 			return err


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
