### PR TITLE
docs: Add manpage for `av stack submit`

### DIFF
--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -16,13 +16,9 @@ import (
 
 var stackSubmitCmd = &cobra.Command{
 	Use:   "submit",
-	Short: "create/synchronize pull requests for the current stack",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			_ = cmd.Usage()
-			return errors.New("this command takes no arguments")
-		}
-
+	Short: "Create pull requests for every branch in the stack",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		// Get the all branches in the stack
 		repo, err := getRepo()
 		if err != nil {

--- a/docs/av-stack-submit.md
+++ b/docs/av-stack-submit.md
@@ -1,0 +1,18 @@
+# av-stack-submit 1 "" av-cli "Aviator CLI User Manual"
+
+# NAME
+
+av-stack-submit - Create pull requests for every branch in the stack
+
+# SYNOPSIS
+
+`av stack submit`
+
+# DESCRIPTION
+
+Create pull requests for every branch in the current stack. This ensures that
+every pull request has the correct base branch and includes the correct metadata
+in the pull request description.
+
+If a branch has an existing pull request, it will be modified with the correct
+base branch and metadata (if necessary).

--- a/docs/av-stack-submit.md
+++ b/docs/av-stack-submit.md
@@ -16,3 +16,7 @@ in the pull request description.
 
 If a branch has an existing pull request, it will be modified with the correct
 base branch and metadata (if necessary).
+
+# SEE ALSO
+
+`av-pr-create`(1)


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
