### PR TITLE
Process entire stack subtree when syncing stack

### DIFF
--- a/cmd/av/stack_foreach.go
+++ b/cmd/av/stack_foreach.go
@@ -65,12 +65,10 @@ Examples:
 			branches = meta.SubsequentBranches(tx, currentBranch)
 			branches = append([]string{currentBranch}, branches...)
 		} else {
-			branches, err = meta.PreviousBranches(tx, currentBranch)
+			branches, err = meta.StackBranches(tx, currentBranch)
 			if err != nil {
 				return err
 			}
-			branches = append(branches, currentBranch)
-			branches = append(branches, meta.SubsequentBranches(tx, currentBranch)...)
 		}
 
 		_, _ = fmt.Fprint(os.Stderr,

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -45,14 +45,21 @@ If the --current flag is given, this command will create pull requests up to the
 		if err != nil {
 			return err
 		}
-		previousBranches, err := meta.PreviousBranches(tx, currentBranch)
-		if err != nil {
-			return err
-		}
 
 		var branchesToSubmit []string
-		branchesToSubmit = append(branchesToSubmit, previousBranches...)
-		branchesToSubmit = append(branchesToSubmit, currentBranch)
+		if stackSubmitFlags.Current {
+			previousBranches, err := meta.PreviousBranches(tx, currentBranch)
+			if err != nil {
+				return err
+			}
+			branchesToSubmit = append(branchesToSubmit, previousBranches...)
+			branchesToSubmit = append(branchesToSubmit, currentBranch)
+		} else {
+			branchesToSubmit, err = meta.StackBranches(tx, currentBranch)
+			if err != nil {
+				return err
+			}
+		}
 
 		if !stackSubmitFlags.Current {
 			subsequentBranches := meta.SubsequentBranches(tx, currentBranch)

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -232,13 +232,10 @@ base branch.
 			if err != nil {
 				return err
 			}
-			branchesToSync, err = meta.PreviousBranches(tx, currentBranch)
+			branchesToSync, err = meta.StackBranches(tx, currentBranch)
 			if err != nil {
 				return err
 			}
-			branchesToSync = append(branchesToSync, currentBranch)
-			nextBranches := meta.SubsequentBranches(tx, branchesToSync[len(branchesToSync)-1])
-			branchesToSync = append(branchesToSync, nextBranches...)
 			state.Branches = branchesToSync
 		}
 		// Either way (--continue or not), we sync all subsequent branches

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -128,6 +128,18 @@ func SubsequentBranches(tx ReadTx, name string) []string {
 	return res
 }
 
+// StackBranches returns branches in the stack associated with the given branch.
+func StackBranches(tx ReadTx, name string) ([]string, error) {
+	root, found := Root(tx, name)
+	if !found {
+		return nil, errors.Errorf("branch %q is not in a stack", name)
+	}
+
+	var res = []string{root}
+	res = append(res, SubsequentBranches(tx, root)...)
+	return res, nil
+}
+
 // Root determines the stack root of a branch.
 func Root(tx ReadTx, name string) (string, bool) {
 	for name != "" {


### PR DESCRIPTION
When running `av stack sync`, sync the entire "stack" (starting from root) instead of just the subtree from the current branch.

Updated test to document new behavior.