### PR TITLE
[MER-2446] Adjust styles for web and manpages

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -5,13 +5,12 @@ import (
 )
 
 var prCmd = &cobra.Command{
-	Use: "pr",
+	Use:   "pr",
 	Short: "manage pull requests",
 }
 
 func init() {
 	prCmd.AddCommand(
 		prCreateCmd,
-
 	)
 }

--- a/docs/av-auth-status.1.md
+++ b/docs/av-auth-status.1.md
@@ -1,13 +1,15 @@
-# av-auth-status 1 "" av-cli "Aviator CLI User Manual"
+# av-auth-status
 
-# NAME
+## NAME
 
-av-auth-status - Show info about the logged in user.
+av-auth-status - Show info about the logged in user
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av auth status`
+```synopsis
+av auth status
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 Shows information about the logged in user using their access token.

--- a/docs/av-commit-amend.1.md
+++ b/docs/av-commit-amend.1.md
@@ -1,21 +1,23 @@
-# av-commit-amend 1 "" av-cli "Aviator CLI User Manual"
+# av-commit-amend
 
-# NAME
+## NAME
 
 av-commit-amend - Amend a commit
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av commit amend [-m <msg>| --message=<msg>] [--no-edit]`
+```synopsis
+av commit amend [-m <msg>| --message=<msg>] [--no-edit]
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 The tip of the current branch can be replaced by creating a new commit. During
 this process, the recorded tree is prepared as per usual. In cases where no
 other message is specified via the command-line option -m, the message from the
 original commit is utilized as the initial point rather than an empty message.
 
-# OPTIONS
+## OPTIONS
 
 `-m <msg>, --message=<msg>`
 : Use the given `<msg>` as the commit message.

--- a/docs/av-commit-create.1.md
+++ b/docs/av-commit-create.1.md
@@ -1,14 +1,16 @@
-# av-commit-create 1 "" av-cli "Aviator CLI User Manual"
+# av-commit-create
 
-# NAME
+## NAME
 
 av-commit-create - Record changes to the repository with commits
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av commit create [-m <msg>| --message=<msg>] [-a | --all]`
+```synopsis
+av commit create [-m <msg>| --message=<msg>] [-a | --all]
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 Create a new commit containing the current contents of the index and the given
 log message describing the changes, then run **av stack sync** on all subsequent
@@ -17,7 +19,7 @@ child branches with the new commit.
 Previous to running **av commit-create**, add changes to the index via
 git-add(1) to incrementally "add" changes to the index.
 
-# OPTIONS
+## OPTIONS
 
 `-m <msg>, --message=<msg>`
 : Use the given `<msg>` as the commit message.

--- a/docs/av-commit-split.1.md
+++ b/docs/av-commit-split.1.md
@@ -1,10 +1,10 @@
-# av-commit-split 1 "" av-cli "Aviator CLI User Manual"
+# av-commit-split
 
-# NAME
+## NAME
 
-av-commit-split - Split a commit into multiple commits.
+av-commit-split - Split a commit into multiple commits
 
-# DESCRIPTION
+## DESCRIPTION
 
 Split the currently checked out commit into multiple commits. When invoked, it
 prompts you which diff chunks should be included in the first commit and asks

--- a/docs/av-fetch.1.md
+++ b/docs/av-fetch.1.md
@@ -1,13 +1,15 @@
-# av-pr-fetch 1 "" av-cli "Aviator CLI User Manual"
+# av-fetch
 
-# NAME
+## NAME
 
-av-fetch - Fetch latest repository state from github.
+av-fetch - Fetch latest repository state from GitHub
 
-# SYNOPSIS
+## SYNOPSIS
 
