### PR TITLE
[MER-2814] Automatically make a PR draft

### DIFF
--- a/cmd/av/pr_create.go
+++ b/cmd/av/pr_create.go
@@ -69,6 +69,11 @@ Examples:
 			prCreateFlags.Body = string(bodyBytes)
 		}
 
+		draft := config.Av.PullRequest.Draft
+		if cmd.Flags().Changed("draft") {
+			draft = prCreateFlags.Draft
+		}
+
 		if _, err := actions.CreatePullRequest(
 			context.Background(), repo, client, tx,
 			actions.CreatePullRequestOpts{
@@ -77,12 +82,8 @@ Examples:
 				Body:       body,
 				NoPush:     prCreateFlags.NoPush,
 				Force:      prCreateFlags.Force,
-				// TODO: this means we can't override with --draft=false if the
-				//       config has draft=true. We need to figure out how to
-				//       unify config and flags (the latter should always
-				//       override the former).
-				Draft: prCreateFlags.Draft || config.Av.PullRequest.Draft,
-				Edit:  prCreateFlags.Edit,
+				Draft:      draft,
+				Edit:       prCreateFlags.Edit,
 			},
 		); err != nil {
 			return err

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -322,13 +322,18 @@ func CreatePullRequest(
 		return nil, err
 	}
 
+	draft := opts.Draft
+	if !config.Av.PullRequest.NoWIPDetection && strings.Contains(opts.Title, "WIP") {
+		draft = true
+	}
+
 	pull, didCreatePR, err := ensurePR(ctx, client, repoMeta, ensurePROpts{
 		baseRefName: parentState.Name,
 		headRefName: opts.BranchName,
 		title:       opts.Title,
 		body:        opts.Body,
 		meta:        prMeta,
-		draft:       opts.Draft,
+		draft:       draft,
 		existingPR:  existingPR,
 	})
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,10 @@ type PullRequest struct {
 	// If not set, the value should be considered true iff there is a CODEOWNERS
 	// file in the repository.
 	RebaseWithDraft *bool
+
+	// By default, when the pull request title contains "WIP", it automatically sets the PR as
+	// a draft PR. Setting this to true suppresses this behavior.
+	NoWIPDetection bool
 }
 
 type Aviator struct {


### PR DESCRIPTION
This creates a PR in a draft state when the title contains "WIP". Can be
turned off in the config.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
