### PR TITLE
refactor: Remove Children from BranchMeta

### DIFF
--- a/cmd/av/branchmeta.go
+++ b/cmd/av/branchmeta.go
@@ -11,9 +11,8 @@ import (
 )
 
 var branchMetaFlags struct {
-	rebuildChildren bool
-	trunk           bool
-	parent          string
+	trunk  bool
+	parent string
 }
 
 var branchMetaCmd = &cobra.Command{
@@ -48,18 +47,8 @@ var branchMetaDeleteCmd = &cobra.Command{
 		for _, branch := range args {
 			tx.DeleteBranch(branch)
 		}
-		if branchMetaFlags.rebuildChildren {
-			meta.RebuildChildren(tx)
-		}
 		return tx.Commit()
 	},
-}
-
-func init() {
-	branchMetaDeleteCmd.Flags().BoolVar(
-		&branchMetaFlags.rebuildChildren, "rebuild-children", true,
-		"rebuild children fields based on parent after modifying the branch metadata",
-	)
 }
 
 var branchMetaListCmd = &cobra.Command{
@@ -98,7 +87,6 @@ var branchMetaRebuildChildrenCmd = &cobra.Command{
 			return err
 		}
 		tx := db.WriteTx()
-		meta.RebuildChildren(tx)
 		if err := tx.Commit(); err != nil {
 			return err
 		}
@@ -144,18 +132,11 @@ var branchMetaSetCmd = &cobra.Command{
 			}
 		}
 		tx.SetBranch(br)
-		if branchMetaFlags.rebuildChildren {
-			meta.RebuildChildren(tx)
-		}
 		return tx.Commit()
 	},
 }
 
 func init() {
-	branchMetaSetCmd.Flags().BoolVar(
-		&branchMetaFlags.rebuildChildren, "rebuild-children", true,
-		"rebuild children fields based on parent after modifying the branch metadata",
-	)
 	branchMetaSetCmd.Flags().BoolVar(
 		&branchMetaFlags.trunk, "trunk", false,
 		"mark the parent branch as trunk",

--- a/cmd/av/stack_branch.go
+++ b/cmd/av/stack_branch.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/cleanup"
-	"github.com/aviator-co/av/internal/utils/sliceutils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -141,7 +140,6 @@ internal tracking metadata that defines the order of branches within a stack.`,
 					},
 				}
 			}
-			parentMeta.Children = append(parentMeta.Children, branchName)
 			logrus.WithField("meta", parentMeta).Debug("writing parent branch metadata")
 			tx.SetBranch(parentMeta)
 		}
