### PR TITLE
[MER-3757] Use the proper branch name for getting a list of commits

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -252,7 +252,7 @@ func CreatePullRequest(
 		prCompareRef = "origin/" + parentState.Name
 	}
 
-	commitsList, err := repo.Git("rev-list", "--reverse", fmt.Sprintf("%s..HEAD", prCompareRef))
+	commitsList, err := repo.Git("rev-list", "--reverse", fmt.Sprintf("%s..%s", prCompareRef, opts.BranchName))
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to determine commits to include in PR")
 	}


### PR DESCRIPTION
HEAD points to the currently checked out ref. Use the right branch name.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
