### PR TITLE
feat(stack branch-commit): Differentiate -a/-A flags

### DIFF
--- a/cmd/av/stack_branchcommit.go
+++ b/cmd/av/stack_branchcommit.go
@@ -42,8 +42,13 @@ var stackBranchCommitFlags struct {
 	// Name of the new branch.
 	BranchName string
 
-	// Same as `git commit --all`.
+	// Same as `git add --all`.
+	// Stages all changes, including untracked files.
 	All bool
+
+	// Same as `git commit --all`.
+	// Stage all files that have been modified and deleted, but ignore untracked files.
+	AllModified bool
 }
 
 var stackBranchCommitCmd = &cobra.Command{
@@ -159,10 +164,29 @@ var stackBranchCommitCmd = &cobra.Command{
 			tx.SetBranch(parentMeta)
 		}
 
-		commitArgs := []string{"commit"}
+		// For "--all" and "--all-modified",
+		var addArgs []string
 		if stackBranchCommitFlags.All {
-			commitArgs = append(commitArgs, "--all")
+			addArgs = append(addArgs, "--all")
+		} else if stackBranchCommitFlags.AllModified {
+			// This is meant to mirror `git commit --all` which does not add
+			// unstaged files to the index (which is different from `git add --all`).
+			addArgs = append(addArgs, "--update")
 		}
+		if len(addArgs) > 0 {
+			_, err := repo.Run(&git.RunOpts{
+				Args:      append([]string{"add"}, addArgs...),
+				ExitError: true,
+			})
+			if err != nil {
+				_, _ = fmt.Fprint(os.Stderr,
+					"\n", colors.Failure("Failed to stage files: ", err.Error()), "\n",
+				)
+				return actions.ErrExitSilently{ExitCode: 1}
+			}
+		}
+
+		commitArgs := []string{"commit"}
 		if stackBranchCommitFlags.Message != "" {
 			commitArgs = append(commitArgs, "--message", stackBranchCommitFlags.Message)
 		}
@@ -192,7 +216,10 @@ var stackBranchCommitCmd = &cobra.Command{
 func init() {
 	stackBranchCommitCmd.Flags().StringVarP(&stackBranchCommitFlags.Message, "message", "m", "", "the commit message")
 	stackBranchCommitCmd.Flags().StringVarP(&stackBranchCommitFlags.BranchName, "branch-name", "b", "", "the branch name to create (if empty, automatically generated from the message)")
-	stackBranchCommitCmd.Flags().BoolVarP(&stackBranchCommitFlags.All, "all", "a", false, "automatically stage modified files (same as git commit --all)")
+	stackBranchCommitCmd.Flags().BoolVarP(&stackBranchCommitFlags.All, "all", "A", false, "automatically stage all files")
+	stackBranchCommitCmd.Flags().BoolVarP(&stackBranchCommitFlags.AllModified, "all-modified", "a", false, "automatically stage modified and deleted files (ignore untracked files)")
+
+	stackBranchCommitCmd.MarkFlagsMutuallyExclusive("all", "all-modified")
 }
 
 func branchNameFromMessage(message string) string {

--- a/e2e_tests/stack_branchcommit_test.go
+++ b/e2e_tests/stack_branchcommit_test.go
@@ -1,0 +1,43 @@
+package e2e_tests
+
+import (
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestStackBranchCommit(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.Dir())
+
+	t.Run("FlagAll", func(t *testing.T) {
+		require.NoError(t, os.WriteFile("myfile.txt", []byte("hello\n"), 0644))
+		RequireAv(t, "stack", "branch-commit", "--all", "-m", "branch one")
+		clean, err := repo.CheckCleanWorkdir()
+		require.NoError(t, err)
+		require.True(t, clean)
+	})
+
+	t.Run("FlagAllModified", func(t *testing.T) {
+		require.NoError(t, os.WriteFile("myfile.txt", []byte("hello\nworld\n"), 0644))
+		require.NoError(t, os.WriteFile("yourfile.txt", []byte("bonjour\n"), 0644))
+		RequireAv(t, "stack", "branch-commit", "--all-modified", "-m", "branch two")
+
+		clean, err := repo.CheckCleanWorkdir()
+		require.NoError(t, err)
+		require.False(t, clean, "workdir should not be clean since yourfile.txt should not be committed")
+
+		diff, err := repo.Diff(&git.DiffOpts{
+			Quiet: true,
+			Paths: []string{"myfile.txt"},
+		})
+		require.NoError(t, err)
+		require.True(t, diff.Empty, "myfile.txt should be committed and not have a diff")
+
+		lsout, err := repo.Git("ls-files", "yourfile.txt")
+		require.NoError(t, err)
+		require.Empty(t, lsout, "yourfile.txt should not be committed")
+	})
+}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -20,6 +20,8 @@ type DiffOpts struct {
 	// If a Commit is specified, the branches will not be used.
 	Branch1 string
 	Branch2 string
+	// If specified, compare only the specified paths.
+	Paths []string
 }
 
 type Diff struct {
@@ -42,6 +44,13 @@ func (r *Repo) Diff(d *DiffOpts) (*Diff, error) {
 
 	if d.Color {
 		args = append(args, "--color=always")
+	}
+
+	// This needs to be last because everything after the `--` is interpreted
+	// as a path, not a flag.
+	if len(d.Paths) > 0 {
+		args = append(args, "--")
+		args = append(args, d.Paths...)
 	}
 	contents, err := r.Git(args...)
 	var exitError *exec.ExitError


### PR DESCRIPTION
Fixes #129.

Technically (but not practically) breaking: `--all` is now equivalent to `av stack branch-commit -A` (before it was equivalent to `-a`).