### PR TITLE
Introducing BranchNamePrefix

### DIFF
--- a/cmd/av/stack_branchcommit.go
+++ b/cmd/av/stack_branchcommit.go
@@ -8,6 +8,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
+	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/cleanup"
@@ -224,5 +225,8 @@ func branchNameFromMessage(message string) string {
 		name = name[:branchNameLength]
 	}
 	name = strings.ToLower(name)
+	if config.Av.PullRequest.BranchNameSuffix != "" {
+		name = fmt.Sprintf("%s%s", config.Av.PullRequest.BranchNameSuffix, name)
+	}
 	return name
 }

--- a/cmd/av/stack_branchcommit.go
+++ b/cmd/av/stack_branchcommit.go
@@ -225,8 +225,8 @@ func branchNameFromMessage(message string) string {
 		name = name[:branchNameLength]
 	}
 	name = strings.ToLower(name)
-	if config.Av.PullRequest.BranchNameSuffix != "" {
-		name = fmt.Sprintf("%s%s", config.Av.PullRequest.BranchNameSuffix, name)
+	if config.Av.PullRequest.BranchNamePrefix != "" {
+		name = fmt.Sprintf("%s%s", config.Av.PullRequest.BranchNamePrefix, name)
 	}
 	return name
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ type PullRequest struct {
 	NoWIPDetection bool
 
 	// Branch prefix to use for creating new branches.
-	BranchNameSuffix string
+	BranchNamePrefix string
 }
 
 type Aviator struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,9 @@ type PullRequest struct {
 	// By default, when the pull request title contains "WIP", it automatically sets the PR as
 	// a draft PR. Setting this to true suppresses this behavior.
 	NoWIPDetection bool
+
+	// Branch prefix to use for creating new branches.
+	BranchNameSuffix string
 }
 
 type Aviator struct {


### PR DESCRIPTION
Resolves #227 
To add a branch name prefix, set the following config:
```
pullRequest:
    branchNamePrefix: "av/"
```
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
