### PR TITLE
[MER-1962] Support retroactively rename the branches

### DIFF
--- a/docs/av-stack-branch.1.md
+++ b/docs/av-stack-branch.1.md
@@ -13,9 +13,11 @@ av-stack-branch - Create or rename a branch in the stack
 Create a new branch that is stacked on the current branch by default
 
 If the --rename/-m flag is given, the current branch is renamed to the name
-instead of creating a new branch. Branches should only be renamed
-with this command (not with git branch -m ...) because av needs to update
-internal tracking metadata that defines the order of branches within a stack.
+instead of creating a new branch. Branches should only be renamed with this
+command (not with `git branch -m ...`) because av needs to update internal
+tracking metadata that defines the order of branches within a stack. If you
+renamed a branch with `git branch -m`, you can retroactively update the internal
+metadata with `av stack branch --rename <old-branch-name>:<new-branch-name>`.
 
 ## OPTIONS
 

--- a/e2e_tests/stack_branch_test.go
+++ b/e2e_tests/stack_branch_test.go
@@ -61,3 +61,37 @@ func TestStackBranchMove(t *testing.T) {
 	require.Equal(t, "deux", branches["trois"].Parent.Name, "expected parent(trois) to be deux")
 	require.Len(t, meta.Children(db.ReadTx(), "trois"), 0, "expected trois to have no children")
 }
+
+func TestStackBranchRetroactiveMove(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.Dir())
+
+	// Create one -> two -> three stack
+	RequireAv(t, "stack", "branch", "one")
+	gittest.CommitFile(t, repo, "one.txt", []byte("one"))
+	RequireAv(t, "stack", "branch", "two")
+	gittest.CommitFile(t, repo, "two.txt", []byte("two"))
+	RequireAv(t, "stack", "branch", "three")
+	gittest.CommitFile(t, repo, "three.txt", []byte("three"))
+
+	// one -> un without av
+	RequireCmd(t, "git", "checkout", "one")
+	RequireCmd(t, "git", "branch", "-m", "un")
+	RequireCurrentBranchName(t, repo, "un")
+
+	// Retroactive rename with av
+	RequireAv(t, "stack", "branch", "--rename", "one:un")
+
+	// Make sure we've handled all the parent/child renames correctly
+	db, err := jsonfiledb.OpenRepo(repo)
+	require.NoError(t, err, "failed to open repo db")
+	branches := db.ReadTx().AllBranches()
+	require.Equal(t, true, branches["un"].Parent.Trunk, "expected parent(un) to be a trunk")
+	require.Equal(
+		t,
+		[]string{"two"},
+		meta.ChildrenNames(db.ReadTx(), "un"),
+		"expected un to have children [two]",
+	)
+	require.NotContainsf(t, branches, "one", "expected one to be deleted from the branch metadata")
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -204,15 +204,21 @@ func (r *Repo) HasChangesToBeCommitted() (bool, error) {
 	return out.ExitCode == 1, nil
 }
 
+func (r *Repo) DoesBranchExist(branch string) (bool, error) {
+	return r.DoesRefExist(fmt.Sprintf("refs/heads/%s", branch))
+}
+
 func (r *Repo) DoesRemoteBranchExist(branch string) (bool, error) {
-	remoteBranch := fmt.Sprintf("refs/remotes/origin/%s", branch)
+	return r.DoesRefExist(fmt.Sprintf("refs/remotes/origin/%s", branch))
+}
+
+func (r *Repo) DoesRefExist(ref string) (bool, error) {
 	out, err := r.Run(&RunOpts{
-		Args: []string{"show-ref", remoteBranch},
+		Args: []string{"show-ref", ref},
 	})
 	if err != nil {
-		return false, errors.Errorf("remote branch does not exist: %v", err)
+		return false, errors.Errorf("ref %s does not exist: %v", ref, err)
 	}
-
 	if len(out.Stdout) > 0 {
 		return true, nil
 	}


### PR DESCRIPTION
When a user renames a branch with git, this allows them to retroactively
fit the Av metadata as well.












<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