-`` av pr fetch``
+```synopsis
+av fetch
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
-Fetch latest repository state from github.
+Fetch latest repository state from GitHub.

--- a/docs/av-init.1.md
+++ b/docs/av-init.1.md
@@ -1,10 +1,10 @@
-# av-init 1 "" av-cli "Aviator CLI User Manual"
+# av-init
 
-# NAME
+## NAME
 
-av-init - Initialize the repository for Aviator CLI.
+av-init - Initialize the repository for Aviator CLI
 
-# DESCRIPTION
+## DESCRIPTION
 
 Aviator CLI internally stores metadata in the repository. This command
 initializes the metadata storage for the repository.

--- a/docs/av-pr-create.1.md
+++ b/docs/av-pr-create.1.md
@@ -1,15 +1,17 @@
-# av-pr-create 1 "" av-cli "Aviator CLI User Manual"
+# av-pr-create
 
-# NAME
+## NAME
 
 av-pr-create - Create a pull request for the current branch
 
-# SYNOPSIS
+## SYNOPSIS
 
-`` av pr create [-t <title>| --title=<title>] [-b <body>| --body=<body>]
-    [--draft] [--edit] [--force] [--no-push] ``
+```synopsis
+av pr create [-t <title>| --title=<title>] [-b <body>| --body=<body>]
+    [--draft] [--edit] [--force] [--no-push]
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 Push the current branch and create a pull request if not exist. If the branch
 has a parent branch, you need to make a pull-request for the parent first. If
@@ -20,7 +22,7 @@ When there's already a pull-request, the command just pushes the branch to
 remote, and you are not asked to provide the title and the body. If you want to
 edit the pull-request description for the existing pull-request, use `--edit`.
 
-# OPTIONS
+## OPTIONS
 
 `-t <title>, --title=<title>`
 : Use the given `<title>` as the title for the pull request.
@@ -43,15 +45,17 @@ edit the pull-request description for the existing pull-request, use `--edit`.
 : Do not push the branch to the remote repository before creating the pull
   request.
 
-# EXAMPLES
+## EXAMPLES
 
 Create a pull request, specifying the body of the PR from standard input:
 
-    $ av pr create --title "Implement fancy feature" --body - <<EOF
-    > Implement my very fancy feature.
-    > Can you please review it?
-    > EOF
+```bash
+$ av pr create --title "Implement fancy feature" --body - <<EOF
+> Implement my very fancy feature.
+> Can you please review it?
+> EOF
+```
 
-# SEE ALSO
+## SEE ALSO
 
 `av-stack-submit`(1)

--- a/docs/av-stack-branch-commit.1.md
+++ b/docs/av-stack-branch-commit.1.md
@@ -1,21 +1,23 @@
-# av-stack-branch-commit 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-branch-commit
 
