### PR TITLE
docs: Add manpage for `av stack diff`

### DIFF
--- a/docs/av-stack-diff.1.md
+++ b/docs/av-stack-diff.1.md
@@ -1,0 +1,13 @@
+# av-stack-diff 1 "" av-cli "Aviator CLI User Manual"
+
+# NAME
+
+av-stack-diff - Show the diff between working tree and parent branch. 
+
+# SYNOPSIS
+
+`av stack diff`
+
+# DESCRIPTION
+
+Generates the diff between the working tree and the parent branch (i.e., the diff between the current branch and the previous branch in the stack).


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
