### PR TITLE
[MER-2598] doc: Add `av pr queue` man page; hide unimplemented flags.

### DIFF
--- a/cmd/av/pr_queue.go
+++ b/cmd/av/pr_queue.go
@@ -100,4 +100,9 @@ func init() {
 		&prQueueFlags.Targets, "targets", "t", "",
 		"additional targets affected by this pull request",
 	)
+	// These flags are not yet supported. 
+	prQueueCmd.Flags().MarkHidden("targets")
+	prQueueCmd.Flags().MarkHidden("skip-line")
+
 }
+

--- a/docs/av-pr-queue.1.md
+++ b/docs/av-pr-queue.1.md
@@ -1,0 +1,15 @@
+# av-pr-queue
+
+## NAME
+
+av-pr-queue - Queue an existng pull request for the current branch
+
+## DESCRIPTION
+
+Attempt to add an existing pull request for the current branch to the queue.
+If the current branch does not have an open pull request it will need to be
+created first. `av pr create` can accomplish this. 
+
+## SEE ALSO
+
+`av-pr-create`(1)


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
