### PR TITLE
feat: add force flag to stack branch rename

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -5,13 +5,12 @@ import (
 )
 
 var prCmd = &cobra.Command{
-	Use: "pr",
+	Use:   "pr",
 	Short: "manage pull requests",
 }
 
 func init() {
 	prCmd.AddCommand(
 		prCreateCmd,
-
 	)
 }

--- a/cmd/av/stack_branch.go
+++ b/cmd/av/stack_branch.go
@@ -199,6 +199,7 @@ func stackBranchMove(
 			Trunk: true,
 		}
 	}
+	currentMeta.PullRequest = nil
 	currentMeta.Name = newBranch
 	tx.SetBranch(currentMeta)
 

--- a/cmd/av/stack_branch.go
+++ b/cmd/av/stack_branch.go
@@ -206,7 +206,7 @@ func stackBranchMove(
 	if !force {
 		if currentMeta.PullRequest != nil {
 			return errors.New(
-				"cannot rename branch because a pull request already exists (bypass with the `--force` flag, but this renames your local branch and not its remote counterpart)",
+				"cannot rename branch because a pull request already exists (bypass with the `--force` flag, but this will require closing this pull request and opening a new one using `av pr create`)",
 			)
 		}
 	}

--- a/docs/av-stack-branch.1.md
+++ b/docs/av-stack-branch.1.md
@@ -6,7 +6,7 @@ av-stack-branch - Create or rename a branch in the stack
 
 # SYNOPSIS
 
-`av stack branch [-m | --rename] [--parent <parent_branch>] <branch-name>`
+`av stack branch [-m | --rename] [--force] [--parent <parent_branch>] <branch-name>`
 
 # DESCRIPTION
 
@@ -25,4 +25,7 @@ internal tracking metadata that defines the order of branches within a stack.
 
 `-m, --rename`
 : Rename the current branch to the provided `<branch_name>` instead of
-  creating a new one.
+  creating a new one, only if a pull request does not exist.
+
+`--force`
+: Force rename the branch, even if a pull request exists.


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
