### PR TITLE
fix: Dont hide `av stack reorder` command

### DIFF
--- a/cmd/av/stack_reorder.go
+++ b/cmd/av/stack_reorder.go
@@ -33,11 +33,10 @@ squashed, dropped, or moved within the stack.
 `
 
 var stackReorderCmd = &cobra.Command{
-	Use:    "reorder",
-	Short:  "reorder the stack",
-	Hidden: true,
-	Long:   strings.TrimSpace(stackReorderDoc),
-	Args:   cobra.NoArgs,
+	Use:   "reorder",
+	Short: "reorder the stack",
+	Long:  strings.TrimSpace(stackReorderDoc),
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repo, err := getRepo()
 		if err != nil {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
