### PR TITLE
feat: add av pr status

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -5,13 +5,13 @@ import (
 )
 
 var prCmd = &cobra.Command{
-	Use: "pr",
+	Use:   "pr",
 	Short: "manage pull requests",
 }
 
 func init() {
 	prCmd.AddCommand(
 		prCreateCmd,
-
+		prStatusCmd,
 	)
 }

--- a/cmd/av/pr_status.go
+++ b/cmd/av/pr_status.go
@@ -45,14 +45,7 @@ var prStatusCmd = &cobra.Command{
 						RequiredCheck struct {
 							Pattern graphql.String
 						}
-						Result    graphql.String
-						CheckRuns []struct {
-							Check struct {
-								Name graphql.String
-							}
-							Status     graphql.String
-							Conclusion graphql.String
-						}
+						Result graphql.String
 					}
 					// TODO: add BotPR info
 				} `graphql:"pullRequest(number: $prNumber)"`

--- a/cmd/av/pr_status.go
+++ b/cmd/av/pr_status.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aviator-co/av/internal/avgql"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/aviator-co/av/internal/utils/timeutils"
+	"github.com/shurcooL/githubv4"
 	"github.com/shurcooL/graphql"
 	"github.com/spf13/cobra"
 )
@@ -36,9 +37,9 @@ var prStatusCmd = &cobra.Command{
 					Author       struct {
 						Login graphql.String
 					}
-					CreatedAt             graphql.String
-					QueuedAt              graphql.String
-					MergedAt              graphql.String
+					CreatedAt             githubv4.DateTime
+					QueuedAt              githubv4.DateTime
+					MergedAt              githubv4.DateTime
 					BaseBranchName        graphql.String
 					HeadBranchName        graphql.String
 					RequiredCheckStatuses []struct {
@@ -94,7 +95,7 @@ var prStatusCmd = &cobra.Command{
 			indent,
 			"Created at: ",
 			colors.UserInput(
-				timeutils.FormatLocal(string(query.GithubRepository.PullRequest.CreatedAt)),
+				timeutils.FormatLocal(query.GithubRepository.PullRequest.CreatedAt.Time),
 			),
 			"\n",
 		)
@@ -105,7 +106,7 @@ var prStatusCmd = &cobra.Command{
 				indent,
 				"Queued at: ",
 				colors.UserInput(
-					timeutils.FormatLocal(string(query.GithubRepository.PullRequest.QueuedAt)),
+					timeutils.FormatLocal(query.GithubRepository.PullRequest.QueuedAt.Time),
 				),
 				"\n",
 			)
@@ -116,7 +117,7 @@ var prStatusCmd = &cobra.Command{
 				indent,
 				"Merged at: ",
 				colors.UserInput(
-					timeutils.FormatLocal(string(query.GithubRepository.PullRequest.MergedAt)),
+					timeutils.FormatLocal(query.GithubRepository.PullRequest.MergedAt.Time),
 				),
 				"\n",
 			)

--- a/cmd/av/pr_status.go
+++ b/cmd/av/pr_status.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/aviator-co/av/internal/avgql"
+	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/shurcooL/graphql"
+	"github.com/spf13/cobra"
+)
+
+var query struct {
+	GithubRepository struct {
+		PullRequest struct {
+			Title        graphql.String
+			Status       graphql.String
+			StatusReason graphql.String
+			Author       struct {
+				Login graphql.String
+			}
+			CreatedAt             graphql.String
+			QueuedAt              graphql.String
+			MergedAt              graphql.String
+			BaseBranchName        graphql.String
+			HeadBranchName        graphql.String
+			RequiredCheckStatuses []struct {
+				RequiredCheck struct {
+					Pattern graphql.String
+				}
+				Result    graphql.String
+				CheckRuns []struct {
+					Check struct {
+						Name graphql.String
+					}
+					Status     graphql.String
+					Conclusion graphql.String
+				}
+			}
+		} `graphql:"pullRequest(number: $prNumber)"`
+	} `graphql:"githubRepository(owner: $repoOwner, name:$repoName)"`
+}
+
+var prStatusCmd = &cobra.Command{
+	Use:          "status",
+	Short:        "check pr status",
+	SilenceUsage: true,
+	Args:         cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		variables, err := getQueryVariables()
+		if err != nil {
+			return err
+		}
+
+		client := avgql.NewClient()
+
+		err = client.Query(context.Background(), &query, variables)
+		if err != nil {
+			return err
+		}
+
+		indent := "    "
+		prStatus := query.GithubRepository.PullRequest.Status
+
+		// Print PR info
+		_, _ = fmt.Fprint(
+			os.Stderr,
+			"#162 ",
+			colors.UserInput(query.GithubRepository.PullRequest.Title),
+			"\n",
+		)
+		_, _ = fmt.Fprint(os.Stderr, indent, "Status: ", colors.UserInput(prStatus), "\n")
+
+		if prStatus == "PENDING" || prStatus == "BLOCKED" {
+			_, _ = fmt.Fprint(
+				os.Stderr,
+				indent,
+				"Status reason: ",
+				colors.UserInput(query.GithubRepository.PullRequest.StatusReason),
+				"\n",
+			)
+		}
+
+		_, _ = fmt.Fprint(
+			os.Stderr,
+			indent,
+			"Author: ",
+			colors.UserInput(query.GithubRepository.PullRequest.Author.Login),
+			"\n",
+		)
+		_, _ = fmt.Fprint(
+			os.Stderr,
+			indent,
+			"Created at: ",
+			colors.UserInput(query.GithubRepository.PullRequest.CreatedAt),
+			"\n",
+		)
+
+		if prStatus == "QUEUED" {
+			_, _ = fmt.Fprint(
+				os.Stderr,
+				indent,
+				"Queued at: ",
+				colors.UserInput(query.GithubRepository.PullRequest.QueuedAt),
+				"\n",
+			)
+		}
+		if prStatus == "MERGED" {
+			_, _ = fmt.Fprint(
+				os.Stderr,
+				indent,
+				"Merged at: ",
+				colors.UserInput(query.GithubRepository.PullRequest.MergedAt),
+				"\n",
+			)
+		}
+
+		_, _ = fmt.Fprint(
+			os.Stderr,
+			indent,
+			"Base branch: ",
+			colors.UserInput(
+				query.GithubRepository.PullRequest.BaseBranchName,
+				" <- ",
+				query.GithubRepository.PullRequest.HeadBranchName,
+			),
+			"\n\n",
+		)
+
+		// Required checks section
+		_, _ = fmt.Fprint(os.Stderr, "Required Checks\n")
+		requiredCheckStatuses := query.GithubRepository.PullRequest.RequiredCheckStatuses
+		for index := range requiredCheckStatuses {
+			result := requiredCheckStatuses[index].Result
+			requiredCheckName := requiredCheckStatuses[index].RequiredCheck.Pattern
+			_, _ = fmt.Fprint(
+				os.Stderr,
+				indent,
+				emojiForRequiredCheckResult(string(result)),
+				" ",
+				colors.UserInput(requiredCheckName),
+				"\n",
+			)
+		}
+
+		return nil
+	},
+}
+
+func getQueryVariables() (map[string]interface{}, error) {
+	repo, err := getRepo()
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := getDB(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := db.ReadTx()
+
+	currentBranchName, err := repo.CurrentBranchName()
+	if err != nil {
+		return nil, err
+	}
+
+	branch, exists := tx.Branch(currentBranchName)
+	if !exists {
+		return nil, errors.New("could not find current branch")
+	}
+
+	if branch.PullRequest == nil {
+		return nil, errors.New("pull request does not exist")
+	}
+
+	// prNumber := branch.PullRequest.Number
+	repository, _ := tx.Repository()
+	var variables = map[string]interface{}{
+		"repoOwner": graphql.String(repository.Owner),
+		"repoName":  graphql.String(repository.Name),
+		"prNumber":  graphql.Int(2897),
+	}
+	return variables, nil
+}
+
+func emojiForRequiredCheckResult(result string) string {
+	if result == "SUCCESS" {
+		return "\u2705"
+	} else if result == "FAILURE" {
+		return "\u274C"
+	} else {
+		return "\u231B"
+	}
+}

--- a/internal/utils/timeutils/timeutils.go
+++ b/internal/utils/timeutils/timeutils.go
@@ -1,0 +1,20 @@
+package timeutils
+
+import (
+	"time"
+)
+
+// FormalLocal takes a timestamp in string format (inputLayout) and converts it into a readable
+// format in the local timezome (outputLayout).
+func FormatLocal(timeString string) string {
+	inputLayout := "2006-01-02T15:04:05.999999Z07:00"
+	outputLayout := "2 January 2006 3:04:05 PM PST"
+
+	timestamp, err := time.Parse(inputLayout, timeString)
+	if err != nil {
+		return timeString
+	}
+
+	timestampDefaultTZ := timestamp.Local()
+	return timestampDefaultTZ.Format(outputLayout)
+}

--- a/internal/utils/timeutils/timeutils.go
+++ b/internal/utils/timeutils/timeutils.go
@@ -4,17 +4,9 @@ import (
 	"time"
 )
 
-// FormalLocal takes a timestamp in string format (inputLayout) and converts it into a readable
-// format in the local timezome (outputLayout).
-func FormatLocal(timeString string) string {
-	inputLayout := "2006-01-02T15:04:05.999999Z07:00"
+// FormalLocal takes a time and converts it into a readable format in the local timezome (outputLayout).
+func FormatLocal(timestamp time.Time) string {
 	outputLayout := "2 January 2006 3:04:05 PM PST"
-
-	timestamp, err := time.Parse(inputLayout, timeString)
-	if err != nil {
-		return timeString
-	}
-
-	timestampDefaultTZ := timestamp.Local()
-	return timestampDefaultTZ.Format(outputLayout)
+	timestamp = timestamp.In(time.Local)
+	return timestamp.Format(outputLayout)
 }


### PR DESCRIPTION
I'll add BotPR data in my next PR


passing checks - 
<img width="650" alt="Screen Shot 2023-06-07 at 9 54 36 PM" src="https://github.com/aviator-co/av/assets/13113118/fb734733-dbe2-4456-87f4-44fb0df06391">

pending checks - 
<img width="651" alt="Screen Shot 2023-06-07 at 9 59 48 PM" src="https://github.com/aviator-co/av/assets/13113118/6202ec49-f54f-488a-8e7a-a6bbb0417798">

merged pr - 
<img width="638" alt="Screen Shot 2023-06-07 at 9 56 25 PM" src="https://github.com/aviator-co/av/assets/13113118/27d1c264-f857-4cce-9f0b-0915af20773d">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