@@ -186,23 +184,15 @@ func stackBranchMove(
 
 	currentMeta, _ := tx.Branch(oldBranch)
 	currentMeta.Name = newBranch
-	tx.DeleteBranch(oldBranch)
 	tx.SetBranch(currentMeta)
 
-	// Update the parent's reference to the child (unless the parent is a trunk
-	// which doesn't maintain references to children).
-	if !currentMeta.Parent.Trunk {
-		parentMeta, _ := tx.Branch(currentMeta.Parent.Name)
-		sliceutils.Replace(parentMeta.Children, oldBranch, newBranch)
-		tx.SetBranch(parentMeta)
-	}
-
 	// Update all child branches to refer to the correct (renamed) parent.
-	for _, child := range currentMeta.Children {
-		childMeta, _ := tx.Branch(child)
-		childMeta.Parent.Name = newBranch
-		tx.SetBranch(childMeta)
+	children := meta.Children(tx, oldBranch)
+	for _, child := range children {
+		child.Parent.Name = newBranch
+		tx.SetBranch(child)
 	}
+	tx.DeleteBranch(oldBranch)
 
 	// Finally, actually rename the branch in Git
 	if _, err := repo.Run(&git.RunOpts{

--- a/cmd/av/stack_branchcommit.go
+++ b/cmd/av/stack_branchcommit.go
@@ -155,15 +155,6 @@ var stackBranchCommitCmd = &cobra.Command{
 			},
 		})
 
-		// If this isn't a new stack root, update the parent metadata to include
-		// the new branch as a child.
-		if !isBranchFromTrunk {
-			parentMeta, _ := tx.Branch(parentBranchName)
-			parentMeta.Children = append(parentMeta.Children, branchName)
-			logrus.WithField("meta", parentMeta).Debug("writing parent branch metadata")
-			tx.SetBranch(parentMeta)
-		}
-
 		// For "--all" and "--all-modified",
 		var addArgs []string
 		if stackBranchCommitFlags.All {

--- a/cmd/av/stack_tidy.go
+++ b/cmd/av/stack_tidy.go
@@ -64,7 +64,6 @@ operates on only av's internal metadata, and it won't delete the actual Git bran
 			}
 			tx.SetBranch(*br)
 		}
-		rebuildChildren(branches)
 
 		if err := tx.Commit(); err != nil {
 			return err
@@ -107,16 +106,4 @@ func findNonDeletedParents(
 		liveParents[name] = state
 	}
 	return liveParents
-}
-
-// rebuildChildren removes Children for all branches and recreates them from Parent.
-func rebuildChildren(branches map[string]*meta.Branch) {
-	for _, br := range branches {
-		br.Children = nil
-	}
-	for name, br := range branches {
-		if parent, ok := branches[br.Parent.Name]; ok {
-			parent.Children = append(parent.Children, name)
-		}
-	}
 }

--- a/e2e_tests/stack_branch_test.go
+++ b/e2e_tests/stack_branch_test.go
@@ -1,6 +1,7 @@
 package e2e_tests
 
 import (
+	"github.com/aviator-co/av/internal/meta"
 	"testing"
 
 	"github.com/aviator-co/av/internal/git/gittest"
@@ -47,16 +48,16 @@ func TestStackBranchMove(t *testing.T) {
 	require.Equal(
 		t,
 		[]string{"deux"},
-		branches["un"].Children,
+		meta.ChildrenNames(db.ReadTx(), "un"),
 		"expected un to have children [deux]",
 	)
 	require.Equal(t, "un", branches["deux"].Parent.Name, "expected parent(deux) to be un")
 	require.Equal(
 		t,
 		[]string{"trois"},
-		branches["deux"].Children,
+		meta.ChildrenNames(db.ReadTx(), "deux"),
 		"expected deux to have children [trois]",
 	)
 	require.Equal(t, "deux", branches["trois"].Parent.Name, "expected parent(trois) to be deux")
-	require.Len(t, branches["trois"].Children, 0, "expected trois to have no children")
+	require.Len(t, meta.Children(db.ReadTx(), "trois"), 0, "expected trois to have no children")
 }

--- a/internal/actions/reparent.go
+++ b/internal/actions/reparent.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/colors"
-	"github.com/aviator-co/av/internal/utils/sliceutils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -170,7 +169,6 @@ func reparentWriteMetadata(
 	opts ReparentOpts,
 ) error {
 	branch, _ := tx.Branch(opts.Branch)
-	oldParent := branch.Parent
 
 	var parentHead string
 	if !opts.NewParentTrunk {
@@ -187,22 +185,6 @@ func reparentWriteMetadata(
 		Head:  parentHead,
 	}
 	tx.SetBranch(branch)
-
-	// Make sure to delete the reference to this branch from the old parent if
-	// necessary.
-	if !oldParent.Trunk {
-		if oldParentMeta, ok := tx.Branch(oldParent.Name); ok {
-			oldParentMeta.Children = sliceutils.DeleteElement(oldParentMeta.Children, opts.Branch)
-			tx.SetBranch(oldParentMeta)
-		}
-	}
-
-	// Add this branch as a child of the new parent (unless it's a trunk branch)
-	if !opts.NewParentTrunk {
-		newParentMeta, _ := tx.Branch(opts.NewParent)
-		newParentMeta.Children = append(newParentMeta.Children, opts.Branch)
-		tx.SetBranch(newParentMeta)
-	}
 
 	return nil
 }

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/aviator-co/av/internal/utils/ghutils"
-	"github.com/aviator-co/av/internal/utils/sliceutils"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -470,7 +469,6 @@ func syncBranchUpdateParent(
 	continuation *SyncBranchContinuation,
 ) {
 	oldParentState := branch.Parent
-	oldParent, _ := tx.Branch(branch.Parent.Name)
 	branch.Parent = meta.BranchState{
 		Name: continuation.NewParentName,
 	}
@@ -486,21 +484,6 @@ func syncBranchUpdateParent(
 			"  - this branch is now a stack root based on trunk branch ",
 			colors.UserInput(branch.Parent.Name), "\n",
 		)
-	}
-
-	if oldParent.Name != branch.Parent.Name {
-		// Remove from the old parent branches metadata
-		oldParent.Children = sliceutils.DeleteElement(oldParent.Children, branch.Name)
-		tx.SetBranch(oldParent)
-
-		if !branch.Parent.Trunk {
-			// We don't store children of the trunk branches.
-			newParent, _ := tx.Branch(branch.Parent.Name)
-			// To avoid duplicates, delete it first and append.
-			newParent.Children = sliceutils.DeleteElement(newParent.Children, branch.Name)
-			newParent.Children = append(newParent.Children, branch.Name)
-			tx.SetBranch(newParent)
-		}
 	}
 }
 

--- a/internal/actions/sync_stack.go
+++ b/internal/actions/sync_stack.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/colors"
-	"github.com/aviator-co/av/internal/utils/sliceutils"
 )
 
 // StackSyncConfig contains the configuration for a sync operation.
