### PR TITLE
Make stackutils return only tree structure

### DIFF
--- a/cmd/av/pr_create.go
+++ b/cmd/av/pr_create.go
@@ -111,7 +111,7 @@ Examples:
 				return err
 			}
 
-			return actions.UpdatePullRequestsWithStack(ctx, client, repo, tx, stackBranches)
+			return actions.UpdatePullRequestsWithStack(ctx, client, tx, stackBranches)
 		}
 
 		return nil

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -111,7 +111,7 @@ If the --current flag is given, this command will create pull requests up to the
 		}
 
 		if config.Av.PullRequest.WriteStack {
-			if err = actions.UpdatePullRequestsWithStack(ctx, client, repo, tx, currentStackBranches); err != nil {
+			if err = actions.UpdatePullRequestsWithStack(ctx, client, tx, currentStackBranches); err != nil {
 				return err
 			}
 		}

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -584,11 +584,11 @@ func syncBranchPushAndUpdatePullRequest(
 
 	var stackToWrite *stackutils.StackTreeNode
 	if config.Av.PullRequest.WriteStack {
-		if stackToWrite, err = stackutils.BuildStackTreeForPullRequest(repo, tx, branchName); err != nil {
+		if stackToWrite, err = stackutils.BuildStackTreeForPullRequest(tx, branchName); err != nil {
 			return err
 		}
 	}
-	prBody := AddPRMetadataAndStack(pr.Body, prMeta, branchName, stackToWrite)
+	prBody := AddPRMetadataAndStack(pr.Body, prMeta, branchName, stackToWrite, tx)
 	if _, err := client.UpdatePullRequest(ctx, githubv4.UpdatePullRequestInput{
 		PullRequestID: branch.PullRequest.ID,
 		BaseRefName:   gh.Ptr(githubv4.String(branch.Parent.Name)),


### PR DESCRIPTION
Additional data can be obtained on the caller side.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"testtools","parentHead":"a43b3d70cb0b3101d5132f025ea28f1c67c62d2e","parentPull":276,"trunk":"master"}
```
-->
