### PR TITLE
fix: Use upper/lowercase to find pull request template

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -460,12 +460,18 @@ var prBodyTemplate = template.Must(
 )
 
 func readDefaultPullRequestTemplate(repo *git.Repo) string {
-	tpl := filepath.Join(repo.Dir(), ".github", "PULL_REQUEST_TEMPLATE.md")
-	data, err := os.ReadFile(tpl)
-	if err != nil {
-		return ""
+	for _, f := range []string{
+		"PULL_REQUEST_TEMPLATE.md",
+		"pull_request_template.md",
+	} {
+		tpl := filepath.Join(repo.Dir(), ".github", f)
+		data, err := os.ReadFile(tpl)
+		if err != nil {
+			continue
+		}
+		return string(data)
 	}
-	return string(data)
+	return ""
 }
 
 type ensurePROpts struct {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
