### PR TITLE
Move stack helpers to separate module for reuse

### DIFF
--- a/cmd/av/stack_tree.go
+++ b/cmd/av/stack_tree.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
-	"github.com/aviator-co/av/internal/git"
-	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/stackutils"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -39,23 +37,7 @@ var stackTreeCmd = &cobra.Command{
 			}
 		}
 
-		trunks := map[string]bool{}
-		var branches []*stackTreeBranchInfo
-		for _, branch := range tx.AllBranches() {
-			branches = append(branches, getBranchInfo(repo, branch))
-			if branch.Parent.Trunk {
-				trunks[branch.Parent.Name] = true
-			}
-		}
-		for branch := range trunks {
-			branches = append(branches, &stackTreeBranchInfo{
-				branchName:       branch,
-				parentBranchName: "",
-				needSync:         false,
-				deleted:          false,
-			})
-		}
-		rootNodes := buildTree(currentBranch, branches)
+		rootNodes := stackutils.BuildStackTree(repo, tx, currentBranch)
 		for _, node := range rootNodes {
 			printNode(0, currentBranch, true, node)
 		}
@@ -63,147 +45,22 @@ var stackTreeCmd = &cobra.Command{
 	},
 }
 
-type stackTreeBranchInfo struct {
-	branchName       string
-	parentBranchName string
-	pullRequestLink  string
-	needSync         bool
-	deleted          bool
-}
-
-func getBranchInfo(repo *git.Repo, branch meta.Branch) *stackTreeBranchInfo {
-	branchInfo := stackTreeBranchInfo{
-		branchName:       branch.Name,
-		parentBranchName: branch.Parent.Name,
-	}
-	if branch.PullRequest != nil && branch.PullRequest.Permalink != "" {
-		branchInfo.pullRequestLink = branch.PullRequest.Permalink
-	}
-	if _, err := repo.RevParse(&git.RevParse{Rev: branch.Name}); err != nil {
-		branchInfo.deleted = true
-	}
-
-	parentHead, err := repo.RevParse(&git.RevParse{Rev: branch.Parent.Name})
-	if err != nil {
-		// The parent branch doesn't exist.
-		branchInfo.needSync = true
-	} else {
-		mergeBase, err := repo.MergeBase(&git.MergeBase{
-			Revs: []string{parentHead, branch.Name},
-		})
-		if err != nil {
-			// The merge base doesn't exist. This is odd. Mark the branch as needing
-			// sync to see if we can fix this.
-			branchInfo.needSync = true
-		}
-		if mergeBase != parentHead {
-			// This branch is not on top of the parent branch. Need sync.
-			branchInfo.needSync = true
-		}
-	}
-
-	upstreamExists, err := repo.DoesRemoteBranchExist(branch.Name)
-	if err != nil || !upstreamExists {
-		// Not pushed.
-		branchInfo.needSync = true
-	}
-	upstreamBranch := fmt.Sprintf("remotes/origin/%s", branch.Name)
-	upstreamDiff, err := repo.Diff(&git.DiffOpts{
-		Quiet:      true,
-		Specifiers: []string{branch.Name, upstreamBranch},
-	})
-	if err != nil || !upstreamDiff.Empty {
-		branchInfo.needSync = true
-	}
-	return &branchInfo
-}
-
-type stackTreeNode struct {
-	branch   *stackTreeBranchInfo
-	children []*stackTreeNode
-}
-
-func buildTree(currentBranchName string, branches []*stackTreeBranchInfo) []*stackTreeNode {
-	childBranches := make(map[string][]string)
-	branchMap := make(map[string]*stackTreeNode)
-	for _, branch := range branches {
-		branchMap[branch.branchName] = &stackTreeNode{branch: branch}
-		childBranches[branch.parentBranchName] = append(childBranches[branch.parentBranchName], branch.branchName)
-	}
-	for _, branch := range branches {
-		node := branchMap[branch.branchName]
-		for _, childBranch := range childBranches[branch.branchName] {
-			node.children = append(node.children, branchMap[childBranch])
-		}
-	}
-
-	// Find the root branches.
-	var rootBranches []*stackTreeNode
-	for _, branch := range branches {
-		if branch.parentBranchName == "" || branchMap[branch.parentBranchName] == nil {
-			rootBranches = append(rootBranches, branchMap[branch.branchName])
-		}
-	}
-
-	// Find the path that contains the current branch.
-	currentBranchPath := make(map[string]bool)
-	var currentBranchVisitFn func(node *stackTreeNode) bool
-	currentBranchVisitFn = func(node *stackTreeNode) bool {
-		if node.branch.branchName == currentBranchName {
-			currentBranchPath[node.branch.branchName] = true
-			return true
-		}
-		for _, child := range node.children {
-			if currentBranchVisitFn(child) {
-				currentBranchPath[node.branch.branchName] = true
-				return true
-			}
-		}
-		return false
-	}
-	for _, rootBranch := range rootBranches {
-		currentBranchVisitFn(rootBranch)
-	}
-	for _, node := range branchMap {
-		// Visit the current branch first. Otherwise, use alphabetical order for the initial ones.
-		sort.Slice(node.children, func(i, j int) bool {
-			if currentBranchPath[node.children[i].branch.branchName] {
-				return true
-			}
-			if currentBranchPath[node.children[j].branch.branchName] {
-				return false
-			}
-			return node.children[i].branch.branchName < node.children[j].branch.branchName
-		})
-	}
-	sort.Slice(rootBranches, func(i, j int) bool {
-		if currentBranchPath[rootBranches[i].branch.branchName] {
-			return true
-		}
-		if currentBranchPath[rootBranches[j].branch.branchName] {
-			return false
-		}
-		return rootBranches[i].branch.branchName < rootBranches[j].branch.branchName
-	})
-	return rootBranches
-}
-
-func printNode(columns int, currentBranchName string, isTrunk bool, node *stackTreeNode) {
-	for i, child := range node.children {
+func printNode(columns int, currentBranchName string, isTrunk bool, node *stackutils.StackTreeNode) {
+	for i, child := range node.Children {
 		printNode(columns+i, currentBranchName, false, child)
 	}
-	if len(node.children) > 1 {
+	if len(node.Children) > 1 {
 		fmt.Print(" ")
 		for i := 0; i < columns; i++ {
 			fmt.Print(" │")
 		}
 		fmt.Print(" ├")
-		for i := 0; i < len(node.children)-2; i++ {
+		for i := 0; i < len(node.Children)-2; i++ {
 			fmt.Print("─┴")
 		}
 		fmt.Print("─┘")
 		fmt.Println()
-	} else if len(node.children) == 1 {
+	} else if len(node.Children) == 1 {
 		fmt.Print(" ")
 		for i := 0; i < columns+1; i++ {
 			fmt.Print(" │")
@@ -222,16 +79,16 @@ func printNode(columns int, currentBranchName string, isTrunk bool, node *stackT
 		fmt.Print(" │")
 	}
 	fmt.Print(" *")
-	branch := node.branch
-	fmt.Printf(" %s", boldString(color.GreenString(branch.branchName)))
+	branch := node.Branch
+	fmt.Printf(" %s", boldString(color.GreenString(branch.BranchName)))
 	var stats []string
-	if branch.branchName == currentBranchName {
+	if branch.BranchName == currentBranchName {
 		stats = append(stats, boldString(color.CyanString("HEAD")))
 	}
-	if branch.deleted {
+	if branch.Deleted {
 		stats = append(stats, boldString(color.RedString("deleted")))
 	}
-	if branch.needSync {
+	if branch.NeedSync {
 		stats = append(stats, boldString(color.RedString("need sync")))
 	}
 	if len(stats) > 0 {
@@ -246,8 +103,8 @@ func printNode(columns int, currentBranchName string, isTrunk bool, node *stackT
 		for i := 0; i < columns+1; i++ {
 			fmt.Print(" │")
 		}
-		if branch.pullRequestLink != "" {
-			fmt.Print(" " + color.HiBlackString(branch.pullRequestLink))
+		if branch.PullRequestLink != "" {
+			fmt.Print(" " + color.HiBlackString(branch.PullRequestLink))
 		} else {
 			fmt.Print(" No pull request")
 		}

--- a/internal/utils/stackutils/stackutils.go
+++ b/internal/utils/stackutils/stackutils.go
@@ -1,0 +1,159 @@
+package stackutils
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+)
+
+type stackTreeBranchInfo struct {
+	BranchName      string
+	Deleted         bool
+	NeedSync        bool
+	PullRequestLink string
+
+	parentBranchName string
+}
+
+type StackTreeNode struct {
+	Branch   *stackTreeBranchInfo
+	Children []*StackTreeNode
+}
+
+func buildTree(currentBranchName string, branches []*stackTreeBranchInfo) []*StackTreeNode {
+	childBranches := make(map[string][]string)
+	branchMap := make(map[string]*StackTreeNode)
+	for _, branch := range branches {
+		branchMap[branch.BranchName] = &StackTreeNode{Branch: branch}
+		childBranches[branch.parentBranchName] = append(childBranches[branch.parentBranchName], branch.BranchName)
+	}
+	for _, branch := range branches {
+		node := branchMap[branch.BranchName]
+		for _, childBranch := range childBranches[branch.BranchName] {
+			node.Children = append(node.Children, branchMap[childBranch])
+		}
+	}
+
+	// Find the root branches.
+	var rootBranches []*StackTreeNode
+	for _, branch := range branches {
+		if branch.parentBranchName == "" || branchMap[branch.parentBranchName] == nil {
+			rootBranches = append(rootBranches, branchMap[branch.BranchName])
+		}
+	}
+
+	// Find the path that contains the current branch.
+	currentBranchPath := make(map[string]bool)
+	var currentBranchVisitFn func(node *StackTreeNode) bool
+	currentBranchVisitFn = func(node *StackTreeNode) bool {
+		if node.Branch.BranchName == currentBranchName {
+			currentBranchPath[node.Branch.BranchName] = true
+			return true
+		}
+		for _, child := range node.Children {
+			if currentBranchVisitFn(child) {
+				currentBranchPath[node.Branch.BranchName] = true
+				return true
+			}
+		}
+		return false
+	}
+	for _, rootBranch := range rootBranches {
+		currentBranchVisitFn(rootBranch)
+	}
+	for _, node := range branchMap {
+		// Visit the current branch first. Otherwise, use alphabetical order for the initial ones.
+		sort.Slice(node.Children, func(i, j int) bool {
+			if currentBranchPath[node.Children[i].Branch.BranchName] {
+				return true
+			}
+			if currentBranchPath[node.Children[j].Branch.BranchName] {
+				return false
+			}
+			return node.Children[i].Branch.BranchName < node.Children[j].Branch.BranchName
+		})
+	}
+	sort.Slice(rootBranches, func(i, j int) bool {
+		if currentBranchPath[rootBranches[i].Branch.BranchName] {
+			return true
+		}
+		if currentBranchPath[rootBranches[j].Branch.BranchName] {
+			return false
+		}
+		return rootBranches[i].Branch.BranchName < rootBranches[j].Branch.BranchName
+	})
+	return rootBranches
+}
+
+func BuildStackTree(repo *git.Repo, tx meta.ReadTx, currentBranch string) []*StackTreeNode {
+	return buildStackTree(repo, currentBranch, tx.AllBranches())
+}
+
+func buildStackTree(repo *git.Repo, currentBranch string, branchesToInclude map[string]meta.Branch) []*StackTreeNode {
+	trunks := map[string]bool{}
+	var branches []*stackTreeBranchInfo
+	for _, branch := range branchesToInclude {
+		branches = append(branches, getBranchInfo(repo, branch))
+		if branch.Parent.Trunk {
+			trunks[branch.Parent.Name] = true
+		}
+	}
+	for branch := range trunks {
+		branches = append(branches, &stackTreeBranchInfo{
+			BranchName:       branch,
+			parentBranchName: "",
+			NeedSync:         false,
+			Deleted:          false,
+		})
+	}
+	return buildTree(currentBranch, branches)
+}
+
+func getBranchInfo(repo *git.Repo, branch meta.Branch) *stackTreeBranchInfo {
+	branchInfo := stackTreeBranchInfo{
+		BranchName:       branch.Name,
+		parentBranchName: branch.Parent.Name,
+	}
+	if branch.PullRequest != nil && branch.PullRequest.Permalink != "" {
+		branchInfo.PullRequestLink = branch.PullRequest.Permalink
+	}
+	if _, err := repo.RevParse(&git.RevParse{Rev: branch.Name}); err != nil {
+		branchInfo.Deleted = true
+	}
+
+	parentHead, err := repo.RevParse(&git.RevParse{Rev: branch.Parent.Name})
+	if err != nil {
+		// The parent branch doesn't exist.
+		branchInfo.NeedSync = true
+	} else {
+		mergeBase, err := repo.MergeBase(&git.MergeBase{
+			Revs: []string{parentHead, branch.Name},
+		})
+		if err != nil {
+			// The merge base doesn't exist. This is odd. Mark the branch as needing
+			// sync to see if we can fix this.
+			branchInfo.NeedSync = true
+		}
+		if mergeBase != parentHead {
+			// This branch is not on top of the parent branch. Need sync.
+			branchInfo.NeedSync = true
+		}
+	}
+
+	upstreamExists, err := repo.DoesRemoteBranchExist(branch.Name)
+	if err != nil || !upstreamExists {
+		// Not pushed.
+		branchInfo.NeedSync = true
+	}
+	upstreamBranch := fmt.Sprintf("remotes/origin/%s", branch.Name)
+	upstreamDiff, err := repo.Diff(&git.DiffOpts{
+		Quiet:      true,
+		Specifiers: []string{branch.Name, upstreamBranch},
+	})
+	if err != nil || !upstreamDiff.Empty {
+		branchInfo.NeedSync = true
+	}
+	return &branchInfo
+}


### PR DESCRIPTION
No functional changes. Move `buildTree()` and other helper functions to a new `stackutils` module, and export `BuildStackTree()` from there. We'll later reuse `buildStackTree()` there to construct the tree of nodes needed for the stack to be written to PR bodies.

See #264 for context.