### PR TITLE
fix: Update base branch correctly in av pr create

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -453,6 +453,7 @@ func ensurePR(
 			PullRequestID: opts.existingPR.ID,
 			Title:         gh.Ptr(githubv4.String(opts.title)),
 			Body:          gh.Ptr(githubv4.String(newBody)),
+			BaseRefName:   gh.Ptr(githubv4.String(opts.baseRefName)),
 		})
 		if err != nil {
 			return nil, false, errors.WithStack(err)


### PR DESCRIPTION
Fixes a bug where running `av pr create` or `av stack submit` won't edit the base branch of a pull request that already exists.

I noticed this when I reparented a branch that I'd already created a PR for and noticed it didn't set the base branch correctly on GitHub.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
