### PR TITLE
Refactor PR body parsing

### DIFF
--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -19,9 +19,7 @@ func TestReadPRMetadata(t *testing.T) {
 	prBody := actions.AddPRMetadata("Hello! This is a cool PR that does some neat things.", prMeta)
 	fmt.Println(prBody)
 	prMeta2, err := actions.ReadPRMetadata(prBody)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Equal(t, prMeta.Parent, prMeta2.Parent)
 	assert.Equal(t, prMeta.ParentHead, prMeta2.ParentHead)
 	assert.Equal(t, prMeta.ParentPull, prMeta2.ParentPull)


### PR DESCRIPTION
As part of adding support for including the stack in PR bodies (see #264), we'll need to extend templating support to handle more than one section:

```
<!-- av pr stack begin --> { stack here } <!-- av pr stack end -->

Here is the main PR body description.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
` ` `
{"parent":"some-parent","parentHead":"abcdef","parentPull":123,"trunk":"main"}
` ` `
-->
```

The current `ParsePRMetadata()` implementation is efficient, but makes it hard to support another section.

This PR updates `ParsePRMetadata` and `AddPRMetadata` to instead make use of substrings and `strings.Builder`. Performance isn't really a concern here - these PR bodies aren't that big and we spend a lot more time interacting with the `git` CLI anyway.