### PR TITLE
[MER-2418] Make it easy to detect a PR markdown

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -284,7 +284,7 @@ func CreatePullRequest(
 
 		res, err := editor.Launch(repo, editor.Config{
 			Text:           editorText,
-			TmpFilePattern: "pr-*.md",
+			TmpFilePattern: "pr-*.av.md",
 			CommentPrefix:  "%%",
 		})
 		if err != nil {

--- a/misc/vim/ftdetect/av-markdown.vim
+++ b/misc/vim/ftdetect/av-markdown.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.av.md set filetype=av-markdown

--- a/misc/vim/ftplugin/av-markdown.vim
+++ b/misc/vim/ftplugin/av-markdown.vim
@@ -1,0 +1,14 @@
+if exists("b:did_ftplugin") | finish | endif
+let b:did_ftplugin = 1
+let s:keepcpo= &cpo
+set cpo&vim
+
+setlocal comments=b:%%
+setlocal commentstring=%%\ %s
+
+let b:undo_ftplugin = 'setlocal comments<'
+      \ . '|setlocal commentstring<'
+      \ . '|unlet! b:undo_ftplugin'
+
+let &cpo = s:keepcpo
+unlet s:keepcpo

--- a/misc/vim/syntax/av-markdown.vim
+++ b/misc/vim/syntax/av-markdown.vim
@@ -1,0 +1,20 @@
+if exists("b:current_syntax")
+  finish
+endif
+
+if !exists('main_syntax')
+  let main_syntax = 'av-markdown'
+endif
+
+runtime! syntax/markdown.vim
+unlet! b:current_syntax
+
+syn match avMarkdownComment "^\s*%%.*$" contains=avMarkdownTodo,@Spell
+syn keyword avMarkdownTodo FIXME NOTE NOTES TODO XXX contained
+
+hi def link avMarkdownComment Comment
+
+let b:current_syntax = "av-markdown"
+if main_syntax ==# 'av-markdown'
+  unlet main_syntax
+endif


### PR DESCRIPTION
This is a nice to have and a harmless change. The temp file created for
the pull-request title and body now has an extension '.av.md'. This is
anyway recognized as a markdown file for most of the editors, but this
extra 'av' extension allows us to have a special file type that supports
'%%' as a comment.

As an example, added a Vim plugin that recognize this file type and
treats '%%' as a comment.






<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
