### PR TITLE
[MER-2452] Bundle manpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries for programs and plugins
 dist/
+man/
 *.exe
 *.exe~
 *.dll

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,8 @@
+before:
+  hooks:
+    - 'rm -rf man'
+    - 'sh -c "cd docs && go run convert-manpages.go --output-dir ../man --version v{{ .Version }}"'
+
 builds:
   - dir: "./cmd/av"
     env:
@@ -23,6 +28,10 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "darwin" }}macos
       {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - 'LICENSE'
+      - 'README.md'
+      - 'man'
 
 
 # Push to the homebrew tap
@@ -35,6 +44,9 @@ brews:
       email: "105820887+aviator-bot@users.noreply.github.com"
     homepage: "https://aviator.co"
     license: "MIT"
+    install: |
+      bin.install "av"
+      man.install Dir["man/*"]
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
With this change, the archives have online manuals and they are
installed with Homebrew. Tested locally with goreleaser and local
formula.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
