### PR TITLE
[MER-2335] Remove the dev version check for reorder

### DIFF
--- a/cmd/av/stack_reorder.go
+++ b/cmd/av/stack_reorder.go
@@ -9,7 +9,6 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
-	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/reorder"
@@ -40,9 +39,6 @@ var stackReorderCmd = &cobra.Command{
 	Long:   strings.TrimSpace(stackReorderDoc),
 	Args:   cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if config.Version != config.VersionDev {
-			logrus.Fatal("av stack reorder is not yet implemented")
-		}
 		repo, err := getRepo()
 		if err != nil {
 			return err


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
