### PR TITLE
chore: fix goreleaser deprecations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,7 +36,7 @@ archives:
 
 # Push to the homebrew tap
 brews:
-  - tap:
+  - repository:
       owner: aviator-co
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
Noticed some deprecation warnings while releasing (https://github.com/aviator-co/av/actions/runs/6578366058/job/17871949957). This fixes those.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
