### PR TITLE
[MER-2417] Remove the unnecessary branch name in logging

### DIFF
--- a/internal/actions/reparent.go
+++ b/internal/actions/reparent.go
@@ -40,7 +40,6 @@ func Reparent(
 			"  - Adopting a branch ",
 			colors.UserInput(opts.Branch),
 			" to Av",
-			colors.UserInput(opts.NewParent),
 			"\n",
 		)
 		branchMeta.Parent.Name = opts.NewParent


### PR DESCRIPTION
This log looks like "Adopting a branch master to Avmaster". Make it
"Adopting a branch master to Av".

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