-# NAME
+## NAME
 
 av-stack-branch-commit - Create a new branch in the stack with the staged changes
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av stack branch-commit [-a | --all] [-b <branch_name> | --branch-name <branch_name>]
-[-m <msg>| --message=<msg>]`
+```synopsis
+av stack branch-commit [-a | --all] [-b <branch_name> | --branch-name <branch_name>]
+    [-m <msg>| --message=<msg>]`
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 Create a new branch that is stacked on the current branch and commit all
 staged changes with the specified arguments. One of `-b` or `-m` flags are
 required to create the branch.
 
-# OPTIONS
+## OPTIONS
 
 `-a, --all`
 : Automatically stage all modified/deleted files, (same as `git commit --all`)

--- a/docs/av-stack-branch.1.md
+++ b/docs/av-stack-branch.1.md
@@ -1,14 +1,16 @@
-# av-stack-branch 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-branch
 
-# NAME
+## NAME
 
 av-stack-branch - Create or rename a branch in the stack
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av stack branch [-m | --rename] [--parent <parent_branch>] <branch-name>`
+```synopsis
+av stack branch [-m | --rename] [--parent <parent_branch>] <branch-name>
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 Create a new branch that is stacked on the current branch by default
 
@@ -17,7 +19,7 @@ instead of creating a new branch. Branches should only be renamed
 with this command (not with git branch -m ...) because av needs to update
 internal tracking metadata that defines the order of branches within a stack.
 
-# OPTIONS
+## OPTIONS
 
 `--parent <parent_branch>`
 : Instead of creating a new branch from current branch, create it from

--- a/docs/av-stack-diff.1.md
+++ b/docs/av-stack-diff.1.md
@@ -1,13 +1,16 @@
-# av-stack-diff 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-diff
 
-# NAME
+## NAME
 
-av-stack-diff - Show the diff between working tree and parent branch. 
+av-stack-diff - Show the diff between working tree and parent branch
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av stack diff`
+```synopsis
+av stack diff
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
-Generates the diff between the working tree and the parent branch (i.e., the diff between the current branch and the previous branch in the stack).
+Generates the diff between the working tree and the parent branch (i.e., the
+diff between the current branch and the previous branch in the stack).

--- a/docs/av-stack-next.1.md
+++ b/docs/av-stack-next.1.md
@@ -1,25 +1,29 @@
-# av-stack-next 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-next
 
-# NAME
+## NAME
 
-av-stack-next - Checkout a later branch in the stack.
+av-stack-next - Checkout a later branch in the stack
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av stack next [<n> | --last]`
+```synopsis
+av stack next [<n> | --last]
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
-Checkout a later branch in the stack. Without any options, this will default to checking out the next branch in the stack.
+Checkout a later branch in the stack. Without any options, this will default to
+checking out the next branch in the stack.
 
-# OPTIONS
+## OPTIONS
 
 `<n>`
-: Checkout to the branch that is `<n>` branches after the current branch in the stack.
+: Checkout to the branch that is `<n>` branches after the current branch in the
+  stack.
 
 `--first`
 : Checkout to the last branch in the stack.
 
-# SEE ALSO
+## SEE ALSO
 
 `av-pr-prev`(1)

--- a/docs/av-stack-prev.1.md
+++ b/docs/av-stack-prev.1.md
@@ -1,25 +1,29 @@
-# av-stack-prev 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-prev
 
-# NAME
+## NAME
 
-av-stack-prev - Checkout a previous branch in the stack.
+av-stack-prev - Checkout a previous branch in the stack
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av stack prev [<n> | --first]`
+```synopsis
+av stack prev [<n> | --first]
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
-Checkout a previous branch in the stack. Without any options, this will default to checking out the previous branch in the stack.
+Checkout a previous branch in the stack. Without any options, this will default
+to checking out the previous branch in the stack.
 
-# OPTIONS
+## OPTIONS
 
 `<n>`
-: Checkout to the branch that is `<n>` branches before the current branch in the stack.
+: Checkout to the branch that is `<n>` branches before the current branch in the
+  stack.
 
 `--first`
 : Checkout to the first branch in the stack.
 
-# SEE ALSO
+## SEE ALSO
 
 `av-pr-next`(1)

--- a/docs/av-stack-submit.1.md
+++ b/docs/av-stack-submit.1.md
@@ -1,14 +1,16 @@
-# av-stack-submit 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-submit
 
-# NAME
+## NAME
 
 av-stack-submit - Create pull requests for every branch in the stack
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av stack submit`
+```synopsis
+av stack submit
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 Create pull requests for every branch in the current stack. This ensures that
 every pull request has the correct base branch and includes the correct metadata
@@ -17,6 +19,6 @@ in the pull request description.
 If a branch has an existing pull request, it will be modified with the correct
 base branch and metadata (if necessary).
 
-# SEE ALSO
+## SEE ALSO
 
 `av-pr-create`(1)

--- a/docs/av-stack-sync.1.md
+++ b/docs/av-stack-sync.1.md
@@ -1,22 +1,23 @@
-# av-stack-sync 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-sync
 
-# NAME
+## NAME
 
 av-stack-sync - Synchronize stacked branches
 
-# SYNOPSIS
+## SYNOPSIS
 
-`` av stack sync [--all | --current] [--no-push] [--no-fetch] [--prune]
+```synopsis
+av stack sync [--all | --current] [--no-push] [--no-fetch] [--prune]
               [--trunk] [--continue | --abort | --skip] [--parent=<parent>]
-``
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 Over the time, branches get unsynchronized in many ways. Some branches are
 merged. The upstream branch is moved. A parent branch get their commit amended.
 `av stack sync` synchronizes the branches following the changes.
 
-For each branch, this command does the following:
+For each branch, this command does the following
 
 * Rebase onto the parent branch. By default, if the parent is the trunk branch
   (e.g. `main`), this step is skipped. If `--trunk` is used, it fetches the
@@ -25,9 +26,9 @@ For each branch, this command does the following:
 * Push to the remote branch. With Git's default config, the push updates the
   same name branch on the remote.
 
-  NOTE: Currently, this overwrites the remote with force. This can overwrite any
-  changes happen on GitHub. To avoid this, pull or manually cherry-pick the
-  changes on the remote.
+Note that currently, this overwrites the remote with force. This can overwrite
+any changes happen on GitHub. To avoid this, pull or manually cherry-pick the
+changes on the remote.
 
 By default, this command will sync all branches starting at the root of the
 stack and repeatedly executes the above steps. If the --current flag is given,
@@ -38,27 +39,27 @@ all branches in the repository.
 
 If --prune option is given, it deletes the merged branches at the end of sync.
 
