### PR TITLE
Fix: remove second create.

### DIFF
--- a/cmd/av/pr_create.go
+++ b/cmd/av/pr_create.go
@@ -95,7 +95,6 @@ Examples:
 }
 
 func init() {
-	prCmd.AddCommand(prCreateCmd)
 
 	// av pr create
 	prCreateCmd.Flags().BoolVar(


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
