### PR TITLE
refactor: Fix the import lines

### DIFF
--- a/cmd/av/fetch.go
+++ b/cmd/av/fetch.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aviator-co/av/internal/actions"
-	"github.com/aviator-co/av/internal/utils/cleanup"
-
 	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/gh"
 	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/cleanup"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/fatih/color"
 	"github.com/shurcooL/githubv4"

--- a/cmd/av/init.go
+++ b/cmd/av/init.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aviator-co/av/internal/utils/cleanup"
-	"github.com/sirupsen/logrus"
-
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/cleanup"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/av/stack_branchcommit.go
+++ b/cmd/av/stack_branchcommit.go
@@ -6,13 +6,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aviator-co/av/internal/actions"
-	"github.com/aviator-co/av/internal/utils/cleanup"
-	"github.com/aviator-co/av/internal/utils/colors"
-
 	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/cleanup"
+	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -3,13 +3,12 @@ package main
 import (
 	"context"
 
-	"github.com/aviator-co/av/internal/utils/cleanup"
-
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/gh"
 	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/cleanup"
 	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 )

--- a/cmd/av/stack_tidy.go
+++ b/cmd/av/stack_tidy.go
@@ -5,11 +5,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aviator-co/av/internal/utils/colors"
-	"github.com/aviator-co/av/internal/utils/textutils"
-
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/aviator-co/av/internal/utils/textutils"
 	"github.com/spf13/cobra"
 )
 

--- a/e2e_tests/stack_branch_test.go
+++ b/e2e_tests/stack_branch_test.go
@@ -1,10 +1,10 @@
 package e2e_tests
 
 import (
-	"github.com/aviator-co/av/internal/meta"
 	"testing"
 
 	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/meta/jsonfiledb"
 	"github.com/stretchr/testify/require"
 )

--- a/e2e_tests/stack_sync_delete_merged_test.go
+++ b/e2e_tests/stack_sync_delete_merged_test.go
@@ -3,10 +3,9 @@ package e2e_tests
 import (
 	"testing"
 
-	"github.com/aviator-co/av/internal/meta"
-
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/meta/jsonfiledb"
 	"github.com/stretchr/testify/require"
 )

--- a/e2e_tests/stack_sync_delete_parent_test.go
+++ b/e2e_tests/stack_sync_delete_parent_test.go
@@ -3,11 +3,10 @@ package e2e_tests
 import (
 	"testing"
 
-	"github.com/aviator-co/av/internal/meta"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/e2e_tests/stack_sync_merge_commit_test.go
+++ b/e2e_tests/stack_sync_merge_commit_test.go
@@ -3,12 +3,11 @@ package e2e_tests
 import (
 	"testing"
 
-	"github.com/aviator-co/av/internal/meta"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/meta/jsonfiledb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/e2e_tests/stack_sync_merged_parent_test.go
+++ b/e2e_tests/stack_sync_merged_parent_test.go
@@ -3,12 +3,11 @@ package e2e_tests
 import (
 	"testing"
 
-	"github.com/aviator-co/av/internal/meta"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/meta/jsonfiledb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -10,19 +10,17 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/aviator-co/av/internal/utils/sanitize"
-
-	"github.com/aviator-co/av/internal/editor"
-	"github.com/aviator-co/av/internal/utils/stringutils"
-	"github.com/aviator-co/av/internal/utils/templateutils"
-
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/config"
+	"github.com/aviator-co/av/internal/editor"
 	"github.com/aviator-co/av/internal/gh"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/browser"
 	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/aviator-co/av/internal/utils/sanitize"
+	"github.com/aviator-co/av/internal/utils/stringutils"
+	"github.com/aviator-co/av/internal/utils/templateutils"
 	"github.com/fatih/color"
 	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -2,11 +2,11 @@ package meta
 
 import (
 	"encoding/json"
-	"golang.org/x/exp/slices"
 
 	"emperror.dev/errors"
 	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 type Branch struct {

--- a/internal/reorder/cmds.go
+++ b/internal/reorder/cmds.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/aviator-co/av/internal/meta"
-
 	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
 )
 
 // Context is the context of a reorder operation.

--- a/internal/reorder/pick_test.go
+++ b/internal/reorder/pick_test.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/aviator-co/av/internal/meta/jsonfiledb"
-
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta/jsonfiledb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/reorder/stackbranch.go
+++ b/internal/reorder/stackbranch.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
-
 	"github.com/spf13/pflag"
 )
 


### PR DESCRIPTION
Looks like there is a bug in goimports that creates multiple blocks.

There is a related bug report when used with -local, which we don't use,
but somehow observed a similar effect.
https://github.com/golang/go/issues/47440

Anyway, rerunning goimports won't split the blocks. This change keeps
the import blocks as described in
https://github.com/golang/go/wiki/CodeReviewComments#imports.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
