### PR TITLE
[MER-2351] Add --all option to sync all branches

### DIFF
--- a/e2e_tests/stack_sync_all_test.go
+++ b/e2e_tests/stack_sync_all_test.go
@@ -1,0 +1,44 @@
+package e2e_tests
+
+import (
+	"testing"
+
+	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackSyncAll(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.Dir())
+
+	require.Equal(t, 0, Cmd(t, "git", "switch", "main").ExitCode)
+	RequireAv(t, "stack", "branch", "stack-1")
+	gittest.CommitFile(t, repo, "my-file", []byte("1a\n"), gittest.WithMessage("Commit 1a"))
+
+	require.Equal(t, 0, Cmd(t, "git", "switch", "main").ExitCode)
+	RequireAv(t, "stack", "branch", "stack-2")
+	gittest.CommitFile(t, repo, "my-file", []byte("2a\n"), gittest.WithMessage("Commit 2a"))
+
+	require.Equal(t, 0, Cmd(t, "git", "switch", "main").ExitCode)
+	gittest.CommitFile(t, repo, "other-file", []byte("X2\n"), gittest.WithMessage("Commit X2"))
+	require.Equal(t, 0, Cmd(t, "git", "push", "origin", "main").ExitCode)
+
+	//     main:    X  -> X2
+	//     stack-1:  \ -> 1a
+	//     stack-2:  \ -> 2a
+
+	require.Equal(t, 0, Av(t, "stack", "sync", "--no-fetch", "--no-push", "--trunk", "--all").ExitCode)
+
+	//     main:    X  -> X2
+	//     stack-1:        \ -> 1a
+	//     stack-2:        \ -> 2a
+
+	require.Equal(t, 0,
+		Cmd(t, "git", "merge-base", "--is-ancestor", "main", "stack-1").ExitCode,
+		"HEAD of main should be an ancestor of HEAD of stack-1",
+	)
+	require.Equal(t, 0,
+		Cmd(t, "git", "merge-base", "--is-ancestor", "main", "stack-2").ExitCode,
+		"HEAD of main should be an ancestor of HEAD of stack-2",
+	)
+}

--- a/internal/actions/sync_stack.go
+++ b/internal/actions/sync_stack.go
@@ -46,6 +46,8 @@ type StackSyncFlags struct {
 	Abort bool
 	// If set, skip a commit and continue a previous sync.
 	Skip bool
+	// If set, synchronize all branches.
+	All bool
 }
 
 // stackSyncState is the state of an in-progress sync operation.


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
