### PR TITLE
Check the git error message in a case-insensitive way

### DIFF
--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -136,10 +136,11 @@ func parseRebaseResult(opts RebaseOpts, out *Output) (*RebaseResult, error) {
 	}
 
 	var status RebaseStatus
+	lowerStderr := strings.ToLower(stderr)
 	switch {
-	case strings.Contains(stderr, "No rebase in progress"):
+	case strings.Contains(lowerStderr, "no rebase in progress"):
 		status = RebaseNotInProgress
-	case strings.Contains(stderr, "Could not apply"):
+	case strings.Contains(lowerStderr, "could not apply"):
 		status = RebaseConflict
 	default:
 		logrus.WithField("exit_code", out.ExitCode).


### PR DESCRIPTION
With
https://github.com/git/git/commit/244001aa20d7a6411d8c920f34799df484d9a787,
the error message has been changed. Follow up with this change.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
