### PR TITLE
[MER-3361] Do not delete the branchmeta for the merged branches in tidy

### DIFF
--- a/cmd/av/stack_tidy.go
+++ b/cmd/av/stack_tidy.go
@@ -89,10 +89,8 @@ func findNonDeletedParents(
 	branches map[string]*meta.Branch,
 ) map[string]meta.BranchState {
 	deleted := make(map[string]bool)
-	for name, br := range branches {
-		if br.MergeCommit != "" {
-			deleted[name] = true
-		} else if _, err := repo.Git("show-ref", "refs/heads/"+name); err != nil {
+	for name := range branches {
+		if _, err := repo.Git("show-ref", "refs/heads/"+name); err != nil {
 			// Ref doesn't exist. Should be removed.
 			deleted[name] = true
 		}


### PR DESCRIPTION
Happened to find this bug. We should not delete branchmeta until the
actual git-branch is pruned, which is done in av stack sync. Otherwise,
this screws up sync.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
