### PR TITLE
[MER-2744] fix: look for correct git dir path.

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -20,12 +20,14 @@ var ErrRemoteNotFound = errors.Sentinel("this repository doesn't have a remote o
 
 type Repo struct {
 	repoDir string
+	gitDir string
 	log     logrus.FieldLogger
 }
 
-func OpenRepo(repoDir string) (*Repo, error) {
+func OpenRepo(repoDir string, gitDir string) (*Repo, error) {
 	r := &Repo{
 		repoDir,
+        gitDir,
 		logrus.WithFields(logrus.Fields{"repo": path.Base(repoDir)}),
 	}
 
@@ -37,7 +39,7 @@ func (r *Repo) Dir() string {
 }
 
 func (r *Repo) GitDir() string {
-	return path.Join(r.repoDir, ".git")
+	return r.gitDir
 }
 
 func (r *Repo) AvDir() string {

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -3,6 +3,7 @@ package gittest
 import (
 	"os"
 	"os/exec"
+    "path"
 	"path/filepath"
 	"testing"
 
@@ -49,7 +50,7 @@ func NewTempRepo(t *testing.T) *git.Repo {
 	err = remoteInit.Run()
 	require.NoError(t, err, "failed to initialize remote git repository")
 
-	repo, err := git.OpenRepo(dir)
+	repo, err := git.OpenRepo(dir, path.Join(dir, ".git"))
 	require.NoError(t, err, "failed to open repo")
 
 	settings := map[string]string{


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
