### PR TITLE
docs: Add manpage for `av stack tidy`

### DIFF
--- a/cmd/av/stack_tidy.go
+++ b/cmd/av/stack_tidy.go
@@ -15,15 +15,17 @@ import (
 
 var stackTidyCmd = &cobra.Command{
 	Use:   "tidy",
-	Short: "tidy up the branch metadata",
+	Short: "Tidy stacked branches",
 	Long: strings.TrimSpace(`
-Tidy up the branch metadata by removing the deleted / merged branches.
+Tidy stacked branches by removing deleted or merged branches.
 
-This command detects which branch is deleted or merged, and re-parent the child branches. This
-operates on only av's internal metadata, and it won't delete the actual Git branches.
-	`),
+This command detects which branches are deleted or merged and re-parents
+children of merged branches. This operates on only av's internal metadata and
+does not delete Git branches.
+`),
 	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Args:         cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		repo, err := getRepo()
 		if err != nil {
 			return err

--- a/docs/av-stack-tidy.1.md
+++ b/docs/av-stack-tidy.1.md
@@ -1,0 +1,17 @@
+# av-commit-create 1 "" av-cli "Aviator CLI User Manual"
+
+# NAME
+
+av-stack-tidy - Record changes to the repository with commits
+
+# SYNOPSIS
+
+`av stack tidy`
+
+# DESCRIPTION
+
+Tidy stacked branches by removing deleted or merged branches.
+
+This command detects which branches are deleted or merged and re-parents
+children of merged branches. This operates on only av's internal metadata and
+does not delete Git branches.

--- a/docs/av-stack-tidy.1.md
+++ b/docs/av-stack-tidy.1.md
@@ -1,4 +1,4 @@
-# av-commit-create 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-tidy 1 "" av-cli "Aviator CLI User Manual"
 
 # NAME
 


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
