### PR TITLE
Don't fetch/push upstack branches on av commit create/amend

### DIFF
--- a/cmd/av/commit_amend.go
+++ b/cmd/av/commit_amend.go
@@ -78,7 +78,7 @@ var commitAmendCmd = &cobra.Command{
 		// Even if it's not configured, there's no need to fetch/push
 		state.Config.NoFetch = true
 		state.Config.NoPush = true
-		err = actions.SyncStack(ctx, repo, client, tx, branchesToSync, state)
+		err = actions.SyncStack(ctx, repo, client, tx, branchesToSync, state, actions.WithLocalOnly())
 		if err != nil {
 			return err
 		}

--- a/cmd/av/commit_create.go
+++ b/cmd/av/commit_create.go
@@ -94,7 +94,7 @@ func commitCreate(repo *git.Repo, currentBranchName string, flags struct {
 
 	branchesToSync := meta.SubsequentBranches(tx, currentBranchName)
 
-	err = actions.SyncStack(ctx, repo, client, tx, branchesToSync, state)
+	err = actions.SyncStack(ctx, repo, client, tx, branchesToSync, state, actions.WithLocalOnly())
 	if err != nil {
 		return err
 	}

--- a/e2e_tests/commit_amend_test.go
+++ b/e2e_tests/commit_amend_test.go
@@ -1,0 +1,49 @@
+package e2e_tests
+
+import (
+	"testing"
+
+	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta/jsonfiledb"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func TestCommitAmendInStack(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.Dir())
+	RequireCmd(t, "git", "fetch")
+	initialTimestamp := GetFetchHeadTimestamp(t, repo)
+
+	// Create a branch and commit a file.
+	filepath := gittest.CreateFile(t, repo, "one.txt", []byte("one"))
+	gittest.AddFile(t, repo, filepath)
+	RequireAv(t, "stack", "branch", "one")
+	RequireAv(t, "commit", "create", "-m", "one")
+
+	// Create another branch and commit a file.
+	filepath = gittest.CreateFile(t, repo, "two.txt", []byte("two"))
+	gittest.AddFile(t, repo, filepath)
+	RequireAv(t, "stack", "branch", "two")
+	RequireAv(t, "commit", "create", "-m", "two")
+
+	// Go back to the first branch and amend the commit with another file.
+	RequireCmd(t, "git", "checkout", "one")
+	filepath = gittest.CreateFile(t, repo, "one-b.txt", []byte("one-b"))
+	gittest.AddFile(t, repo, filepath)
+	RequireAv(t, "commit", "amend", "--no-edit")
+
+	// Verify that the branches are still there.
+	db, err := jsonfiledb.OpenRepo(repo)
+	require.NoError(t, err, "failed to open repo db")
+	branchNames := maps.Keys(db.ReadTx().AllBranches())
+	require.ElementsMatch(t, branchNames, []string{"one", "two"})
+
+	// Commit shouldn't have triggered a fetch.
+	updatedTimestamp := GetFetchHeadTimestamp(t, repo)
+	require.Equal(t, initialTimestamp, updatedTimestamp)
+
+	// It also shouldn't have triggered a push.
+	// TODO: once we support mocking the GitHub API and there is an associated PR,
+	// validate that a push didn't happen.
+}

--- a/e2e_tests/commit_create_test.go
+++ b/e2e_tests/commit_create_test.go
@@ -1,0 +1,49 @@
+package e2e_tests
+
+import (
+	"testing"
+
+	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta/jsonfiledb"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func TestCommitCreateInStack(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.Dir())
+	RequireCmd(t, "git", "fetch")
+	initialTimestamp := GetFetchHeadTimestamp(t, repo)
+
+	// Create a branch and commit a file.
+	filepath := gittest.CreateFile(t, repo, "one.txt", []byte("one"))
+	gittest.AddFile(t, repo, filepath)
+	RequireAv(t, "stack", "branch", "one")
+	RequireAv(t, "commit", "create", "-m", "one")
+
+	// Create another branch and commit a file.
+	filepath = gittest.CreateFile(t, repo, "two.txt", []byte("two"))
+	gittest.AddFile(t, repo, filepath)
+	RequireAv(t, "stack", "branch", "two")
+	RequireAv(t, "commit", "create", "-m", "two")
+
+	// Go back to the first branch and commit another file.
+	RequireCmd(t, "git", "checkout", "one")
+	filepath = gittest.CreateFile(t, repo, "one-b.txt", []byte("one-b"))
+	gittest.AddFile(t, repo, filepath)
+	RequireAv(t, "commit", "create", "-m", "one-b")
+
+	// Verify that the branches are still there.
+	db, err := jsonfiledb.OpenRepo(repo)
+	require.NoError(t, err, "failed to open repo db")
+	branchNames := maps.Keys(db.ReadTx().AllBranches())
+	require.ElementsMatch(t, branchNames, []string{"one", "two"})
+
+	// Commit shouldn't have triggered a fetch.
+	updatedTimestamp := GetFetchHeadTimestamp(t, repo)
+	require.Equal(t, initialTimestamp, updatedTimestamp)
+
+	// It also shouldn't have triggered a push.
+	// TODO: once we support mocking the GitHub API and there is an associated PR,
+	// validate that a push didn't happen.
+}

--- a/e2e_tests/helpers.go
+++ b/e2e_tests/helpers.go
@@ -1,7 +1,9 @@
 package e2e_tests
 
 import (
+	"os"
 	"testing"
+	"time"
 
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
@@ -20,6 +22,12 @@ func RequireCurrentBranchName(t *testing.T, repo *git.Repo, name string) {
 		name,
 		currentBranch,
 	)
+}
+
+func GetFetchHeadTimestamp(t *testing.T, repo *git.Repo) time.Time {
+	fileInfo, err := os.Stat(repo.Dir() + "/.git/FETCH_HEAD")
+	require.NoError(t, err, "failed to stat .git/FETCH_HEAD")
+	return fileInfo.ModTime()
 }
 
 func GetStoredParentBranchState(t *testing.T, repo *git.Repo, name string) meta.BranchState {

--- a/internal/actions/sync_stack.go
+++ b/internal/actions/sync_stack.go
@@ -59,12 +59,19 @@ type (
 	SyncStackOpt  func(*syncStackOpts)
 	syncStackOpts struct {
 		skipNextCommit bool
+		localOnly      bool
 	}
 )
 
 func WithSkipNextCommit() SyncStackOpt {
 	return func(opts *syncStackOpts) {
 		opts.skipNextCommit = true
+	}
+}
+
+func WithLocalOnly() SyncStackOpt {
+	return func(opts *syncStackOpts) {
+		opts.localOnly = true
 	}
 }
 
@@ -92,8 +99,8 @@ func SyncStack(ctx context.Context,
 		state.CurrentBranch = currentBranch
 		cont, err := SyncBranch(ctx, repo, client, tx, SyncBranchOpts{
 			Branch:       currentBranch,
-			Fetch:        !state.Config.NoFetch,
-			Push:         !state.Config.NoPush,
+			Fetch:        !state.Config.NoFetch && !opts.localOnly,
+			Push:         !state.Config.NoPush && !opts.localOnly,
 			Continuation: state.Continuation,
 			ToTrunk:      state.Config.Trunk,
 			Skip:         skip,

--- a/internal/git/gittest/commit.go
+++ b/internal/git/gittest/commit.go
@@ -2,8 +2,6 @@ package gittest
 
 import (
 	"fmt"
-	"os"
-	"path"
 	"testing"
 
 	"github.com/aviator-co/av/internal/git"
@@ -43,18 +41,14 @@ func CommitFile(
 		o(&opts)
 	}
 
-	filepath := path.Join(repo.Dir(), filename)
-	err := os.WriteFile(filepath, body, 0644)
-	require.NoError(t, err, "failed to write file: %s", filename)
-
-	_, err = repo.Git("add", filepath)
-	require.NoError(t, err, "failed to add file: %s", filename)
+	filepath := CreateFile(t, repo, filename, body)
+	AddFile(t, repo, filepath)
 
 	args := []string{"commit", "-m", opts.msg}
 	if opts.amend {
 		args = append(args, "--amend")
 	}
-	_, err = repo.Git(args...)
+	_, err := repo.Git(args...)
 	require.NoError(t, err, "failed to commit file: %s", filename)
 
 	head, err := repo.RevParse(&git.RevParse{Rev: "HEAD"})

--- a/internal/git/gittest/files.go
+++ b/internal/git/gittest/files.go
@@ -1,0 +1,31 @@
+package gittest
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/aviator-co/av/internal/git"
+	"github.com/stretchr/testify/require"
+)
+
+func CreateFile(
+	t *testing.T,
+	repo *git.Repo,
+	filename string,
+	body []byte,
+) string {
+	filepath := path.Join(repo.Dir(), filename)
+	err := os.WriteFile(filepath, body, 0644)
+	require.NoError(t, err, "failed to write file: %s", filename)
+	return filepath
+}
+
+func AddFile(
+	t *testing.T,
+	repo *git.Repo,
+	filepath string,
+) {
+	_, err := repo.Git("add", filepath)
+	require.NoError(t, err, "failed to add file: %s", filepath)
+}


### PR DESCRIPTION
Currently, `av commit create` and `av commit amend` will sync dependent branches. This also ends up fetching and pushing to the remote in the process, which isn't expected as the remote gets out of sync as the head branch remains unpushed. Syncing with the remote repo ought to happen separately with `av stack sync`.

Also added some end to end tests for these commands.

Closes #263.