### PR TITLE
Check the repository initialization when the program starts

### DIFF
--- a/cmd/av/fetch.go
+++ b/cmd/av/fetch.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"emperror.dev/errors"
-	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/gh"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/cleanup"
@@ -38,10 +37,7 @@ var fetchCmd = &cobra.Command{
 			tx.Abort()
 		})
 
-		info, ok := tx.Repository()
-		if !ok {
-			return actions.ErrRepoNotInitialized
-		}
+		info := tx.Repository()
 		branches := tx.AllBranches()
 
 		client, err := getGitHubClient()

--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/meta/jsonfiledb"
 	"github.com/aviator-co/av/internal/meta/refmeta"
-	"github.com/sirupsen/logrus"
 )
 
 var cachedRepo *git.Repo
@@ -50,18 +49,37 @@ func getRepo() (*git.Repo, error) {
 	return cachedRepo, nil
 }
 
+var ErrRepoNotInitialized = errors.Sentinel(
+	"this repository is not initialized; please run `av init`",
+)
+
 func getDB(repo *git.Repo) (meta.DB, error) {
-	dbPath := filepath.Join(repo.AvDir(), "av.db")
-	existingStat, _ := os.Stat(dbPath)
-	db, err := jsonfiledb.OpenPath(dbPath)
+	db, exists, err := getOrCreateDB(repo)
 	if err != nil {
 		return nil, err
 	}
-	if existingStat == nil {
-		logrus.Debug("Initializing new av database")
-		if err := refmeta.Import(repo, db); err != nil {
-			return nil, errors.WrapIff(err, "failed to import ref metadata into av database")
-		}
+	if !exists {
+		return nil, ErrRepoNotInitialized
 	}
 	return db, nil
+}
+
+func getOrCreateDB(repo *git.Repo) (meta.DB, bool, error) {
+	dbPath := filepath.Join(repo.AvDir(), "av.db")
+	oldDBPathPath := filepath.Join(repo.AvDir(), "repo-metadata.json")
+	dbPathStat, _ := os.Stat(dbPath)
+	oldDBPathStat, _ := os.Stat(oldDBPathPath)
+
+	if dbPathStat == nil && oldDBPathStat != nil {
+		// Migrate old db to new db
+		db, exists, err := jsonfiledb.OpenPath(dbPath)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := refmeta.Import(repo, db); err != nil {
+			return nil, false, errors.WrapIff(err, "failed to import ref metadata into av database")
+		}
+		return db, exists, nil
+	}
+	return jsonfiledb.OpenPath(dbPath)
 }

--- a/cmd/av/init.go
+++ b/cmd/av/init.go
@@ -18,7 +18,7 @@ var initCmd = &cobra.Command{
 			return err
 		}
 
-		db, err := getDB(repo)
+		db, _, err := getOrCreateDB(repo)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/pr_queue.go
+++ b/cmd/av/pr_queue.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/avgql"
 	"github.com/shurcooL/graphql"
 	"github.com/spf13/cobra"
@@ -51,10 +50,7 @@ var prQueueCmd = &cobra.Command{
 		}
 
 		prNumber := branch.PullRequest.Number
-		repository, exists := tx.Repository()
-		if !exists {
-			return actions.ErrRepoNotInitialized
-		}
+		repository := tx.Repository()
 
 		var variables = map[string]interface{}{
 			"repoOwner": graphql.String(repository.Owner),

--- a/cmd/av/pr_status.go
+++ b/cmd/av/pr_status.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/avgql"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/aviator-co/av/internal/utils/timeutils"
@@ -225,11 +224,7 @@ func getQueryVariables() (map[string]interface{}, error) {
 	}
 
 	prNumber := branch.PullRequest.Number
-	repository, exists := tx.Repository()
-	if !exists {
-		return nil, actions.ErrRepoNotInitialized
-	}
-
+	repository := tx.Repository()
 	var variables = map[string]interface{}{
 		"repoOwner": graphql.String(repository.Owner),
 		"repoName":  graphql.String(repository.Name),

--- a/internal/actions/errors.go
+++ b/internal/actions/errors.go
@@ -1,11 +1,5 @@
 package actions
 
-import "emperror.dev/errors"
-
-var ErrRepoNotInitialized = errors.Sentinel(
-	"this repository is not initialized; please run `av init`",
-)
-
 // errExitSilently is an error type that indicates that program should exit
 // without printing any additional information with the given exit code.
 // This is meant for cases where the running commands wants to manage its own

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -147,10 +147,7 @@ func CreatePullRequest(
 		logrus.Panicf("internal invariant error: CreatePullRequest called with empty branch name")
 	}
 
-	repoMeta, ok := tx.Repository()
-	if !ok {
-		return nil, ErrRepoNotInitialized
-	}
+	repoMeta := tx.Repository()
 	branchMeta, _ := tx.Branch(opts.BranchName)
 
 	var existingPR *gh.PullRequest
@@ -558,10 +555,7 @@ func UpdatePullRequestState(
 	tx meta.WriteTx,
 	branchName string,
 ) (*UpdatePullRequestResult, error) {
-	repoMeta, ok := tx.Repository()
-	if !ok {
-		return nil, ErrRepoNotInitialized
-	}
+	repoMeta := tx.Repository()
 	branch, _ := tx.Branch(branchName)
 
 	_, _ = fmt.Fprint(os.Stderr,
@@ -898,10 +892,7 @@ func UpdatePullRequestWithStack(
 	branchMeta, _ := tx.Branch(branchName)
 	logrus.WithField("branch", branchName).WithField("pr", branchMeta.PullRequest.ID).Debug("Updating pull requests with stack")
 
-	repoMeta, ok := tx.Repository()
-	if !ok {
-		return ErrRepoNotInitialized
-	}
+	repoMeta := tx.Repository()
 
 	stackToWrite, err := stackutils.BuildStackTreeForPullRequest(tx, branchName)
 	if err != nil {

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -242,8 +242,8 @@ This information is embedded by the av CLI when creating PRs to track the status
 
 type fakeReadTx map[string]meta.Branch
 
-func (tx fakeReadTx) Repository() (meta.Repository, bool) {
-	return meta.Repository{}, false
+func (tx fakeReadTx) Repository() meta.Repository {
+	return meta.Repository{}
 }
 
 func (tx fakeReadTx) Branch(name string) (meta.Branch, bool) {

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -78,7 +78,10 @@ func NewTempRepo(t *testing.T) *GitTestRepo {
 	// This repository obviously doesn't exist so tests still need to be careful
 	// not to invoke operations that would communicate with GitHub (e.g.,
 	// by using the `--no-fetch` and `--no-push` flags).
-	db := repo.OpenDB(t)
+	db, _, err := jsonfiledb.OpenPath(filepath.Join(repo.GitDir, "av", "av.db"))
+	if err != nil {
+		require.NoError(t, err, "failed to open database")
+	}
 	tx := db.WriteTx()
 	tx.SetRepository(meta.Repository{
 		ID:    "R_nonexistent_",
@@ -129,7 +132,7 @@ func (r *GitTestRepo) Git(t *testing.T, args ...string) string {
 }
 
 func (r *GitTestRepo) OpenDB(t *testing.T) *jsonfiledb.DB {
-	db, err := jsonfiledb.OpenPath(filepath.Join(r.GitDir, "av", "av.db"))
+	db, _, err := jsonfiledb.OpenPath(filepath.Join(r.GitDir, "av", "av.db"))
 	require.NoError(t, err, "failed to open database")
 	return db
 }

--- a/internal/meta/db.go
+++ b/internal/meta/db.go
@@ -9,7 +9,7 @@ type DB interface {
 // It presents a consistent view of the underlying database.
 type ReadTx interface {
 	// Repository returns the repository information.
-	Repository() (Repository, bool)
+	Repository() Repository
 	// Branch returns the branch with the given name. If no such branch exists,
 	// the second return value is false.
 	Branch(name string) (Branch, bool)

--- a/internal/meta/jsonfiledb/db.go
+++ b/internal/meta/jsonfiledb/db.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 )
 
@@ -16,24 +15,16 @@ type DB struct {
 	state   *state
 }
 
-func RepoPath(repo *git.Repo) string {
-	return filepath.Join(repo.AvDir(), "av.db")
-}
-
-func OpenRepo(repo *git.Repo) (*DB, error) {
-	return OpenPath(RepoPath(repo))
-}
-
 // OpenPath opens a JSON file database at the given path.
 // If the file does not exist, it is created (as well as all ancestor directories).
-func OpenPath(fp string) (*DB, error) {
+func OpenPath(fp string) (*DB, bool, error) {
 	_ = os.MkdirAll(filepath.Dir(fp), 0755)
 	state, err := readState(fp)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	db := &DB{filepath: fp, stateMu: sync.Mutex{}, state: state}
-	return db, nil
+	return db, state.RepositoryState.ID != "", nil
 }
 
 func (d *DB) ReadTx() meta.ReadTx {

--- a/internal/meta/jsonfiledb/readtx.go
+++ b/internal/meta/jsonfiledb/readtx.go
@@ -11,8 +11,8 @@ type readTx struct {
 
 var _ meta.ReadTx = &readTx{}
 
-func (tx *readTx) Repository() (meta.Repository, bool) {
-	return tx.state.RepositoryState, tx.state.RepositoryState.ID != ""
+func (tx *readTx) Repository() meta.Repository {
+	return tx.state.RepositoryState
 }
 
 func (tx *readTx) Branch(name string) (meta.Branch, bool) {

--- a/internal/meta/refmeta/import.go
+++ b/internal/meta/refmeta/import.go
@@ -1,7 +1,6 @@
 package refmeta
 
 import (
-	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/cleanup"
@@ -15,7 +14,7 @@ func Import(repo *git.Repo, db meta.DB) error {
 	defer cu.Cleanup()
 
 	repoMeta, err := ReadRepository(repo)
-	if err != nil && !errors.Is(err, ErrRepoNotInitialized) {
+	if err != nil {
 		return err
 	}
 	tx.SetRepository(repoMeta)

--- a/internal/meta/refmeta/repository.go
+++ b/internal/meta/refmeta/repository.go
@@ -8,24 +8,19 @@ import (
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
-	"github.com/sirupsen/logrus"
 )
-
-var ErrRepoNotInitialized = errors.Sentinel("this repository not initialized: please run `av init`")
 
 // ReadRepository reads repository metadata from the git repo.
 // Returns the metadata and a boolean indicating if the metadata was found.
 func ReadRepository(repo *git.Repo) (meta.Repository, error) {
-	var repository meta.Repository
-
 	metaPath := filepath.Join(repo.Dir(), ".git", "av", "repo-metadata.json")
 	data, err := os.ReadFile(metaPath)
 	if err != nil {
-		return repository, ErrRepoNotInitialized
+		return meta.Repository{}, errors.WrapIf(err, "failed to read the repository metadata")
 	}
+	var repository meta.Repository
 	if err := json.Unmarshal(data, &repository); err != nil {
-		logrus.WithError(err).Error("repository metadata file is corrupt - ignoring")
-		return repository, ErrRepoNotInitialized
+		return meta.Repository{}, errors.WrapIf(err, "failed to unmarshal the repository metadata")
 	}
 	return repository, nil
 }


### PR DESCRIPTION
Currently, the repository initialization is checked deeper in the
program. Instead, this change checks that when we open the database.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
