### PR TITLE
fix: Push correctly during av stack sync

### DIFF
--- a/cmd/av/pr_queue.go
+++ b/cmd/av/pr_queue.go
@@ -103,9 +103,8 @@ func init() {
 		&prQueueFlags.Targets, "targets", "t", "",
 		"additional targets affected by this pull request",
 	)
-	// These flags are not yet supported. 
+	// These flags are not yet supported.
 	prQueueCmd.Flags().MarkHidden("targets")
 	prQueueCmd.Flags().MarkHidden("skip-line")
 
 }
-

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -531,7 +531,7 @@ func syncBranchPushAndUpdatePullRequest(
 		}
 	}
 
-	if err := Push(repo, PushOpts{
+	if err := Push(repo, branchName, PushOpts{
 		Force:                        ForceWithLease,
 		SkipIfRemoteBranchNotExist:   true,
 		SkipIfRemoteBranchIsUpToDate: true,


### PR DESCRIPTION
Fixes a bug where branches other than the current branch in the stack would not be pushed during `av stack sync`.

The bug was essentially that `actions.Push` assumed that the branch to be pushed was the current branch and the calling code didn't match that assumption. I changed the `Push` function to take the branch name explicitly since 1) it doesn't actually require the branch to be checked out and 2) APIs with fewer non-obvious assumptions are generally better and less prone to this kind of bug.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