-# REBASE CONFLICT
+## REBASE CONFLICT
 
 Rebasing can cause a conflict. When a conflict happens, it prompts you to
 resolve the conflict, and continue with `av stack sync --continue`. This is
 similar to `git rebase --continue`, but it continues with syncing the rest of
 the branches.
 
-# CHANGE PARENT
+## CHANGE PARENT
 
 If you want to change the parent, use `--parent=<parent>` to specify the new
 parent. This rebases the current branch onto the new parent and runs the sync
 operations on the children.
 
-# ADOPTING BRANCHES
+## ADOPTING BRANCHES
 
 If you want to adopt a Git branch that is created outside of `av`, you can run
 `av stack sync --parent=<parent>` or `av stack sync --parent=<parent> --trunk`
 to adopt a branch to `av`. If the parent is a trunk branch (e.g. main), use
 `--trunk`.
 
-# OPTIONS
+## OPTIONS
 
 `--all`
 : Synchronize all branches.

--- a/docs/av-stack-tidy.1.md
+++ b/docs/av-stack-tidy.1.md
@@ -1,14 +1,16 @@
-# av-stack-tidy 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-tidy
 
-# NAME
+## NAME
 
 av-stack-tidy - Tidy stacked branches by removing deleted or merged branches
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av stack tidy`
+```synopsis
+av stack tidy
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 Tidy stacked branches by removing deleted or merged branches.
 

--- a/docs/av-stack-tree.1.md
+++ b/docs/av-stack-tree.1.md
@@ -1,13 +1,15 @@
-# av-stack-tree 1 "" av-cli "Aviator CLI User Manual"
+# av-stack-tree
 
-# NAME
+## NAME
 
-av-stack-tree - Shows the tree of stacked branches.
+av-stack-tree - Shows the tree of stacked branches
 
-# SYNOPSIS
+## SYNOPSIS
 
-`av stack tree`
+```synopsis
+av stack tree
+```
 
-# DESCRIPTION
+## DESCRIPTION
 
 Show the tree of stacked branches.

--- a/docs/av.1.md
+++ b/docs/av.1.md
@@ -1,14 +1,14 @@
-# av 1 "" av-cli "Aviator CLI User Manual"
+# av
 
-# NAME
+## NAME
 
 av - Aviator CLI
 
-# DESCRIPTION
+## DESCRIPTION
 
 **av** allows you to manage stacked pull requests with Aviator.
 
-# SUBCOMMANDS
+## SUBCOMMANDS
 
 - av-commit-create(1): Create a new commit.
 - av-commit-split(1): Split a commit into multiple commits.
@@ -26,7 +26,7 @@ av - Aviator CLI
 - av-stack-tidy(1): Tidy up the branch metadata.
 - av-stack-tree(1): Show the tree of stacked branches.
 