@@ -130,7 +129,7 @@ func SyncStack(ctx context.Context,
 			if br.MergeCommit == "" {
 				continue
 			}
-			if len(br.Children) > 0 {
+			if len(meta.Children(tx, currentBranch)) > 0 {
 				_, _ = fmt.Fprint(
 					os.Stderr,
 					"  - not deleting merged branch ",
@@ -192,14 +191,6 @@ func SyncStack(ctx context.Context,
 			}
 			// There's no children, but this can have a non-trunk parent.
 			tx.DeleteBranch(currentBranch)
-			if !br.Parent.Trunk {
-				parentBranch, _ := tx.Branch(br.Parent.Name)
-				parentBranch.Children = sliceutils.DeleteElement(
-					parentBranch.Children,
-					currentBranch,
-				)
-				tx.SetBranch(parentBranch)
-			}
 			if currentBranch == state.OriginalBranch {
 				// The original branch is deleted.
 				state.OriginalBranch = ""

--- a/internal/meta/jsonfiledb/readtx.go
+++ b/internal/meta/jsonfiledb/readtx.go
@@ -3,6 +3,7 @@ package jsonfiledb
 import (
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/maputils"
+	"golang.org/x/exp/slices"
 )
 
 type readTx struct {
@@ -25,4 +26,19 @@ func (tx *readTx) Branch(name string) (branch meta.Branch, ok bool) {
 
 func (tx *readTx) AllBranches() map[string]meta.Branch {
 	return maputils.Copy(tx.state.BranchState)
+}
+
+func (tx *readTx) Children(name string) []meta.Branch {
+	var children []meta.Branch
+	for _, branch := range tx.state.BranchState {
+		if branch.Parent.Name == name {
+			children = append(children, branch)
+		}
+	}
+
+	// Sort for deterministic output.
+	slices.SortFunc(children, func(a, b meta.Branch) bool {
+		return a.Name < b.Name
+	})
+	return children
 }


### PR DESCRIPTION
Originally, we stored the children in the `meta.Branch` struct. This resulted in a duplication of the parent/child relationship (we store the parent of each branch in `Branch.Parent` as well as the children of each branch in `Branch.Children`).

This was because we had to read Git refs for each branch to get its metadata which is expensive. Now that we store the state of the repo in-memory, it's pretty trivial to just reconstruct the branch dependency graph whenever we need it.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
