### PR TITLE
[MER-2449] Replace the deprecated "replacements"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,13 @@ builds:
 release: {}
 
 archives:
-  - replacements:
-      amd64: x86_64
-      darwin: macos
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "darwin" }}macos
+      {{- else }}{{ .Arch }}{{ end }}
 
 
 # Push to the homebrew tap

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     hooks:
       - id: golines
         name: golines
-        files: ".+$"
+        files: ".+.go$"
         language: system
         entry: |
           sh -c 'go run github.com/segmentio/golines -w .'
       - id: goimports
         name: goimports
-        files: ".+$"
+        files: ".+.go$"
         language: system
         entry: |
           sh -c 'go run golang.org/x/tools/cmd/goimports@latest -w .'


### PR DESCRIPTION
https://goreleaser.com/deprecations/#archivesreplacements

archives.replacements is removed as of 2023-06-06.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