-# FURTHER DOCUMENTATION
+## FURTHER DOCUMENTATION
 
 See [Aviator documentation](https://docs.aviator.co) for the help document
 beyond Aviator CLI.

--- a/docs/internal/md2man/md2man.go
+++ b/docs/internal/md2man/md2man.go
@@ -1,0 +1,20 @@
+package md2man
+
+import (
+	"regexp"
+
+	"github.com/russross/blackfriday/v2"
+)
+
+var returns = regexp.MustCompile(`\n+`)
+
+func RenderToRoff(text []byte, section int, version, source, volume string) []byte {
+	renderer := NewRoffRenderer(section, version, source, volume)
+	bs := blackfriday.Run(text,
+		[]blackfriday.Option{
+			blackfriday.WithRenderer(renderer),
+			blackfriday.WithExtensions(renderer.GetExtensions()),
+		}...,
+	)
+	return []byte(returns.ReplaceAllString(string(bs), "\n"))
+}

--- a/docs/internal/md2man/roff.go
+++ b/docs/internal/md2man/roff.go
@@ -1,0 +1,390 @@
+// This is a fork of https://github.com/cpuguy83/go-md2man.
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2014 Brian Goff
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+package md2man
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/russross/blackfriday/v2"
+)
+
+// roffRenderer implements the blackfriday.Renderer interface for creating
+// roff format (manpages) from markdown text
+type roffRenderer struct {
+	extensions   blackfriday.Extensions
+	listCounters []int
+	firstDD      bool
+	listDepth    int
+
+	section int
+	version string
+	source  string
+	volume  string
+}
+
+const (
+	titleHeader      = ".TH "
+	topLevelHeader   = "\n\n.SH "
+	secondLevelHdr   = "\n.SH "
+	otherHeader      = "\n.SS "
+	crTag            = "\n"
+	emphTag          = "\\fI"
+	emphCloseTag     = "\\fP"
+	strongTag        = "\\fB"
+	strongCloseTag   = "\\fP"
+	breakTag         = "\n.br\n"
+	paraTag          = "\n.PP\n"
+	hruleTag         = "\n.ti 0\n\\l'\\n(.lu'\n"
+	linkTag          = "\n\\[la]"
+	linkCloseTag     = "\\[ra]"
+	codespanTag      = "\\fB\\fC"
+	codespanCloseTag = "\\fR"
+	codeTag          = "\n.sp\n.EX\n"
+	codeCloseTag     = "\n.EE\n"
+	quoteTag         = "\n.PP\n.RS\n"
+	quoteCloseTag    = "\n.RE\n"
+	listTag          = "\n.RS\n"
+	listCloseTag     = "\n.RE\n"
+	dtTag            = "\n.TP 4\n"
+	dd2Tag           = "\n"
+	tableStart       = "\n.TS\nallbox;\n"
+	tableEnd         = ".TE\n"
+	tableCellStart   = "T{\n"
+	tableCellEnd     = "\nT}\n"
+)
+
+// NewRoffRenderer creates a new blackfriday Renderer for generating roff documents
+// from markdown
+func NewRoffRenderer(section int, version, source, volume string) *roffRenderer { // nolint: golint
+	var extensions blackfriday.Extensions
+
+	extensions |= blackfriday.NoIntraEmphasis
+	extensions |= blackfriday.Tables
+	extensions |= blackfriday.FencedCode
+	extensions |= blackfriday.SpaceHeadings
+	extensions |= blackfriday.Footnotes
+	extensions |= blackfriday.Titleblock
+	extensions |= blackfriday.DefinitionLists
+	return &roffRenderer{
+		extensions: extensions,
+		section:    section,
+		version:    version,
+		source:     source,
+		volume:     volume,
+	}
+}
+
+// GetExtensions returns the list of extensions used by this renderer implementation
+func (r *roffRenderer) GetExtensions() blackfriday.Extensions {
+	return r.extensions
+}
+
+// RenderHeader handles outputting the header at document start
+func (r *roffRenderer) RenderHeader(w io.Writer, ast *blackfriday.Node) {
+	// disable hyphenation
+	out(w, ".nh\n")
+}
+
+// RenderFooter handles outputting the footer at the document end; the roff
+// renderer has no footer information
+func (r *roffRenderer) RenderFooter(w io.Writer, ast *blackfriday.Node) {
+}
+
+// RenderNode is called for each node in a markdown document; based on the node
+// type the equivalent roff output is sent to the writer
+func (r *roffRenderer) RenderNode(
+	w io.Writer,
+	node *blackfriday.Node,
+	entering bool,
+) blackfriday.WalkStatus {
+	walkAction := blackfriday.GoToNext
+
+	switch node.Type {
+	case blackfriday.Text:
+		escapeSpecialChars(w, node.Literal)
+	case blackfriday.Softbreak:
+		out(w, crTag)
+	case blackfriday.Hardbreak:
+		out(w, breakTag)
+	case blackfriday.Emph:
+		if entering {
+			out(w, emphTag)
+		} else {
+			out(w, emphCloseTag)
+		}
+	case blackfriday.Strong:
+		if entering {
+			out(w, strongTag)
+		} else {
+			out(w, strongCloseTag)
+		}
+	case blackfriday.Link:
+		// Don't render the link text for automatic links, because this
+		// will only duplicate the URL in the roff output.
+		// See https://daringfireball.net/projects/markdown/syntax#autolink
+		if !bytes.Equal(node.LinkData.Destination, node.FirstChild.Literal) {
+			out(w, string(node.FirstChild.Literal))
+		}
+		// Hyphens in a link must be escaped to avoid word-wrap in the rendered man page.
+		escapedLink := strings.ReplaceAll(string(node.LinkData.Destination), "-", "\\-")
+		out(w, linkTag+escapedLink+linkCloseTag)
+		walkAction = blackfriday.SkipChildren
+	case blackfriday.Image:
+		// ignore images
+		walkAction = blackfriday.SkipChildren
+	case blackfriday.Code:
+		out(w, codespanTag)
+		escapeSpecialChars(w, node.Literal)
+		out(w, codespanCloseTag)
+	case blackfriday.Document:
+		break
+	case blackfriday.Paragraph:
+		// roff .PP markers break lists
+		if r.listDepth > 0 {
+			return blackfriday.GoToNext
+		}
+		if entering {
+			out(w, paraTag)
+		} else {
+			out(w, crTag)
+		}
+	case blackfriday.BlockQuote:
+		if entering {
+			out(w, quoteTag)
+		} else {
+			out(w, quoteCloseTag)
+		}
+	case blackfriday.Heading:
+		r.handleHeading(w, node, entering)
+	case blackfriday.HorizontalRule:
+		out(w, hruleTag)
+	case blackfriday.List:
+		r.handleList(w, node, entering)
+	case blackfriday.Item:
+		r.handleItem(w, node, entering)
+	case blackfriday.CodeBlock:
+		if node.CodeBlockData.IsFenced && string(node.CodeBlockData.Info) == "synopsis" {
+			out(w, "\n.nf\n")
+			escapeSpecialChars(w, node.Literal)
+			out(w, "\n.fi\n")
+		} else {
+			out(w, codeTag)
+			for _, line := range strings.Split(string(node.Literal), "\n") {
+				escapeSpecialChars(w, []byte("    "+line+"\n"))
+			}
+			out(w, codeCloseTag)
+		}
+	case blackfriday.Table:
+		r.handleTable(w, node, entering)
+	case blackfriday.TableHead:
+	case blackfriday.TableBody:
+	case blackfriday.TableRow:
+		// no action as cell entries do all the nroff formatting
+		return blackfriday.GoToNext
+	case blackfriday.TableCell:
+		r.handleTableCell(w, node, entering)
+	case blackfriday.HTMLSpan:
+		// ignore other HTML tags
+	default:
+		fmt.Fprintln(os.Stderr, "WARNING: go-md2man does not handle node type "+node.Type.String())
+	}
+	return walkAction
+}
+
+func (r *roffRenderer) handleHeading(w io.Writer, node *blackfriday.Node, entering bool) {
+	if entering {
+		switch node.Level {
+		case 1:
+			out(w, titleHeader)
+		case 2:
+			out(w, topLevelHeader)
+		case 3:
+			out(w, secondLevelHdr)
+		default:
+			out(w, otherHeader)
+		}
+	} else {
+		if node.Level == 1 {
+			out(w, fmt.Sprintf(" %d %q %q %q", r.section, r.version, r.source, r.volume))
+		}
+	}
+}
+
+func (r *roffRenderer) handleList(w io.Writer, node *blackfriday.Node, entering bool) {
+	openTag := listTag
+	closeTag := listCloseTag
+	if node.ListFlags&blackfriday.ListTypeDefinition != 0 {
+		// tags for definition lists handled within Item node
+		openTag = ""
+		closeTag = ""
+	}
+	if entering {
+		r.listDepth++
+		if node.ListFlags&blackfriday.ListTypeOrdered != 0 {
+			r.listCounters = append(r.listCounters, 1)
+		}
+		out(w, openTag)
+	} else {
+		if node.ListFlags&blackfriday.ListTypeOrdered != 0 {
+			r.listCounters = r.listCounters[:len(r.listCounters)-1]
+		}
+		out(w, closeTag)
+		r.listDepth--
+	}
+}
+
+func (r *roffRenderer) handleItem(w io.Writer, node *blackfriday.Node, entering bool) {
+	if entering {
+		if node.ListFlags&blackfriday.ListTypeOrdered != 0 {
+			out(w, fmt.Sprintf(".IP \"%3d.\" 5\n", r.listCounters[len(r.listCounters)-1]))
+			r.listCounters[len(r.listCounters)-1]++
+		} else if node.ListFlags&blackfriday.ListTypeTerm != 0 {
+			// DT (definition term): line just before DD (see below).
+			out(w, dtTag)
+			r.firstDD = true
+		} else if node.ListFlags&blackfriday.ListTypeDefinition != 0 {
+			// DD (definition description): line that starts with ": ".
+			//
+			// We have to distinguish between the first DD and the
+			// subsequent ones, as there should be no vertical
+			// whitespace between the DT and the first DD.
+			if r.firstDD {
+				r.firstDD = false
+			} else {
+				out(w, dd2Tag)
+			}
+		} else {
+			out(w, ".IP \\(bu 2\n")
+		}
+	} else {
+		out(w, "\n")
+	}
+}
+
+func (r *roffRenderer) handleTable(w io.Writer, node *blackfriday.Node, entering bool) {
+	if entering {
+		out(w, tableStart)
+		// call walker to count cells (and rows?) so format section can be produced
+		columns := countColumns(node)
+		out(w, strings.Repeat("l ", columns)+"\n")
+		out(w, strings.Repeat("l ", columns)+".\n")
+	} else {
+		out(w, tableEnd)
+	}
+}
+
+func (r *roffRenderer) handleTableCell(w io.Writer, node *blackfriday.Node, entering bool) {
+	if entering {
+		var start string
+		if node.Prev != nil && node.Prev.Type == blackfriday.TableCell {
+			start = "\t"
+		}
+		if node.IsHeader {
+			start += strongTag
+		} else if nodeLiteralSize(node) > 30 {
+			start += tableCellStart
+		}
+		out(w, start)
+	} else {
+		var end string
+		if node.IsHeader {
+			end = strongCloseTag
+		} else if nodeLiteralSize(node) > 30 {
+			end = tableCellEnd
+		}
+		if node.Next == nil && end != tableCellEnd {
+			// Last cell: need to carriage return if we are at the end of the
+			// header row and content isn't wrapped in a "tablecell"
+			end += crTag
+		}
+		out(w, end)
+	}
+}
+
+func nodeLiteralSize(node *blackfriday.Node) int {
+	total := 0
+	for n := node.FirstChild; n != nil; n = n.FirstChild {
+		total += len(n.Literal)
+	}
+	return total
+}
+
+// because roff format requires knowing the column count before outputting any table
+// data we need to walk a table tree and count the columns
+func countColumns(node *blackfriday.Node) int {
+	var columns int
+
+	node.Walk(func(node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+		switch node.Type {
+		case blackfriday.TableRow:
+			if !entering {
+				return blackfriday.Terminate
+			}
+		case blackfriday.TableCell:
+			if entering {
+				columns++
+			}
+		default:
+		}
+		return blackfriday.GoToNext
+	})
+	return columns
+}
+
+func out(w io.Writer, output string) {
+	io.WriteString(w, output) // nolint: errcheck
+}
+
+func escapeSpecialChars(w io.Writer, text []byte) {
+	for i := 0; i < len(text); i++ {
+		// escape initial apostrophe or period
+		if len(text) >= 1 && (text[0] == '\'' || text[0] == '.') {
+			out(w, "\\&")
+		}
+
+		// directly copy normal characters
+		org := i
+
+		for i < len(text) && text[i] != '\\' {
+			i++
+		}
+		if i > org {
+			w.Write(text[org:i]) // nolint: errcheck
+		}
+
+		// escape a character
+		if i >= len(text) {
+			break
+		}
+
+		w.Write([]byte{'\\', text[i]}) // nolint: errcheck
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.20
 
 require (
 	emperror.dev/errors v0.8.1
-	github.com/cpuguy83/go-md2man/v2 v2.0.2
 	github.com/fatih/color v1.15.0
 	github.com/golangci/golangci-lint v1.52.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/text v0.2.0
+	github.com/russross/blackfriday/v2 v2.1.0
 	github.com/segmentio/golines v0.11.0
 	github.com/shurcooL/githubv4 v0.0.0-20220115235240-a14260e6f8a2
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
@@ -144,7 +144,6 @@ require (
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryancurrah/gomodguard v1.3.0 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.4.0 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,7 +109,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/curioswitch/go-reassign v0.2.0 h1:G9UZyOcpk/d7Gd6mqYgd8XYWFMw/znxwGDUstnC9DIo=


### PR DESCRIPTION
We are trying to use `docs/*` as both command manuals on the web as well
as online manual distributed along with the binary. For that, we want to
customize go-md2man output, especially the header part.

This includes a fork of https://github.com/cpuguy83/go-md2man. This
includes the title part and some whitespace handling
modifications.

Note that go-md2man is licensed under MIT license, which is the same as
this repository. The file independently have a license header and a
copyright notice with a SPDX header.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
