### PR TITLE
Calculate the merge base based on the remote tracking branch

### DIFF
--- a/internal/reorder/plan.go
+++ b/internal/reorder/plan.go
@@ -29,7 +29,7 @@ func CreatePlan(repo *git.Repo, tx meta.ReadTx, rootBranch string) ([]Cmd, error
 			upstreamCommit = branch.Parent.Head
 		} else {
 			trunkCommit, err := repo.MergeBase(&git.MergeBase{
-				Revs: []string{branchName, branch.Parent.Name},
+				Revs: []string{branchName, "origin/" + branch.Parent.Name},
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
The local `master` might be behind the remote `master` branch. Because
of this, many unrelated commits are shown in `av stack reorder`. Use the
remote tracking branch (assuming it exists) to calculate the merge base.

Fixes #249

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
