### PR TITLE
fix: Check authentication status in `av pr status`

### DIFF
--- a/internal/avgql/viewer.go
+++ b/internal/avgql/viewer.go
@@ -1,0 +1,29 @@
+package avgql
+
+import (
+	"emperror.dev/errors"
+	"github.com/shurcooL/graphql"
+)
+
+// ViewerSubquery is a GraphQL query that fetches the viewer's email and full name.
+// It's meant to be embedded into other queries to check if the user is authenticated
+// via the CheckViewer method.
+type ViewerSubquery struct {
+	Viewer struct {
+		Email    graphql.String `graphql:"email"`
+		FullName graphql.String `graphql:"fullName"`
+	}
+}
+
+var ErrNotAuthenticated = errors.New(
+	"You are not logged in. Please verify that your API token is correct.",
+)
+
+// CheckViewer checks whether or not the viewer is authenticated.
+// It returns ErrNotAuthenticated if the viewer is not authenticated.
+func (v ViewerSubquery) CheckViewer() error {
+	if v.Viewer.Email == "" {
+		return ErrNotAuthenticated
+	}
+	return nil
+}


### PR DESCRIPTION
This was previously resulting in `av pr status` showing junk if the user was not logged in.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
