### PR TITLE
[MER-3336] Make sure that the flags are in the right combination

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -50,6 +50,12 @@ base branch.
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
+		if stackSyncFlags.Trunk && stackSyncFlags.NoFetch {
+			return errors.New("--trunk requires git-fetch to re-root the stacks")
+		}
+		if !stackSyncFlags.NoPush && stackSyncFlags.NoFetch {
+			return errors.New("--no-fetch requires --no-push as git-push requires git-fetch")
+		}
 
 		repo, err := getRepo()
 		if err != nil {


### PR DESCRIPTION
We need to do git-fetch & GitHub API calls before rebasing so that we
can make all PRs draft at once instead of doing so one by one. Towards
that end, this change makes sure that the fetch related flags are set in
the right combination.

* When rebasing the stack roots, it needs to fetch from remote.
* When pushing branches, it needs to fetch.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"tidy_on_sync","parentHead":"f14608228818426bd5e478fe15f6f24f4635234f","parentPull":221,"trunk":"master"}
```
-->
