### PR TITLE
Update av stack submit to open PRs in browser after entire stack is submitted

### DIFF
--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -69,7 +69,7 @@ If the --current flag is given, this command will create pull requests up to the
 		}
 
 		// ensure pull requests for each branch in the stack
-		var lastCreatedPullRequest *meta.PullRequest
+		createdPullRequestPermalinks := []string{}
 		ctx := context.Background()
 		client, err := getGitHubClient()
 		if err != nil {
@@ -90,7 +90,7 @@ If the --current flag is given, this command will create pull requests up to the
 				return err
 			}
 			if result.Created {
-				lastCreatedPullRequest = result.Branch.PullRequest
+				createdPullRequestPermalinks = append(createdPullRequestPermalinks, result.Branch.PullRequest.Permalink)
 			}
 			// make sure the base branch of the PR is up to date if it already exists
 			if !result.Created && result.Pull.BaseRefName != result.Branch.Parent.Name {
@@ -116,8 +116,10 @@ If the --current flag is given, this command will create pull requests up to the
 			}
 		}
 
-		if lastCreatedPullRequest != nil && config.Av.PullRequest.OpenBrowser {
-			actions.OpenPullRequestInBrowser(lastCreatedPullRequest.Permalink)
+		if config.Av.PullRequest.OpenBrowser {
+			for _, createdPullRequestPermalink := range createdPullRequestPermalinks {
+				actions.OpenPullRequestInBrowser(createdPullRequestPermalink)
+			}
 		}
 
 		return nil

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -69,6 +69,7 @@ If the --current flag is given, this command will create pull requests up to the
 		}
 
 		// ensure pull requests for each branch in the stack
+		var lastCreatedPullRequest *meta.PullRequest
 		ctx := context.Background()
 		client, err := getGitHubClient()
 		if err != nil {
@@ -80,12 +81,16 @@ If the --current flag is given, this command will create pull requests up to the
 			result, err := actions.CreatePullRequest(
 				ctx, repo, client, tx,
 				actions.CreatePullRequestOpts{
-					BranchName: branchName,
-					Draft:      config.Av.PullRequest.Draft,
+					BranchName:    branchName,
+					Draft:         config.Av.PullRequest.Draft,
+					NoOpenBrowser: true,
 				},
 			)
 			if err != nil {
 				return err
+			}
+			if result.Created {
+				lastCreatedPullRequest = result.Branch.PullRequest
 			}
 			// make sure the base branch of the PR is up to date if it already exists
 			if !result.Created && result.Pull.BaseRefName != result.Branch.Parent.Name {
@@ -109,6 +114,10 @@ If the --current flag is given, this command will create pull requests up to the
 			if err = actions.UpdatePullRequestsWithStack(ctx, client, repo, tx, currentStackBranches); err != nil {
 				return err
 			}
+		}
+
+		if lastCreatedPullRequest != nil && config.Av.PullRequest.OpenBrowser {
+			actions.OpenPullRequestInBrowser(lastCreatedPullRequest.Permalink)
 		}
 
 		return nil

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -46,6 +46,8 @@ type CreatePullRequestOpts struct {
 	Force bool
 	// If true, open an editor for editing the title and body
 	Edit bool
+	// If true, do not open the browser after creating the PR
+	NoOpenBrowser bool
 }
 
 type CreatePullRequestResult struct {
@@ -407,19 +409,23 @@ func CreatePullRequest(
 		colors.UserInput(pull.Permalink), "\n",
 	)
 
-	if didCreatePR && config.Av.PullRequest.OpenBrowser {
-		if err := browser.Open(pull.Permalink); err != nil {
-			_, _ = fmt.Fprint(os.Stderr,
-				"  - couldn't open browser ",
-				colors.UserInput(err),
-				" for pull request link ",
-				colors.UserInput(pull.Permalink),
-			)
-		}
+	if didCreatePR && !opts.NoOpenBrowser && config.Av.PullRequest.OpenBrowser {
+		OpenPullRequestInBrowser(pull.Permalink)
 	}
 
 	tx.SetBranch(branchMeta)
 	return &CreatePullRequestResult{didCreatePR, branchMeta, pull}, nil
+}
+
+func OpenPullRequestInBrowser(pullRequestLink string) {
+	if err := browser.Open(pullRequestLink); err != nil {
+		_, _ = fmt.Fprint(os.Stderr,
+			"  - couldn't open browser ",
+			colors.UserInput(err),
+			" for pull request link ",
+			colors.UserInput(pullRequestLink),
+		)
+	}
 }
 
 func savePRDescriptionToTemporaryFile(saveFile string, contents string) {


### PR DESCRIPTION
When run with a stack of unpushed branches, `av stack submit` ends up opening a bunch of new browser windows for each PR one by one, which is a bit disruptive. ~Since we're pushing a single stack, only open the last-created PR once completed.~ Open all the PRs at the end once created instead.