### PR TITLE
feat: Allow specifying Aviator API URL from configuration

### DIFF
--- a/cmd/av/auth_status.go
+++ b/cmd/av/auth_status.go
@@ -18,7 +18,10 @@ var authStatusCmd = &cobra.Command{
 	SilenceUsage: true,
 	Args:         cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client := avgql.NewClient()
+		client, err := avgql.NewClient()
+		if err != nil {
+			return err
+		}
 
 		var query struct {
 			Viewer struct {
@@ -26,7 +29,7 @@ var authStatusCmd = &cobra.Command{
 			}
 		}
 
-		err := client.Query(context.Background(), &query, nil)
+		err = client.Query(context.Background(), &query, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/pr_queue.go
+++ b/cmd/av/pr_queue.go
@@ -63,7 +63,10 @@ var prQueueCmd = &cobra.Command{
 		}
 
 		// I have a feeling this would be better written inside of av/internals
-		client := avgql.NewClient()
+		client, err := avgql.NewClient()
+		if err != nil {
+			return err
+		}
 
 		var mutation struct {
 			QueuePullRequest struct {

--- a/cmd/av/pr_status.go
+++ b/cmd/av/pr_status.go
@@ -26,7 +26,10 @@ var prStatusCmd = &cobra.Command{
 			return err
 		}
 
-		client := avgql.NewClient()
+		client, err := avgql.NewClient()
+		if err != nil {
+			return err
+		}
 
 		var query struct {
 			GithubRepository struct {

--- a/internal/avgql/client.go
+++ b/internal/avgql/client.go
@@ -2,21 +2,29 @@ package avgql
 
 import (
 	"context"
+	"net/url"
 	"os"
 
+	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/config"
 	"github.com/shurcooL/graphql"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
-func NewClient() *graphql.Client {
+func NewClient() (*graphql.Client, error) {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: config.Av.Aviator.APIToken},
 	)
 	httpClient := oauth2.NewClient(context.Background(), src)
 	apiURL := os.Getenv("AV_GRAPHQL_URL")
 	if apiURL == "" {
-		apiURL = "https://api.aviator.co/graphql"
+		baseURL, err := url.Parse(config.Av.Aviator.APIHost)
+		if err != nil {
+			return nil, errors.WrapIff(err, "failed to parse aviator.apiHost configuration value")
+		}
+		apiURL = baseURL.JoinPath("/graphql").String()
 	}
-	return graphql.NewClient(apiURL, httpClient)
+	logrus.WithField("api_url", apiURL).Debug("creating GraphQL client")
+	return graphql.NewClient(apiURL, httpClient), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,12 @@ type PullRequest struct {
 }
 
 type Aviator struct {
+	// The base URL of the Aviator API to use.
+	// By default, this is https://aviator.co, but for on-prem installations
+	// this can be changed (e.g., https://aviator.mycompany.com).
+	// It should not include a trailing slash or any path components.
+	APIHost string
+	// The API token to use for authenticating to the Aviator API.
 	APIToken string
 }
 
@@ -34,6 +40,9 @@ var Av = struct {
 	GitHub      GitHub
 	Aviator     Aviator
 }{
+	Aviator: Aviator{
+		APIHost: "https://api.aviator.co",
+	},
 	PullRequest: PullRequest{
 		OpenBrowser: true,
 	},
@@ -49,7 +58,12 @@ var Av = struct {
 // error if one occurred.
 func Load(paths []string) (bool, error) {
 	loaded, err := loadFromFile(paths)
-	loadFromEnv()
+	if err != nil {
+		return loaded, err
+	}
+	if err := loadFromEnv(); err != nil {
+		return loaded, err
+	}
 	return loaded, err
 }
 
@@ -86,7 +100,7 @@ func loadFromFile(paths []string) (bool, error) {
 	return false, nil
 }
 
-func loadFromEnv() {
+func loadFromEnv() error {
 	// TODO: integrate this better with cobra/viper/whatever
 	if githubToken := os.Getenv("AV_GITHUB_TOKEN"); githubToken != "" {
 		Av.GitHub.Token = githubToken
@@ -97,4 +111,9 @@ func loadFromEnv() {
 	if apiToken := os.Getenv("AV_API_TOKEN"); apiToken != "" {
 		Av.Aviator.APIToken = apiToken
 	}
+	if apiHost := os.Getenv("AV_API_HOST"); apiHost != "" {
+		Av.Aviator.APIHost = apiHost
+	}
+
+	return nil
 }


### PR DESCRIPTION
Feature request from a customer to support on-prem installations.

Ideally this would be configurable per-repo as it's possible that a user might have some repositories that use the \~\~cloud~~ version of Aviator and some that use on-prem, but that's not very likely at this point and I didn't want to add that complexity to this pull request.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
