### PR TITLE
Add root and data/ as PR template paths

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -460,11 +460,11 @@ var prBodyTemplate = template.Must(
 )
 
 func readDefaultPullRequestTemplate(repo *git.Repo) string {
-	for _, f := range []string{
-		"PULL_REQUEST_TEMPLATE.md",
-		"pull_request_template.md",
-	} {
-		for _, dir := range []string{"", ".github", "data"} {
+	for _, dir := range []string{"", ".github", "data"} {
+		for _, f := range []string{
+			"PULL_REQUEST_TEMPLATE.md",
+			"pull_request_template.md",
+		} {
 			tpl := filepath.Join(repo.Dir(), dir, f)
 			data, err := os.ReadFile(tpl)
 			if err != nil {

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -464,12 +464,14 @@ func readDefaultPullRequestTemplate(repo *git.Repo) string {
 		"PULL_REQUEST_TEMPLATE.md",
 		"pull_request_template.md",
 	} {
-		tpl := filepath.Join(repo.Dir(), ".github", f)
-		data, err := os.ReadFile(tpl)
-		if err != nil {
-			continue
+		for _, dir := range []string{"", ".github", "data"} {
+			tpl := filepath.Join(repo.Dir(), dir, f)
+			data, err := os.ReadFile(tpl)
+			if err != nil {
+				continue
+			}
+			return string(data)
 		}
-		return string(data)
 	}
 	return ""
 }


### PR DESCRIPTION
## Overview
Add `root` and `data/` as default PR template paths, in addition to `.github/`. These are common paths mentioned in the [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template) for creating PR templates.

## Test Plan
Created a test repro with `pull_request_template.md` in the root and verified that it's picked up when calling `av pr create`

```
❯ go run ./cmd/av -C /Users/andrew/dev/projects/test pr create
```
```
%% Creating pull request for branch 'foo'
%% Lines starting with '%%' will be ignored and an empty message aborts the
%% creation of the pull request.

%% Pull request title (single line)
Hello world

%% Pull request body (multiple lines)
A test PR template


%% This branch includes the following commits:
%%     8e34ff9    Hello world
```

fixes #219