### PR TITLE
Use path/filepath for filepath operations

### DIFF
--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"emperror.dev/errors"
@@ -51,7 +51,7 @@ func getRepo() (*git.Repo, error) {
 }
 
 func getDB(repo *git.Repo) (meta.DB, error) {
-	dbPath := path.Join(repo.AvDir(), "av.db")
+	dbPath := filepath.Join(repo.AvDir(), "av.db")
 	existingStat, _ := os.Stat(dbPath)
 	db, err := jsonfiledb.OpenPath(dbPath)
 	if err != nil {

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"emperror.dev/errors"
@@ -81,7 +81,7 @@ base branch.
 			}
 
 			// Abort the rebase if we need to
-			if stat, _ := os.Stat(path.Join(repo.GitDir(), "REBASE_HEAD")); stat != nil {
+			if stat, _ := os.Stat(filepath.Join(repo.GitDir(), "REBASE_HEAD")); stat != nil {
 				if _, err := repo.Rebase(git.RebaseOpts{Abort: true}); err != nil {
 					return errors.WrapIf(err, "failed to abort in-progress rebase")
 				}

--- a/e2e_tests/stack_sync_test.go
+++ b/e2e_tests/stack_sync_test.go
@@ -2,7 +2,6 @@ package e2e_tests
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -201,7 +200,7 @@ func TestStackSyncAbort(t *testing.T) {
 	)
 	require.FileExists(
 		t,
-		path.Join(repo.GitDir(), "REBASE_HEAD"),
+		filepath.Join(repo.GitDir(), "REBASE_HEAD"),
 		"REBASE_HEAD should be created for conflict",
 	)
 
@@ -209,7 +208,7 @@ func TestStackSyncAbort(t *testing.T) {
 	RequireAv(t, "stack", "sync", "--abort")
 	require.NoFileExists(
 		t,
-		path.Join(repo.GitDir(), "REBASE_HEAD"),
+		filepath.Join(repo.GitDir(), "REBASE_HEAD"),
 		"REBASE_HEAD should be removed after abort",
 	)
 

--- a/internal/actions/sync_stack.go
+++ b/internal/actions/sync_stack.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/gh"
@@ -236,7 +236,7 @@ const stackSyncStateFile = "stack-sync.state.json"
 
 func ReadStackSyncState(repo *git.Repo) (StackSyncState, error) {
 	var state StackSyncState
-	data, err := os.ReadFile(path.Join(repo.AvDir(), stackSyncStateFile))
+	data, err := os.ReadFile(filepath.Join(repo.AvDir(), stackSyncStateFile))
 	if err != nil {
 		return state, err
 	}
@@ -259,7 +259,7 @@ func WriteStackSyncState(repo *git.Repo, state *StackSyncState) error {
 
 	// delete the file if state is nil (i.e., --abort)
 	if state == nil {
-		err := os.Remove(path.Join(avDir, stackSyncStateFile))
+		err := os.Remove(filepath.Join(avDir, stackSyncStateFile))
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
@@ -271,5 +271,5 @@ func WriteStackSyncState(repo *git.Repo, state *StackSyncState) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path.Join(avDir, stackSyncStateFile), data, 0644)
+	return os.WriteFile(filepath.Join(avDir, stackSyncStateFile), data, 0644)
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -28,7 +28,7 @@ func OpenRepo(repoDir string, gitDir string) (*Repo, error) {
 	r := &Repo{
 		repoDir,
 		gitDir,
-		logrus.WithFields(logrus.Fields{"repo": path.Base(repoDir)}),
+		logrus.WithFields(logrus.Fields{"repo": filepath.Base(repoDir)}),
 	}
 
 	return r, nil
@@ -43,11 +43,11 @@ func (r *Repo) GitDir() string {
 }
 
 func (r *Repo) AvDir() string {
-	return path.Join(r.GitDir(), "av")
+	return filepath.Join(r.GitDir(), "av")
 }
 
 func (r *Repo) AvTmpDir() string {
-	dir := path.Join(r.AvDir(), "tmp")
+	dir := filepath.Join(r.AvDir(), "tmp")
 	// Try to create the directory, but swallow the error since it will
 	// ultimately be surfaced when trying to create a file in the directory.
 	_ = os.MkdirAll(dir, 0755)

--- a/internal/git/gittest/files.go
+++ b/internal/git/gittest/files.go
@@ -2,7 +2,7 @@ package gittest
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/aviator-co/av/internal/git"
@@ -15,17 +15,17 @@ func CreateFile(
 	filename string,
 	body []byte,
 ) string {
-	filepath := path.Join(repo.Dir(), filename)
-	err := os.WriteFile(filepath, body, 0644)
+	fp := filepath.Join(repo.Dir(), filename)
+	err := os.WriteFile(fp, body, 0644)
 	require.NoError(t, err, "failed to write file: %s", filename)
-	return filepath
+	return fp
 }
 
 func AddFile(
 	t *testing.T,
 	repo *git.Repo,
-	filepath string,
+	fp string,
 ) {
-	_, err := repo.Git("add", filepath)
-	require.NoError(t, err, "failed to add file: %s", filepath)
+	_, err := repo.Git("add", fp)
+	require.NoError(t, err, "failed to add file: %s", fp)
 }

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -3,7 +3,6 @@ package gittest
 import (
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -50,7 +49,7 @@ func NewTempRepo(t *testing.T) *git.Repo {
 	err = remoteInit.Run()
 	require.NoError(t, err, "failed to initialize remote git repository")
 
-	repo, err := git.OpenRepo(dir, path.Join(dir, ".git"))
+	repo, err := git.OpenRepo(dir, filepath.Join(dir, ".git"))
 	require.NoError(t, err, "failed to open repo")
 
 	settings := map[string]string{

--- a/internal/meta/jsonfiledb/db.go
+++ b/internal/meta/jsonfiledb/db.go
@@ -2,7 +2,7 @@ package jsonfiledb
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 
 	"github.com/aviator-co/av/internal/git"
@@ -17,7 +17,7 @@ type DB struct {
 }
 
 func RepoPath(repo *git.Repo) string {
-	return path.Join(repo.AvDir(), "av.db")
+	return filepath.Join(repo.AvDir(), "av.db")
 }
 
 func OpenRepo(repo *git.Repo) (*DB, error) {
@@ -26,13 +26,13 @@ func OpenRepo(repo *git.Repo) (*DB, error) {
 
 // OpenPath opens a JSON file database at the given path.
 // If the file does not exist, it is created (as well as all ancestor directories).
-func OpenPath(filepath string) (*DB, error) {
-	_ = os.MkdirAll(path.Dir(filepath), 0755)
-	state, err := readState(filepath)
+func OpenPath(fp string) (*DB, error) {
+	_ = os.MkdirAll(filepath.Dir(fp), 0755)
+	state, err := readState(fp)
 	if err != nil {
 		return nil, err
 	}
-	db := &DB{filepath, sync.Mutex{}, state}
+	db := &DB{filepath: fp, stateMu: sync.Mutex{}, state: state}
 	return db, nil
 }
 

--- a/internal/meta/refmeta/repository.go
+++ b/internal/meta/refmeta/repository.go
@@ -3,7 +3,7 @@ package refmeta
 import (
 	"encoding/json"
 	"os"
-	"path"
+	"path/filepath"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
@@ -18,7 +18,7 @@ var ErrRepoNotInitialized = errors.Sentinel("this repository not initialized: pl
 func ReadRepository(repo *git.Repo) (meta.Repository, error) {
 	var repository meta.Repository
 
-	metaPath := path.Join(repo.Dir(), ".git", "av", "repo-metadata.json")
+	metaPath := filepath.Join(repo.Dir(), ".git", "av", "repo-metadata.json")
 	data, err := os.ReadFile(metaPath)
 	if err != nil {
 		return repository, ErrRepoNotInitialized

--- a/internal/utils/ghutils/ghutils.go
+++ b/internal/utils/ghutils/ghutils.go
@@ -2,13 +2,13 @@ package ghutils
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/aviator-co/av/internal/git"
 )
 
 func HasCodeowners(repo *git.Repo) bool {
-	if stat, _ := os.Stat(path.Join(repo.Dir(), ".github/CODEOWNERS")); stat != nil {
+	if stat, _ := os.Stat(filepath.Join(repo.Dir(), ".github/CODEOWNERS")); stat != nil {
 		return true
 	}
 	return false


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
