### PR TITLE
Enable writing stack trees to PR bodies

### DIFF
--- a/cmd/av/pr_create.go
+++ b/cmd/av/pr_create.go
@@ -8,6 +8,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/config"
+	"github.com/aviator-co/av/internal/meta"
 	"github.com/spf13/cobra"
 )
 
@@ -102,6 +103,15 @@ Examples:
 			if err := actions.AddPullRequestReviewers(ctx, client, res.Pull.ID, prCreateFlags.Reviewers); err != nil {
 				return err
 			}
+		}
+
+		if config.Av.PullRequest.WriteStack {
+			stackBranches, err := meta.StackBranches(tx, branchName)
+			if err != nil {
+				return err
+			}
+
+			return actions.UpdatePullRequestsWithStack(ctx, client, repo, tx, stackBranches)
 		}
 
 		return nil

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -47,6 +47,10 @@ If the --current flag is given, this command will create pull requests up to the
 		}
 
 		currentStackBranches, err := meta.StackBranches(tx, currentBranch)
+		if err != nil {
+			return err
+		}
+
 		var branchesToSubmit []string
 		if stackSubmitFlags.Current {
 			previousBranches, err := meta.PreviousBranches(tx, currentBranch)

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -905,6 +905,9 @@ func UpdatePullRequestWithStack(
 	}
 
 	body, prMeta, err := ParsePRBody(existingPR.Body)
+	if err != nil {
+		return err
+	}
 
 	newBody := AddPRMetadataAndStack(body, prMeta, branchName, stackToWrite)
 	_, err = client.UpdatePullRequest(ctx, githubv4.UpdatePullRequestInput{

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/aviator-co/av/internal/utils/browser"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/aviator-co/av/internal/utils/sanitize"
+	"github.com/aviator-co/av/internal/utils/stackutils"
 	"github.com/aviator-co/av/internal/utils/stringutils"
 	"github.com/aviator-co/av/internal/utils/templateutils"
 	"github.com/fatih/color"
@@ -503,8 +505,11 @@ func ensurePR(
 	repoMeta meta.Repository,
 	opts ensurePROpts,
 ) (*gh.PullRequest, bool, error) {
+	// Don't pass in a stack to start; we'll do a pass over all open PRs in the stack later.
+	var initialStack *stackutils.StackTreeNode = nil
+
 	if opts.existingPR != nil {
-		newBody := AddPRMetadata(opts.body, opts.meta)
+		newBody := AddPRMetadataAndStack(opts.body, opts.meta, opts.headRefName, initialStack)
 		updatedPR, err := client.UpdatePullRequest(ctx, githubv4.UpdatePullRequestInput{
 			PullRequestID: opts.existingPR.ID,
 			Title:         gh.Ptr(githubv4.String(opts.title)),
@@ -521,7 +526,7 @@ func ensurePR(
 		BaseRefName:  githubv4.String(opts.baseRefName),
 		HeadRefName:  githubv4.String(opts.headRefName),
 		Title:        githubv4.String(opts.title),
-		Body:         gh.Ptr(githubv4.String(AddPRMetadata(opts.body, opts.meta))),
+		Body:         gh.Ptr(githubv4.String(AddPRMetadataAndStack(opts.body, opts.meta, opts.headRefName, initialStack))),
 		Draft:        gh.Ptr(githubv4.Boolean(opts.draft)),
 	})
 	if err != nil {
@@ -675,6 +680,9 @@ const PRMetadataCommentStart = "<!-- av pr metadata"
 const PRMetadataCommentHelpText = "This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.\n"
 const PRMetadataCommentEnd = "-->"
 
+const PRStackCommentStart = "<!-- av pr stack begin -->"
+const PRStackCommentEnd = "<!-- av pr stack end -->"
+
 // extractContent parses the given input and looks for the start and end
 // strings. It returns the content between the start and end strings and the
 // remaining input. If the start or end strings are not found, the content is
@@ -708,6 +716,8 @@ func ParsePRBody(input string) (body string, prMeta PRMetadata, retErr error) {
 		return
 	}
 
+	_, body = extractContent(body, PRStackCommentStart, PRStackCommentEnd)
+
 	return
 }
 
@@ -716,15 +726,135 @@ func ReadPRMetadata(body string) (PRMetadata, error) {
 	return prMeta, err
 }
 
-func AddPRMetadata(body string, prMeta PRMetadata) string {
+func walkStack(stack *stackutils.StackTreeNode, branchName string) (stackString string, parentPullRequestNumber int64) {
+	ssb := strings.Builder{}
+
+	// For simple stacks (i.e., degenerate trees) print them top-down. For example:
+	// - #1
+	// - #2
+	// - main
+	var visitSimple func(node *stackutils.StackTreeNode, depth int, parentNode *stackutils.StackTreeNode)
+	visitSimple = func(node *stackutils.StackTreeNode, depth int, parentNode *stackutils.StackTreeNode) {
+		if len(node.Children) > 1 {
+			panic("stack tree has more than one child")
+		} else if len(node.Children) == 1 {
+			visitSimple(node.Children[0], depth+1, node)
+		}
+
+		ssb.WriteString("* ")
+
+		if depth == 0 || node.Branch.PullRequestNumber <= 0 {
+			ssb.WriteString("`")
+			ssb.WriteString(node.Branch.BranchName)
+			ssb.WriteString("`")
+		} else {
+			if node.Branch.BranchName == branchName {
+				ssb.WriteString("➡️ ")
+				parentPullRequestNumber = parentNode.Branch.PullRequestNumber
+			}
+			ssb.WriteString("**#")
+			ssb.WriteString(strconv.FormatInt(node.Branch.PullRequestNumber, 10))
+			ssb.WriteString("**")
+		}
+		ssb.WriteString("\n")
+	}
+
+	// For more complex stacks, print them sideways using a bulleted list. For example:
+	// - main
+	//   - #1
+	//     - #2
+	//   - #3
+	var visitComplex func(node *stackutils.StackTreeNode, depth int, parentNode *stackutils.StackTreeNode)
+	visitComplex = func(node *stackutils.StackTreeNode, depth int, parentNode *stackutils.StackTreeNode) {
+		if depth == 0 {
+			ssb.WriteString("* ")
+			ssb.WriteString("`")
+			ssb.WriteString(node.Branch.BranchName)
+			ssb.WriteString("`")
+		} else {
+			ssb.WriteString(strings.Repeat("  ", depth))
+			ssb.WriteString("* ")
+			if node.Branch.BranchName == branchName {
+				ssb.WriteString("➡️ ")
+				parentPullRequestNumber = parentNode.Branch.PullRequestNumber
+			}
+			if node.Branch.PullRequestNumber > 0 {
+				ssb.WriteString("**#")
+				ssb.WriteString(strconv.FormatInt(node.Branch.PullRequestNumber, 10))
+				ssb.WriteString("**")
+			} else {
+				ssb.WriteString("`")
+				ssb.WriteString(node.Branch.BranchName)
+				ssb.WriteString("`")
+			}
+		}
+		ssb.WriteString("\n")
+
+		for _, child := range node.Children {
+			visitComplex(child, depth+1, node)
+		}
+	}
+
+	var hasMultipleChildren func(node *stackutils.StackTreeNode) bool
+	hasMultipleChildren = func(node *stackutils.StackTreeNode) bool {
+		if len(node.Children) > 1 {
+			return true
+		} else if len(node.Children) == 1 {
+			return hasMultipleChildren(node.Children[0])
+		}
+		return false
+	}
+
+	// Optimize navigation within a stack by making sure the output has the same shape everywhere.
+	if hasMultipleChildren(stack) {
+		visitComplex(stack, 0, nil)
+	} else {
+		visitSimple(stack, 0, nil)
+	}
+
+	return ssb.String(), parentPullRequestNumber
+}
+
+func AddPRMetadataAndStack(
+	body string,
+	prMeta PRMetadata,
+	branchName string,
+	stack *stackutils.StackTreeNode,
+) string {
 	body, _, err := ParsePRBody(body)
 	if err != nil {
 		// No existing metadata comment, so add one.
 		logrus.WithError(err).Debug("could not parse PR metadata (assuming it doesn't exist)")
-		body += "\n\n"
 	}
 
 	sb := strings.Builder{}
+
+	// Don't write out a stack unless there is more than one PR in it.
+	has_multilevel_stack := stack != nil && len(stack.Children) > 0 && len(stack.Children[0].Children) > 0
+	if has_multilevel_stack {
+		stackString, parentPullRequestNumber := walkStack(stack, branchName)
+		sb.WriteString(PRStackCommentStart)
+
+		// Enclose this stack summary in a table for two reasons:
+		// 1. It actually looks nicer on GitHub
+		// 2. For the Slack GitHub integration, Slack doesn't support and strips out <table> elements in unfurls - we can avoid showing the stack in the unfurl.
+		sb.WriteString("\n<table><tr><td>")
+		sb.WriteString("<details><summary>")
+		if parentPullRequestNumber > 0 {
+			sb.WriteString("<b>Depends on #")
+			sb.WriteString(strconv.FormatInt(parentPullRequestNumber, 10))
+			sb.WriteString(".</b> ")
+		}
+		sb.WriteString("This PR is part of a stack created with <a href=\"https://github.com/aviator-co/av\">Aviator</a>.")
+		sb.WriteString("</summary>")
+		sb.WriteString("\n\n")
+		sb.WriteString(stackString)
+		sb.WriteString("</details>")
+		sb.WriteString("</td></tr></table>\n")
+		sb.WriteString(PRStackCommentEnd)
+		sb.WriteString("\n\n")
+	}
+
 	sb.WriteString(body)
 
 	sb.WriteString("\n\n")
@@ -744,4 +874,64 @@ func AddPRMetadata(body string, prMeta PRMetadata) string {
 	sb.WriteString("\n")
 
 	return sb.String()
+}
+
+// UpdatePullRequestWithStack updates the GitHub pull request associated with the given branch to include
+// the stack of branches that the branch is a part of.
+// This should be called after all applicable PRs have been created to ensure we can properly link them.
+func UpdatePullRequestWithStack(
+	ctx context.Context,
+	client *gh.Client,
+	repo *git.Repo,
+	tx meta.WriteTx,
+	branchName string,
+) error {
+	branchMeta, _ := tx.Branch(branchName)
+	logrus.WithField("branch", branchName).WithField("pr", branchMeta.PullRequest.ID).Debug("Updating pull requests with stack")
+
+	repoMeta, ok := tx.Repository()
+	if !ok {
+		return ErrRepoNotInitialized
+	}
+
+	stackToWrite, err := stackutils.BuildStackTreeForPullRequest(repo, tx, branchName)
+	if err != nil {
+		return err
+	}
+
+	existingPR, err := getExistingOpenPR(ctx, client, repoMeta, branchMeta, branchName)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	body, prMeta, err := ParsePRBody(existingPR.Body)
+
+	newBody := AddPRMetadataAndStack(body, prMeta, branchName, stackToWrite)
+	_, err = client.UpdatePullRequest(ctx, githubv4.UpdatePullRequestInput{
+		PullRequestID: existingPR.ID,
+		Body:          gh.Ptr(githubv4.String(newBody)),
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+// UpdatePullRequestsWithStack updates the GitHub pull requests associated with the given branches to include
+// the stack of branches that each branch is a part of.
+func UpdatePullRequestsWithStack(
+	ctx context.Context,
+	client *gh.Client,
+	repo *git.Repo,
+	tx meta.WriteTx,
+	branchNames []string,
+) error {
+	for _, branchName := range branchNames {
+		if err := UpdatePullRequestWithStack(ctx, client, repo, tx, branchName); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -830,8 +830,8 @@ func AddPRMetadataAndStack(
 	sb := strings.Builder{}
 
 	// Don't write out a stack unless there is more than one PR in it.
-	has_multilevel_stack := stack != nil && len(stack.Children) > 0 && len(stack.Children[0].Children) > 0
-	if has_multilevel_stack {
+	hasMultilevelStack := stack != nil && len(stack.Children) > 0 && len(stack.Children[0].Children) > 0
+	if hasMultilevelStack {
 		stackString, parentPullRequestNumber := walkStack(stack, branchName)
 		sb.WriteString(PRStackCommentStart)
 

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -1,10 +1,10 @@
 package actions_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/aviator-co/av/internal/actions"
+	"github.com/aviator-co/av/internal/utils/stackutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,8 +16,7 @@ func TestReadPRMetadata(t *testing.T) {
 		ParentPull: 123,
 		Trunk:      "baz",
 	}
-	prBody := actions.AddPRMetadata("Hello! This is a cool PR that does some neat things.", prMeta)
-	fmt.Println(prBody)
+	prBody := actions.AddPRMetadataAndStack("Hello! This is a cool PR that does some neat things.", prMeta, "foo", nil)
 	prMeta2, err := actions.ReadPRMetadata(prBody)
 	require.NoError(t, err)
 	assert.Equal(t, prMeta.Parent, prMeta2.Parent)
@@ -25,12 +24,12 @@ func TestReadPRMetadata(t *testing.T) {
 	assert.Equal(t, prMeta.ParentPull, prMeta2.ParentPull)
 	assert.Equal(t, prMeta.Trunk, prMeta2.Trunk)
 
-	prBody = actions.AddPRMetadata(prBody, actions.PRMetadata{
+	prBody = actions.AddPRMetadataAndStack(prBody, actions.PRMetadata{
 		Parent:     "foo2",
 		ParentHead: "bar2",
 		ParentPull: 1234,
 		Trunk:      "baz2",
-	})
+	}, "foo2", nil)
 	assert.Contains(t, prBody, "Hello! This is a cool PR that does some neat things.\n\n")
 	prMeta2, err = actions.ReadPRMetadata(prBody)
 	require.NoError(t, err)
@@ -45,15 +44,158 @@ func TestPRMetadataPreservesBody(t *testing.T) {
 		ParentPull: 123,
 		Trunk:      "baz",
 	}
-	body1 := actions.AddPRMetadata(
+	body1 := actions.AddPRMetadataAndStack(
 		"Hello! This is a cool PR that does some neat things.",
 		sampleMeta,
+		"foo",
+		nil,
 	)
 	// Add some text to the end of the body (as if someone had edited manually)
 	body1 += "\n\nIt's very neat, actually."
 
-	body2 := actions.AddPRMetadata(body1, sampleMeta)
+	body2 := actions.AddPRMetadataAndStack(body1, sampleMeta, "foo", nil)
 	assert.Contains(t, body2, "Hello! This is a cool PR that does some neat things.")
 	assert.Contains(t, body2, "It's very neat, actually.")
 	assert.Contains(t, body2, "\n"+actions.PRMetadataCommentStart)
+}
+
+func TestPRWithStack(t *testing.T) {
+	stack := &stackutils.StackTreeNode{
+		Branch: &stackutils.StackTreeBranchInfo{
+			BranchName:        "main",
+			Deleted:           false,
+			NeedSync:          false,
+			PullRequestNumber: 1001,
+			PullRequestLink:   "",
+		},
+		Children: []*stackutils.StackTreeNode{
+			{
+				Branch: &stackutils.StackTreeBranchInfo{
+					BranchName:        "baz",
+					Deleted:           false,
+					NeedSync:          false,
+					PullRequestNumber: 1001,
+					PullRequestLink:   "https://github.com/org/repo/pull/1001",
+				},
+				Children: []*stackutils.StackTreeNode{
+					{
+						Branch: &stackutils.StackTreeBranchInfo{
+							BranchName:        "foo",
+							Deleted:           false,
+							NeedSync:          false,
+							PullRequestNumber: 1002,
+							PullRequestLink:   "https://github.com/org/repo/pull/1002",
+						},
+						Children: []*stackutils.StackTreeNode{},
+					},
+				},
+			},
+		},
+	}
+
+	sampleMeta := actions.PRMetadata{
+		Parent:     "foo",
+		ParentHead: "bar",
+		ParentPull: 123,
+		Trunk:      "baz",
+	}
+	body1 := actions.AddPRMetadataAndStack(
+		"Hello! This is a cool PR that does some neat things.",
+		sampleMeta,
+		"foo",
+		stack,
+	)
+
+	assert.Equal(t, `<!-- av pr stack begin -->
+<table><tr><td><details><summary><b>Depends on #1001.</b> This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>
+* ➡️ **#1002**
+* **#1001**
+* `+"`"+`main`+"`"+`
+</details></td></tr></table><!-- av pr stack end -->
+
+Hello! This is a cool PR that does some neat things.
+
+<!-- av pr metadata
+This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
+`+"```"+`
+{"parent":"foo","parentHead":"bar","parentPull":123,"trunk":"baz"}
+`+"```"+`
+-->
+`, body1)
+}
+
+func TestPRWithForkedStack(t *testing.T) {
+	stack := &stackutils.StackTreeNode{
+		Branch: &stackutils.StackTreeBranchInfo{
+			BranchName:        "main",
+			Deleted:           false,
+			NeedSync:          false,
+			PullRequestNumber: 1001,
+			PullRequestLink:   "",
+		},
+		Children: []*stackutils.StackTreeNode{
+			{
+				Branch: &stackutils.StackTreeBranchInfo{
+					BranchName:        "baz",
+					Deleted:           false,
+					NeedSync:          false,
+					PullRequestNumber: 1001,
+					PullRequestLink:   "https://github.com/org/repo/pull/1001",
+				},
+				Children: []*stackutils.StackTreeNode{
+					{
+						Branch: &stackutils.StackTreeBranchInfo{
+							BranchName:        "foo",
+							Deleted:           false,
+							NeedSync:          false,
+							PullRequestNumber: 1002,
+							PullRequestLink:   "https://github.com/org/repo/pull/1002",
+						},
+						Children: []*stackutils.StackTreeNode{},
+					},
+				},
+			},
+			{
+				Branch: &stackutils.StackTreeBranchInfo{
+					BranchName:        "qux",
+					Deleted:           false,
+					NeedSync:          false,
+					PullRequestNumber: 1003,
+					PullRequestLink:   "https://github.com/org/repo/pull/1003",
+				},
+				Children: []*stackutils.StackTreeNode{},
+			},
+		},
+	}
+
+	sampleMeta := actions.PRMetadata{
+		Parent:     "foo",
+		ParentHead: "bar",
+		ParentPull: 123,
+		Trunk:      "baz",
+	}
+	body1 := actions.AddPRMetadataAndStack(
+		"Hello! This is a cool PR that does some neat things.",
+		sampleMeta,
+		"foo",
+		stack,
+	)
+
+	assert.Equal(t, `<!-- av pr stack begin -->
+<table><tr><td><details><summary><b>Depends on #1001.</b> This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>
+* `+"`"+`main`+"`"+`
+  * **#1001**
+    * ➡️ **#1002**
+  * **#1003**
+</details></td></tr></table><!-- av pr stack end -->
+
+Hello! This is a cool PR that does some neat things.
+
+<!-- av pr metadata
+This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
+`+"```"+`
+{"parent":"foo","parentHead":"bar","parentPull":123,"trunk":"baz"}
+`+"```"+`
+-->
+`, body1)
 }

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -108,10 +108,12 @@ func TestPRWithStack(t *testing.T) {
 
 	assert.Equal(t, `<!-- av pr stack begin -->
 <table><tr><td><details><summary><b>Depends on #1001.</b> This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>
+
 * ➡️ **#1002**
 * **#1001**
 * `+"`"+`main`+"`"+`
-</details></td></tr></table><!-- av pr stack end -->
+</details></td></tr></table>
+<!-- av pr stack end -->
 
 Hello! This is a cool PR that does some neat things.
 
@@ -183,11 +185,13 @@ func TestPRWithForkedStack(t *testing.T) {
 
 	assert.Equal(t, `<!-- av pr stack begin -->
 <table><tr><td><details><summary><b>Depends on #1001.</b> This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>
+
 * `+"`"+`main`+"`"+`
   * **#1001**
     * ➡️ **#1002**
   * **#1003**
-</details></td></tr></table><!-- av pr stack end -->
+</details></td></tr></table>
+<!-- av pr stack end -->
 
 Hello! This is a cool PR that does some neat things.
 

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/aviator-co/av/internal/utils/ghutils"
+	"github.com/aviator-co/av/internal/utils/stackutils"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -580,7 +581,14 @@ func syncBranchPushAndUpdatePullRequest(
 	if err != nil {
 		return err
 	}
-	prBody := AddPRMetadata(pr.Body, prMeta)
+
+	var stackToWrite *stackutils.StackTreeNode
+	if config.Av.PullRequest.WriteStack {
+		if stackToWrite, err = stackutils.BuildStackTreeForPullRequest(repo, tx, branchName); err != nil {
+			return err
+		}
+	}
+	prBody := AddPRMetadataAndStack(pr.Body, prMeta, branchName, stackToWrite)
 	if _, err := client.UpdatePullRequest(ctx, githubv4.UpdatePullRequestInput{
 		PullRequestID: branch.PullRequest.ID,
 		BaseRefName:   gh.Ptr(githubv4.String(branch.Parent.Name)),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,10 @@ type PullRequest struct {
 
 	// Branch prefix to use for creating new branches.
 	BranchNamePrefix string
+
+	// If true, the CLI will automatically add/update a comment to all PRs linking other PRs in the stack.
+	// False by default, since Aviator's MergeQueue also adds a similar comment.
+	WriteStack bool
 }
 
 type Aviator struct {

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -140,6 +140,25 @@ func StackBranches(tx ReadTx, name string) ([]string, error) {
 	return res, nil
 }
 
+// StackBranchesMap returns a map of branch names to their metadata for the stack
+// associated with the given branch.
+func StackBranchesMap(tx ReadTx, name string) (map[string]Branch, error) {
+	branchNames, err := StackBranches(tx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	branches := make(map[string]Branch, len(branchNames))
+	for _, branchName := range branchNames {
+		branch, ok := tx.Branch(branchName)
+		if !ok {
+			return nil, errors.Errorf("branch metadata not found for %q", branchName)
+		}
+		branches[branchName] = branch
+	}
+	return branches, nil
+}
+
 // Root determines the stack root of a branch.
 func Root(tx ReadTx, name string) (string, bool) {
 	for name != "" {


### PR DESCRIPTION
This PR adds a new configuration option, `pullRequest.writeStack`, that if enabled will add stack trees directly to GitHub pull requests.

For ease of navigation, these are added to the top as follows:

![image](https://github.com/aviator-co/av/assets/1815707/5d4f9286-e083-4d01-b1f2-7f31116bed0d)

And when expanded, show the stack of requests from the latest PR down to the trunk branch:

![image](https://github.com/aviator-co/av/assets/1815707/74c68d39-bbca-4ce2-8f7a-ad3bf0244fd6)

Most PR stacks tend to be linear, but an alternate format is used if there are forks in the stack that make it look more like a tree:

![image](https://github.com/aviator-co/av/assets/1815707/4941043e-3f59-4104-af62-9600d9938d99)

This isn't the default format since I personally think the one above is cleaner to read, especially on phones that run out of horizontal real estate.