### PR TITLE
[MER-3360] Run av stack tidy on av stack sync

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -59,6 +59,10 @@ base branch.
 		if err != nil {
 			return err
 		}
+		if _, err = actions.TidyDB(repo, db); err != nil {
+			return err
+		}
+
 		tx := db.WriteTx()
 		defer tx.Abort()
 

--- a/cmd/av/stack_tidy.go
+++ b/cmd/av/stack_tidy.go
@@ -5,8 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aviator-co/av/internal/git"
-	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/aviator-co/av/internal/utils/textutils"
 	"github.com/spf13/cobra"
@@ -34,39 +33,9 @@ does not delete Git branches.
 		if err != nil {
 			return err
 		}
-		tx := db.WriteTx()
-		defer tx.Abort()
-		origBranches := tx.AllBranches()
-		branches := make(map[string]*meta.Branch)
-		for name, br := range origBranches {
-			// origBranches has values, not references. Convert to references so that we
-			// can modify them through references.
-			b := br
-			branches[name] = &b
-		}
 
-		newParents := findNonDeletedParents(repo, branches)
-		for name, br := range branches {
-			if _, deleted := newParents[name]; deleted {
-				// This branch is merged/deleted. Do not have to change the parent.
-				continue
-			}
-			if newParent, ok := newParents[br.Parent.Name]; ok {
-				br.Parent = newParent
-			}
-		}
-
-		nDeleted := 0
-		for name, br := range branches {
-			if _, deleted := newParents[name]; deleted {
-				tx.DeleteBranch(name)
-				nDeleted += 1
-				continue
-			}
-			tx.SetBranch(*br)
-		}
-
-		if err := tx.Commit(); err != nil {
+		nDeleted, err := actions.TidyDB(repo, db)
+		if err != nil {
 			return err
 		}
 
@@ -81,28 +50,4 @@ does not delete Git branches.
 		}
 		return nil
 	},
-}
-
-// findNonDeletedParents finds the non-deleted/merged branch for each deleted/merged branches.
-func findNonDeletedParents(
-	repo *git.Repo,
-	branches map[string]*meta.Branch,
-) map[string]meta.BranchState {
-	deleted := make(map[string]bool)
-	for name := range branches {
-		if _, err := repo.Git("show-ref", "refs/heads/"+name); err != nil {
-			// Ref doesn't exist. Should be removed.
-			deleted[name] = true
-		}
-	}
-
-	liveParents := make(map[string]meta.BranchState)
-	for name := range deleted {
-		state := branches[name].Parent
-		for !state.Trunk && deleted[state.Name] {
-			state = branches[state.Name].Parent
-		}
-		liveParents[name] = state
-	}
-	return liveParents
 }

--- a/cmd/av/stack_tidy.go
+++ b/cmd/av/stack_tidy.go
@@ -89,10 +89,8 @@ func findNonDeletedParents(
 	branches map[string]*meta.Branch,
 ) map[string]meta.BranchState {
 	deleted := make(map[string]bool)
-	for name, br := range branches {
-		if br.MergeCommit != "" {
-			deleted[name] = true
-		} else if _, err := repo.Git("show-ref", "refs/heads/"+name); err != nil {
+	for name := range branches {
+		if _, err := repo.Git("show-ref", "refs/heads/"+name); err != nil {
 			// Ref doesn't exist. Should be removed.
 			deleted[name] = true
 		}

--- a/internal/actions/tidy.go
+++ b/internal/actions/tidy.go
@@ -1,0 +1,71 @@
+package actions
+
+import (
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+)
+
+// TidyDB removes deleted branches from the metadata and returns number of branches removed from the
+// DB.
+func TidyDB(repo *git.Repo, db meta.DB) (int, error) {
+	tx := db.WriteTx()
+	defer tx.Abort()
+	origBranches := tx.AllBranches()
+	branches := make(map[string]*meta.Branch)
+	for name, br := range origBranches {
+		// origBranches has values, not references. Convert to references so that we
+		// can modify them through references.
+		b := br
+		branches[name] = &b
+	}
+
+	newParents := findNonDeletedParents(repo, branches)
+	for name, br := range branches {
+		if _, deleted := newParents[name]; deleted {
+			// This branch is merged/deleted. Do not have to change the parent.
+			continue
+		}
+		if newParent, ok := newParents[br.Parent.Name]; ok {
+			br.Parent = newParent
+		}
+	}
+
+	nDeleted := 0
+	for name, br := range branches {
+		if _, deleted := newParents[name]; deleted {
+			tx.DeleteBranch(name)
+			nDeleted += 1
+			continue
+		}
+		tx.SetBranch(*br)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return nDeleted, nil
+}
+
+// findNonDeletedParents finds the non-deleted/merged branch for each deleted/merged branches.
+func findNonDeletedParents(
+	repo *git.Repo,
+	branches map[string]*meta.Branch,
+) map[string]meta.BranchState {
+	deleted := make(map[string]bool)
+	for name := range branches {
+		if _, err := repo.Git("show-ref", "refs/heads/"+name); err != nil {
+			// Ref doesn't exist. Should be removed.
+			deleted[name] = true
+		}
+	}
+
+	liveParents := make(map[string]meta.BranchState)
+	for name := range deleted {
+		state := branches[name].Parent
+		for !state.Trunk && deleted[state.Name] {
+			state = branches[state.Name].Parent
+		}
+		liveParents[name] = state
+	}
+	return liveParents
+}


### PR DESCRIPTION
I think this should happen automatically on av stack sync. Otherwise, av
stack sync will result in an error that it cannot find a branch in the
repository.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"tidy_no_delete_merged","parentHead":"a5ed69e772783eb345e63663cfdf1987e698180d","parentPull":222,"trunk":"master"}
```
-->
