### PR TITLE
Make a generic state file read/write mechanism

### DIFF
--- a/cmd/av/commit_amend.go
+++ b/cmd/av/commit_amend.go
@@ -54,12 +54,12 @@ var commitAmendCmd = &cobra.Command{
 			return actions.ErrExitSilently{ExitCode: 1}
 		}
 
-		state, err := actions.ReadStackSyncState(repo)
-		state.OriginalBranch = currentBranchName
-
-		if err != nil && !os.IsNotExist(err) {
+		var state actions.StackSyncState
+		if err := repo.ReadStateFile(git.StateFileKindSync, &state); err != nil && !os.IsNotExist(err) {
 			return err
 		}
+
+		state.OriginalBranch = currentBranchName
 		ctx := context.Background()
 		db, err := getDB(repo)
 		if err != nil {

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -68,15 +68,15 @@ base branch.
 
 		// Read any preexisting state.
 		// This is required to allow us to handle --continue/--abort/--skip
-		state, err := actions.ReadStackSyncState(repo)
-		if err != nil && !os.IsNotExist(err) {
+		var state actions.StackSyncState
+		if err := repo.ReadStateFile(git.StateFileKindSync, &state); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 
 		if stackSyncFlags.Abort {
 			if state.CurrentBranch == "" || state.Continuation == nil {
 				// Try to clear the state file if it exists just to be safe.
-				_ = actions.WriteStackSyncState(repo, nil)
+				_ = repo.WriteStateFile(git.StateFileKindSync, nil)
 				return errors.New("no sync in progress")
 			}
 
@@ -87,7 +87,7 @@ base branch.
 				}
 			}
 
-			err := actions.WriteStackSyncState(repo, nil)
+			_ = repo.WriteStateFile(git.StateFileKindSync, nil)
 			if err != nil {
 				return errors.Wrap(err, "failed to reset stack sync state")
 			}
@@ -169,7 +169,7 @@ base branch.
 				return err
 			}
 			if !res.Success {
-				if err := actions.WriteStackSyncState(repo, &state); err != nil {
+				if err := repo.WriteStateFile(git.StateFileKindSync, &state); err != nil {
 					return errors.Wrap(err, "failed to write stack sync state")
 				}
 				_, _ = fmt.Fprint(os.Stderr,

--- a/internal/git/state_file.go
+++ b/internal/git/state_file.go
@@ -1,0 +1,37 @@
+package git
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+type StateFileKind string
+
+const (
+	StateFileKindSync    StateFileKind = "stack-sync.state.json"
+	StateFileKindReorder StateFileKind = "stack-reorder.state.json"
+)
+
+func (r *Repo) ReadStateFile(kind StateFileKind, msg any) error {
+	bs, err := os.ReadFile(filepath.Join(r.AvDir(), string(kind)))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bs, msg)
+}
+
+func (r *Repo) WriteStateFile(kind StateFileKind, msg any) error {
+	if msg == nil {
+		if err := os.Remove(filepath.Join(r.AvDir(), string(kind))); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+
+	bs, err := json.MarshalIndent(msg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(r.AvDir(), string(kind)), bs, 0644)
+}

--- a/internal/reorder/reorder.go
+++ b/internal/reorder/reorder.go
@@ -1,12 +1,8 @@
 package reorder
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
-
-	"github.com/aviator-co/av/internal/git"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/utils/colors"
@@ -15,7 +11,7 @@ import (
 // Reorder executes a reorder.
 // If the reorder couldn't be completed (due to a conflict), a continuation is returned.
 // If the reorder was completed successfully, a nil continuation and nil error is returned.
-func Reorder(ctx Context) (*Continuation, error) {
+func Reorder(ctx Context) (*State, error) {
 	if ctx.Output == nil {
 		ctx.Output = os.Stderr
 	}
@@ -23,7 +19,7 @@ func Reorder(ctx Context) (*Continuation, error) {
 	for _, cmd := range ctx.State.Commands {
 		err := cmd.Execute(&ctx)
 		if errors.Is(err, ErrInterruptReorder) {
-			return &Continuation{State: ctx.State}, nil
+			return ctx.State, nil
 		} else if err != nil {
 			return nil, err
 		}
@@ -36,46 +32,4 @@ func Reorder(ctx Context) (*Continuation, error) {
 
 type Continuation struct {
 	State *State
-}
-
-const stateFileName = "stack-reorder.state.json"
-
-// ReadContinuation reads a continuation from the state file.
-// Returns the raw error returned by os.Open if the file couldn't be opened.
-// Use os.IsNotExist to check if the continuation doesn't exist.
-func ReadContinuation(repo *git.Repo) (*Continuation, error) {
-	file, err := os.Open(filepath.Join(repo.AvDir(), stateFileName))
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = file.Close() }()
-
-	decoder := json.NewDecoder(file)
-	var continuation Continuation
-	err = decoder.Decode(&continuation)
-	if err != nil {
-		return nil, err
-	}
-
-	return &continuation, nil
-}
-
-// WriteContinuation writes a continuation to the state file.
-// If a nil continuation is passed, the state file is deleted.
-func WriteContinuation(repo *git.Repo, continuation *Continuation) error {
-	if continuation == nil {
-		return os.Remove(filepath.Join(repo.AvDir(), stateFileName))
-	}
-
-	file, err := os.Create(filepath.Join(repo.AvDir(), stateFileName))
-	if err != nil {
-		return err
-	}
-	enc := json.NewEncoder(file)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(continuation); err != nil {
-		_ = file.Close()
-		return err
-	}
-	return file.Close()
 }

--- a/internal/reorder/reorder_test.go
+++ b/internal/reorder/reorder_test.go
@@ -24,7 +24,7 @@ func TestReorder(t *testing.T) {
 	c2a := repo.CommitFile(t, "fichier", "bonjour\n")
 	c2b := repo.CommitFile(t, "fichier", "bonjour\nle monde\n")
 
-	continuation, err := reorder.Reorder(reorder.Context{
+	state, err := reorder.Reorder(reorder.Context{
 		Repo: repo.AsAvGitRepo(),
 		DB:   db,
 		State: &reorder.State{
@@ -41,7 +41,7 @@ func TestReorder(t *testing.T) {
 		},
 	})
 	require.NoError(t, err, "expected reorder to complete cleanly")
-	require.Nil(t, continuation, "expected reorder to complete cleanly")
+	require.Nil(t, state, "expected reorder to complete cleanly")
 
 	mainHead := repo.GetCommitAtRef(t, plumbing.NewBranchReferenceName("main"))
 	assert.Equal(t, initial, mainHead, "expected main to be at initial commit")
@@ -68,7 +68,7 @@ func TestReorderConflict(t *testing.T) {
 	c2a := repo.CommitFile(t, "file", "bonjour\n")
 	c2b := repo.CommitFile(t, "file", "bonjour\nle monde\n")
 
-	continuation, err := reorder.Reorder(reorder.Context{
+	state, err := reorder.Reorder(reorder.Context{
 		Repo: repo.AsAvGitRepo(),
 		DB:   db,
 		State: &reorder.State{
@@ -84,6 +84,6 @@ func TestReorderConflict(t *testing.T) {
 		},
 	})
 	require.NoError(t, err, "expected reorder to complete without error even with conflicts")
-	require.NotNil(t, continuation, "expected continuation to be returned after conflicts")
-	require.Equal(t, continuation.State.Commands[0], reorder.PickCmd{Commit: c2a.String()})
+	require.NotNil(t, state, "expected state to be returned after conflicts")
+	require.Equal(t, state.Commands[0], reorder.PickCmd{Commit: c2a.String()})
 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
