### PR TITLE
[MER-3206] Fix github.baseURL configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,8 +8,13 @@ import (
 )
 
 type GitHub struct {
-	Token   string
-	BaseUrl string
+	// The GitHub API token to use for authenticating to the GitHub API.
+	Token string
+	// The base URL of the GitHub instance to use.
+	// This should only be set for GitHub Enterprise Server (GHES) instances.
+	// For example, "https://github.mycompany.com/" (without a "/api/v3" or
+	// "/api/graphql" suffix).
+	BaseURL string
 }
 
 type PullRequest struct {
@@ -50,9 +55,7 @@ var Av = struct {
 	PullRequest: PullRequest{
 		OpenBrowser: true,
 	},
-	GitHub: GitHub{
-		BaseUrl: "https://github.com",
-	},
+	GitHub: GitHub{},
 }
 
 // Load initializes the configuration values.

--- a/internal/gh/client.go
+++ b/internal/gh/client.go
@@ -38,7 +38,7 @@ func NewClient(token string) (*Client, error) {
 	if config.Av.GitHub.BaseURL == "" {
 		gh = githubv4.NewClient(httpClient)
 	} else {
-		gh = githubv4.NewEnterpriseClient(config.Av.GitHub.BaseURL+"/graphql", httpClient)
+		gh = githubv4.NewEnterpriseClient(config.Av.GitHub.BaseURL+"/api/graphql", httpClient)
 	}
 	return &Client{httpClient, gh}, nil
 }
@@ -109,7 +109,7 @@ func (c *Client) restPost(
 	if config.Av.GitHub.BaseURL == "" {
 		url = githubCloudApiBaseUrl + endpoint
 	} else {
-		url = config.Av.GitHub.BaseURL + "/v3" + endpoint
+		url = config.Av.GitHub.BaseURL + "/api/v3" + endpoint
 	}
 
 	log := logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
Fixes #215.

We're taking the base URL from the global config object which might not be suuuuper ideal but this is all internal code anyway.

Unfortunately, I don't have a way to test against a GHES instance but this *should* work.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
