### PR TITLE
refac: add pr.go

### DIFF
--- a/cmd/av/stack_reorder.go
+++ b/cmd/av/stack_reorder.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
-	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/actions"
+	"github.com/aviator-co/av/internal/config"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/reorder"
+	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/sirupsen/logrus"
+
 	"github.com/spf13/cobra"
 )
 
@@ -15,8 +23,8 @@ var stackReorderFlags struct {
 const stackReorderDoc = `
 Interactively reorder the stack.
 
-This is analogous to git rebase --interactive but operates on the stack (rather
-than branch) level.
+This is analogous to git rebase --interactive but operates across all branches
+in the stack.
 
 Branches can be re-arranged within the stack and commits can be edited,
 squashed, dropped, or moved within the stack.
@@ -27,8 +35,130 @@ var stackReorderCmd = &cobra.Command{
 	Short:  "reorder the stack",
 	Hidden: true,
 	Long:   strings.TrimSpace(stackReorderDoc),
+	Args:   cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.New("not implemented")
+		if config.Version != config.VersionDev {
+			logrus.Fatal("av stack reorder is not yet implemented")
+		}
+		repo, err := getRepo()
+		if err != nil {
+			return err
+		}
+		db, err := getDB(repo)
+		if err != nil {
+			return err
+		}
+
+		continuation, err := reorder.ReadContinuation(repo)
+		if os.IsNotExist(err) {
+			if stackReorderFlags.Continue || stackReorderFlags.Abort {
+				_, _ = fmt.Fprint(os.Stderr,
+					colors.Failure("ERROR: no reorder in progress\n"),
+				)
+				return actions.ErrExitSilently{ExitCode: 127}
+			}
+		} else if err != nil {
+			return err
+		}
+
+		var state *reorder.State
+		if stackReorderFlags.Abort {
+			// TODO: Handle clearing any cherry-pick state and whatnot.
+			// TODO: --abort should probably reset the state of each branch
+			//   associated with the reorder to the original. It might be worth
+			//   storing some history and allow the user to do --undo to restore
+			//   their Git state to the state before the reorder.
+			return reorder.WriteContinuation(repo, nil)
+		} else if stackReorderFlags.Continue {
+			state = continuation.State
+		} else {
+			if continuation != nil {
+				_, _ = fmt.Fprint(os.Stderr,
+					colors.Failure("ERROR: reorder already in progress\n"),
+					colors.Failure("	   use --continue or --abort to continue or abort the reorder\n"),
+				)
+				return actions.ErrExitSilently{ExitCode: 127}
+			}
+			tx := db.ReadTx()
+			currentBranch, err := repo.CurrentBranchName()
+			if err != nil {
+				return err
+			}
+			root, ok := meta.Root(tx, currentBranch)
+			if !ok {
+				_, _ = fmt.Fprint(os.Stderr,
+					colors.Failure("ERROR: branch "), colors.UserInput(currentBranch),
+					colors.Failure(" is not part of a stack\n"),
+				)
+				return actions.ErrExitSilently{ExitCode: 127}
+			}
+			plan, err := reorder.CreatePlan(repo, db.ReadTx(), root)
+			if err != nil {
+				return err
+			}
+
+			// TODO:
+			// What should we do if the plan removes branches? Currently,
+			// we just don't edit those branches. So if a user edits
+			//     sb one
+			//     pick 1a
+			//     sb two
+			//     pick 2a
+			// and deletes the line for `sb two`, then the reorder will modify
+			// one to contain 1a/2a, but we don't modify two so it'll still be
+			// considered stacked on top of one.
+			// We can probably delete the branch and also emit a message to the
+			// user to the effect of
+			//     Deleting branch `two` because it was removed from the reorder.
+			//     To restore the branch, run `git switch -C two <OLD HEAD>`.
+			// just to make sure they can recover their work. (They already would
+			// be able to using `git reflog` but generally only advanced Git
+			// users think to do that).
+			plan, err = reorder.EditPlan(repo, plan)
+			if err != nil {
+				return err
+			}
+			if len(plan) == 0 {
+				_, _ = fmt.Fprint(os.Stderr,
+					colors.Failure("ERROR: reorder plan is empty\n"),
+				)
+				return actions.ErrExitSilently{ExitCode: 127}
+			}
+
+			logrus.WithFields(logrus.Fields{
+				"plan":           plan,
+				"current_branch": currentBranch,
+				"root_branch":    root,
+			}).Debug("created reorder plan")
+			state = &reorder.State{Commands: plan}
+		}
+
+		continuation, err = reorder.Reorder(reorder.Context{
+			Repo:   repo,
+			DB:     db,
+			State:  state,
+			Output: os.Stderr,
+		})
+		if err != nil {
+			return err
+		}
+		if continuation == nil {
+			_, _ = fmt.Fprint(os.Stderr,
+				colors.Success("\nThe stack was reordered successfully.\n"),
+			)
+			return nil
+		}
+
+		if err := reorder.WriteContinuation(repo, continuation); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprint(os.Stderr,
+			colors.Warning("\nThe reorder was interrupted by a conflict.\n"),
+			colors.Warning("Resolve the conflict and run "),
+			colors.CliCmd("av stack reorder --continue"),
+			colors.Warning(" to continue.\n"),
+		)
+		return actions.ErrExitSilently{ExitCode: 1}
 	},
 }
 
@@ -37,4 +167,5 @@ func init() {
 		BoolVar(&stackReorderFlags.Continue, "continue", false, "continue a previous reorder")
 	stackReorderCmd.Flags().
 		BoolVar(&stackReorderFlags.Abort, "abort", false, "abort a previous reorder")
+	stackReorderCmd.MarkFlagsMutuallyExclusive("continue", "abort")
 }

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -8,17 +8,18 @@ import (
 
 func TestEditor(t *testing.T) {
 	type test struct {
-		name    string
-		command string
-		in      string
-		out     string
-		error   bool
+		name        string
+		command     string
+		in          string
+		out         string
+		error       bool
+		eolcomments bool
 	}
 	for _, tt := range []test{
 		{
 			name:    "with comments",
 			command: "true",
-			in:      "Hello world!\n\nBonjour le monde!\n%% This is a commend\n",
+			in:      "Hello world!\n\nBonjour le monde!\n%% This is a comment\n",
 			out:     "Hello world!\n\nBonjour le monde!\n",
 		},
 		{
@@ -33,11 +34,19 @@ func TestEditor(t *testing.T) {
 			in:      "Hello world!\n\nBonjour le monde!\n",
 			error:   true,
 		},
+		{
+			name:        "eolcomments",
+			command:     "true",
+			in:          "Hello world!  %% One\n\nBonjour le monde!  %% Two\n%% This is a comment\n",
+			out:         "Hello world!  \n\nBonjour le monde!  \n",
+			eolcomments: true,
+		},
 	} {
 		res, err := Launch(nil, Config{
-			Text:          tt.in,
-			CommentPrefix: "%%",
-			Command:       tt.command,
+			Text:              tt.in,
+			CommentPrefix:     "%%",
+			Command:           tt.command,
+			EndOfLineComments: tt.eolcomments,
 		})
 		if tt.error {
 			require.Error(t, err, "expected error while executing `%s`", tt.command)

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -65,7 +65,6 @@ func (b *Branch) UnmarshalJSON(bytes []byte) error {
 		return err
 	}
 
-	logrus.Debugf("parsed branch metadata: %s => %#+v %#+v", bytes, d, b)
 	return nil
 }
 
@@ -127,6 +126,18 @@ func SubsequentBranches(tx ReadTx, name string) []string {
 		res = append(res, SubsequentBranches(tx, child.Name)...)
 	}
 	return res
+}
+
+// Root determines the stack root of a branch.
+func Root(tx ReadTx, name string) (string, bool) {
+	for name != "" {
+		branch, _ := tx.Branch(name)
+		if branch.Parent.Trunk {
+			return name, true
+		}
+		name = branch.Parent.Name
+	}
+	return "", false
 }
 
 // Trunk determines the trunk of a branch.

--- a/internal/reorder/editor.go
+++ b/internal/reorder/editor.go
@@ -1,0 +1,49 @@
+package reorder
+
+import (
+	"strings"
+
+	"github.com/aviator-co/av/internal/editor"
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/utils/typeutils"
+)
+
+// EditPlan opens the user's editor and allows them to edit the plan.
+func EditPlan(repo *git.Repo, plan []Cmd) ([]Cmd, error) {
+	text := strings.Builder{}
+	for i, cmd := range plan {
+		if i > 0 && typeutils.Is[StackBranchCmd](cmd) {
+			// Write an extra newline at the start of each branch command
+			// (other than the first) to create a visual separation between
+			// branches.
+			text.WriteString("\n")
+		}
+		text.WriteString(cmd.String())
+		text.WriteString("\n")
+	}
+
+	res, err := editor.Launch(repo, editor.Config{
+		Text:              text.String(),
+		CommentPrefix:     "#",
+		EndOfLineComments: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var newPlan []Cmd
+	lines := strings.Split(res, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		cmd, err := ParseCmd(line)
+		if err != nil {
+			return nil, err
+		}
+		newPlan = append(newPlan, cmd)
+	}
+
+	return newPlan, nil
+}

--- a/internal/reorder/stackbranch.go
+++ b/internal/reorder/stackbranch.go
@@ -3,6 +3,8 @@ package reorder
 import (
 	"strings"
 
+	"github.com/aviator-co/av/internal/utils/colors"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/spf13/pflag"
@@ -73,6 +75,13 @@ func (b StackBranchCmd) Execute(ctx *Context) error {
 	if _, err := ctx.Repo.Git("reset", "--hard", headCommit); err != nil {
 		return err
 	}
+	ctx.Print(
+		"Starting branch ",
+		colors.UserInput(b.Name),
+		" at ",
+		colors.UserInput(git.ShortSha(headCommit)),
+		"\n",
+	)
 
 	return tx.Commit()
 }

--- a/internal/utils/typeutils/is.go
+++ b/internal/utils/typeutils/is.go
@@ -1,0 +1,6 @@
+package typeutils
+
+func Is[T any](elt any) bool {
+	_, ok := elt.(T)
+	return ok
+}


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
