### PR TITLE
feat: improve av stack reorder UX

### DIFF
--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -355,8 +355,8 @@ func syncBranchRebase(
 
 	// Scenario 3: the branch is not up-to-date with its parent.
 	_, _ = fmt.Fprint(os.Stderr,
-		"  - synching branch ", colors.UserInput(branch.Name),
-		" on latest commit ", git.ShortSha(parentHead),
+		"  - syncing branch ", colors.UserInput(branch.Name),
+		" on latest commit ", colors.UserInput(git.ShortSha(parentHead)),
 		" of parent branch ", colors.UserInput(parentState.Name),
 		"\n",
 	)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -112,6 +112,9 @@ type Output struct {
 
 func (o Output) Lines() []string {
 	s := strings.TrimSpace(string(o.Stdout))
+	if s == "" {
+		return nil
+	}
 	return strings.Split(s, "\n")
 }
 

--- a/internal/reorder/editor.go
+++ b/internal/reorder/editor.go
@@ -23,6 +23,7 @@ func EditPlan(repo *git.Repo, plan []Cmd) ([]Cmd, error) {
 		text.WriteString(cmd.String())
 		text.WriteString("\n")
 	}
+	text.WriteString(instructionsText)
 
 	res, err := editor.Launch(repo, editor.Config{
 		Text:              text.String(),
@@ -76,3 +77,18 @@ func Diff(old []Cmd, new []Cmd) PlanDiff {
 		AddedBranches:   sliceutils.Subtract(newBranches, oldBranches),
 	}
 }
+
+const instructionsText = `
+# Instructions:
+#
+# Commands:
+# sb, stack-branch <branch-name> [--parent <parent-branch-name> | --trunk <trunk-branch-name>]
+#         Create a new branch as part of a stack. If parent is not specified,
+#         the previous branch in the stack is used (if any). If trunk is
+#         specified, the branch is rooted from the given branch.
+#         trunk-branch-name can be either a branch name or a branch name with a
+#         commit ID in the format "<branch-name>@<commit-id>".
+# p, pick <commit-id>
+#         Pick a commit to be included in the stack. Only valid after a
+#         stack-branch command.
+`

--- a/internal/reorder/stackbranch.go
+++ b/internal/reorder/stackbranch.go
@@ -26,6 +26,8 @@ type StackBranchCmd struct {
 	// The branch can be rooted at a given commit by appending "@<commit>" to the
 	// branch name.
 	Trunk string
+	// An optional comment to include in the reorder plan for this command.
+	Comment string
 }
 
 func (b StackBranchCmd) Execute(ctx *Context) error {
@@ -97,6 +99,10 @@ func (b StackBranchCmd) String() string {
 	if b.Trunk != "" {
 		sb.WriteString(" --trunk ")
 		sb.WriteString(b.Trunk)
+	}
+	if b.Comment != "" {
+		sb.WriteString("  # ")
+		sb.WriteString(b.Comment)
 	}
 	return sb.String()
 }


### PR DESCRIPTION
This was originally going to be just fixing an issue that occurs where running `av stack reorder` on a stack that has a branch with no commits.

That ended up being comparatively easy to fix (it's essentially just the two line change in `git.go`), but realized that we didn't actually include any instructions when running `av stack reorder`, so I added that.

Now, when editing a reorder plan, it looks like:
```
stack-branch 2023-10-20-blegg-1 --trunk main@49331c9878615a5227fe56ede8521f7e5d8462e7  # this branch has no commits

# Instructions:
#
# Commands:
# sb, stack-branch <branch-name> [--parent <parent-branch-name> | --trunk <trunk-branch-name>]
#         Create a new branch as part of a stack. If parent is not specified,
#         the previous branch in the stack is used (if any). If trunk is
#         specified, the branch is rooted from the given branch.
#         trunk-branch-name can be either a branch name or a branch name with a
#         commit ID in the format "<branch-name>@<commit-id>".
# p, pick <commit-id>
#         Pick a commit to be included in the stack. Only valid after a
#         stack-branch command.
```

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
