### PR TITLE
Add restack command

### DIFF
--- a/cmd/av/stack.go
+++ b/cmd/av/stack.go
@@ -21,6 +21,7 @@ func init() {
 		stackPrevCmd,
 		stackReorderCmd,
 		stackReparentCmd,
+		stackRestackCmd,
 		stackSubmitCmd,
 		stackSwitchCmd,
 		stackSyncCmd,

--- a/cmd/av/stack_restack.go
+++ b/cmd/av/stack_restack.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/actions"
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/sequencer"
+	"github.com/aviator-co/av/internal/sequencer/planner"
+	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/aviator-co/av/internal/utils/stackutils"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+)
+
+var stackRestackFlags struct {
+	DryRun   bool
+	Abort    bool
+	Continue bool
+	Skip     bool
+}
+
+var stackRestackCmd = &cobra.Command{
+	Use:   "restack",
+	Short: "Restack branches",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repo, err := getRepo()
+		if err != nil {
+			return err
+		}
+
+		db, err := getDB(repo)
+		if err != nil {
+			return err
+		}
+
+		var opts []tea.ProgramOption
+		if !isatty.IsTerminal(os.Stdout.Fd()) {
+			opts = []tea.ProgramOption{
+				tea.WithInput(nil),
+			}
+		}
+		p := tea.NewProgram(stackRestackViewModel{
+			repo:    repo,
+			db:      db,
+			spinner: spinner.New(spinner.WithSpinner(spinner.Dot)),
+		}, opts...)
+		model, err := p.Run()
+		if err != nil {
+			return err
+		}
+		if err := model.(stackRestackViewModel).err; err != nil {
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
+		if s := model.(stackRestackViewModel).rebaseConflictErrorHeadline; s != "" {
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
+		return nil
+	},
+}
+
+type stackRestackState struct {
+	InitialBranch string
+	StNode        *stackutils.StackTreeNode
+	Seq           *sequencer.Sequencer
+}
+
+type stackRestackSeqResult struct {
+	result *git.RebaseResult
+	err    error
+}
+
+type stackRestackViewModel struct {
+	repo    *git.Repo
+	db      meta.DB
+	state   *stackRestackState
+	spinner spinner.Model
+
+	rebaseConflictErrorHeadline string
+	rebaseConflictHint          string
+	abortedBranch               plumbing.ReferenceName
+	err                         error
+}
+
+func (vm stackRestackViewModel) Init() tea.Cmd {
+	return tea.Batch(vm.spinner.Tick, vm.initCmd)
+}
+
+func (vm stackRestackViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case error:
+		vm.err = msg
+		return vm, tea.Quit
+	case *stackRestackState:
+		vm.state = msg
+		if stackRestackFlags.DryRun {
+			return vm, tea.Quit
+		}
+		if stackRestackFlags.Skip || stackRestackFlags.Continue || stackRestackFlags.Abort {
+			if stackRestackFlags.Abort {
+				vm.abortedBranch = vm.state.Seq.CurrentSyncRef
+			}
+			return vm, vm.runSeqWithContinuationFlags
+		}
+		return vm, vm.runSeq
+	case *stackRestackSeqResult:
+		if msg.err == nil && msg.result == nil {
+			// Finished the sequence.
+			if err := vm.repo.WriteStateFile(git.StateFileKindRestack, nil); err != nil {
+				vm.err = err
+			}
+			if _, err := vm.repo.CheckoutBranch(&git.CheckoutBranch{Name: vm.state.InitialBranch}); err != nil {
+				vm.err = err
+			}
+			return vm, tea.Quit
+		}
+		if msg.result.Status == git.RebaseConflict {
+			vm.rebaseConflictErrorHeadline = msg.result.ErrorHeadline
+			vm.rebaseConflictHint = msg.result.Hint
+			if err := vm.repo.WriteStateFile(git.StateFileKindRestack, vm.state); err != nil {
+				vm.err = err
+			}
+			return vm, tea.Quit
+		}
+		vm.err = msg.err
+		if vm.err != nil {
+			return vm, tea.Quit
+		}
+		return vm, vm.runSeq
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		vm.spinner, cmd = vm.spinner.Update(msg)
+		return vm, cmd
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			return vm, tea.Quit
+		}
+	}
+	return vm, nil
+}
+
+func (vm stackRestackViewModel) View() string {
+	sb := strings.Builder{}
+	if vm.state != nil && vm.state.Seq != nil {
+		if vm.state.Seq.CurrentSyncRef != "" {
+			sb.WriteString("Restacking " + vm.state.Seq.CurrentSyncRef.Short() + "...\n")
+		} else if vm.abortedBranch != "" {
+			sb.WriteString("Restack aborted\n")
+		} else {
+			sb.WriteString("Restack done\n")
+		}
+		syncedBranches := map[plumbing.ReferenceName]bool{}
+		pendingBranches := map[plumbing.ReferenceName]bool{}
+		seenCurrent := false
+		for _, op := range vm.state.Seq.Operations {
+			if op.Name == vm.state.Seq.CurrentSyncRef || op.Name == vm.abortedBranch {
+				seenCurrent = true
+			} else if !seenCurrent {
+				syncedBranches[op.Name] = true
+			} else {
+				pendingBranches[op.Name] = true
+			}
+		}
+
+		sb.WriteString(stackutils.RenderTree(vm.state.StNode, func(branchName string, isTrunk bool) string {
+			bn := plumbing.NewBranchReferenceName(branchName)
+			if syncedBranches[bn] {
+				return colors.Success("✓ " + branchName)
+			}
+			if pendingBranches[bn] {
+				return lipgloss.NewStyle().Foreground(colors.Amber500).Render(branchName)
+			}
+			if bn == vm.state.Seq.CurrentSyncRef {
+				return lipgloss.NewStyle().Foreground(colors.Amber500).Render(vm.spinner.View() + branchName)
+			}
+			if bn == vm.abortedBranch {
+				return colors.Failure("✗ " + branchName)
+			}
+			return branchName
+		}))
+	}
+	if vm.rebaseConflictErrorHeadline != "" {
+		sb.WriteString("\n")
+		sb.WriteString(colors.Failure("Rebase conflict while rebasing ", vm.state.Seq.CurrentSyncRef.Short()) + "\n")
+		sb.WriteString(vm.rebaseConflictErrorHeadline + "\n")
+		sb.WriteString(vm.rebaseConflictHint + "\n")
+		sb.WriteString("\n")
+		sb.WriteString("Resolve the conflicts and continue the restack with " + colors.CliCmd("av stack restack --continue") + "\n")
+	}
+	if vm.err != nil {
+		sb.WriteString(vm.err.Error() + "\n")
+	}
+	return sb.String()
+}
+
+func (vm stackRestackViewModel) initCmd() tea.Msg {
+	var state stackRestackState
+	if err := vm.repo.ReadStateFile(git.StateFileKindRestack, &state); err != nil && os.IsNotExist(err) {
+		var currentBranch string
+		if dh, err := vm.repo.DetachedHead(); err != nil {
+			return err
+		} else if !dh {
+			currentBranch, err = vm.repo.CurrentBranchName()
+			if err != nil {
+				return err
+			}
+		}
+		if _, exist := vm.db.ReadTx().Branch(currentBranch); !exist {
+			return errors.New("current branch is not adopted to av")
+		}
+		state.InitialBranch = currentBranch
+		state.StNode, err = stackutils.BuildStackTreeCurrentStack(vm.db.ReadTx(), currentBranch, true)
+		if err != nil {
+			return err
+		}
+		targetBranches, err := planner.GetTargetBranches(vm.db.ReadTx(), vm.repo, false, planner.CurrentStack)
+		if err != nil {
+			return err
+		}
+		ops, err := planner.PlanForRestack(vm.db.ReadTx(), vm.repo, targetBranches)
+		if err != nil {
+			return err
+		}
+		if len(ops) == 0 {
+			return errors.New("nothing to restack")
+		}
+		state.Seq = sequencer.NewSequencer("origin", vm.db, ops)
+	} else if err != nil {
+		return err
+	}
+	return &state
+}
+
+func (vm stackRestackViewModel) runSeqWithContinuationFlags() tea.Msg {
+	result, err := vm.state.Seq.Run(vm.repo, vm.db, stackRestackFlags.Abort, stackRestackFlags.Continue, stackRestackFlags.Skip)
+	return &stackRestackSeqResult{result: result, err: err}
+}
+
+func (vm stackRestackViewModel) runSeq() tea.Msg {
+	result, err := vm.state.Seq.Run(vm.repo, vm.db, false, false, false)
+	return &stackRestackSeqResult{result: result, err: err}
+}
+
+func init() {
+	stackRestackCmd.Flags().BoolVar(
+		&stackRestackFlags.Continue, "continue", false,
+		"continue an in-progress restack",
+	)
+	stackRestackCmd.Flags().BoolVar(
+		&stackRestackFlags.Abort, "abort", false,
+		"abort an in-progress restack",
+	)
+	stackRestackCmd.Flags().BoolVar(
+		&stackRestackFlags.Skip, "skip", false,
+		"skip the current commit and continue an in-progress restack",
+	)
+	stackRestackCmd.Flags().BoolVar(
+		&stackRestackFlags.DryRun, "dry-run", false,
+		"dry-run the restack",
+	)
+
+	stackRestackCmd.MarkFlagsMutuallyExclusive("continue", "abort", "skip")
+}

--- a/docs/av-stack-restack.1.md
+++ b/docs/av-stack-restack.1.md
@@ -1,0 +1,43 @@
+# av-stack-restack
+
+## NAME
+
+av-stack-restack - Rebase the stacked branches
+
+## SYNOPSIS
+
+```synopsis
+av stack restack [--dry-run] [--continue | --abort | --skip]
+```
+
+## DESCRIPTION
+
+`av stack restack` is a command to re-align the stacked branches. When a parent
+branch is amended or has a new commit, the children branches need to be rebased
+on the new parent. This command does the rebase operation for all the branches
+in the current stack.
+
+## REBASE CONFLICT
+
+Rebasing can cause a conflict. When a conflict happens, it prompts you to
+resolve the conflict, and continue with `av stack restack --continue`. This is
+similar to `git rebase --continue`, but it continues with syncing the rest of
+the branches.
+
+## OPTIONS
+
+`--continue`
+: Continue an in-progress rebase.
+
+`--abort`
+: Abort an in-progress rebase.
+
+`--skip`
+: Skip the current commit and continue an in-progress rebase.
+
+`--dry-run`
+: Show the list of branches that will be rebased without actually rebasing.
+
+## SEE ALSO
+
+`av-stack-sync`(1) for syncing with the remote repository.

--- a/e2e_tests/stack_restack_test.go
+++ b/e2e_tests/stack_restack_test.go
@@ -1,0 +1,318 @@
+package e2e_tests
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackRestack(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.RepoDir)
+
+	// To start, we create a simple three-stack where each stack has a single commit.
+	// Our stack looks like:
+	//     stack-1: main -> 1a
+	//     stack-2:           \ -> 2a
+	//     stack-3:           |    \ -> 3a
+	//     stack-4:           \ -> 4a
+	// Note: we create the first branch with a "vanilla" git checkout just to
+	// make sure that's working as intended.
+	repo.Git(t, "checkout", "-b", "stack-1")
+	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
+	RequireAv(t, "stack", "branch", "stack-2")
+	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
+	RequireAv(t, "stack", "branch", "stack-3")
+	repo.CommitFile(
+		t,
+		"different-file",
+		"1a\n2a\n3a\n",
+		gittest.WithMessage("Commit 3a"),
+	)
+	repo.Git(t, "checkout", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-4")
+	repo.CommitFile(t, "another-file", "1a\n4a\n", gittest.WithMessage("Commit 4a"))
+	repo.Git(t, "checkout", "stack-3")
+
+	// Everything up to date now, so this should be a no-op.
+	RequireAv(t, "stack", "restack")
+
+	// We're going to add a commit to the first branch in the stack.
+	// Our stack looks like:
+	//      stack-1: main -> 1a -> 1b
+	//      stack-2:           \ -> 2a
+	//      stack-3:           |    \ -> 3a
+	//      stack-4:           \ -> 4a
+
+	// (note that stack-2 has diverged with stack-1)
+	// Ultimately, after the sync (and resolving conflicts), our stack should look like:
+	//      stack-1: main -> 1a -> 1b
+	//      stack-2:                 \ -> 2a'
+	//      stack-3:                 |     \ -> 3a'
+	//      stack-4:                 \ -> 4a'
+	// It's very important here to make sure to handle the sync of stack-3 correctly.
+	// After syncing stack-2 onto stack-1 (before syncinc stack-3), our commit
+	// graph looks like:
+	//      stack-1: main -> 1a -> 1b
+	//      stack-2:                 \ -> 2a'
+	//      stack-3:          \ -> 2a -> 3a
+	//      stack-4:          \ -> 4a
+
+	// (remember that we haven't yet modified stack-3, so 3a still has parent 2a,
+	// but 2a is actually not even associated with stack-2 anymore since we had
+	// to rebase sync it on top of 1b, creating new commit 2a').
+	// If we do this naively (trying to rebase stack-3 on top of 2a'), Git will
+	// find every commit that is reachable from 3a but not 2a' (in this case,
+	// that's 2a and 3a) and replay those commits on top of 2a'. The net result
+	// is that we've duplicated 2a (and it's likely to have conflicts at that).
+	// A naive `git rebase stack-2` won't work. Instead we need to make sure to
+	// do `git rebase --onto 2a' 2a` instead (which says look at every
+	// commit since 2a and play it on top of 2a').
+	// This also applies to any situation where the user has modified a commit
+	// that was stacked-upon (e.g., with `git commit --amend`).
+	repo.WithCheckoutBranch(t, "refs/heads/stack-1", func() {
+		repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
+	})
+
+	// Since both commits updated my-file in ways that conflict, we should get
+	// a merge/rebase conflict here.
+	syncConflict := Av(t, "stack", "restack")
+	require.NotEqual(
+		t, 0, syncConflict.ExitCode,
+		"stack restack should return non-zero exit code if conflicts",
+	)
+	require.Contains(
+		t, syncConflict.Stdout,
+		"error: could not apply", "stack restack should include error message on rebase",
+	)
+	require.Contains(
+		t, syncConflict.Stdout, "av stack restack --continue",
+		"stack restack should print a message with instructions to continue",
+	)
+	syncContinueWithoutResolving := Av(t, "stack", "restack", "--continue")
+	require.NotEqual(
+		t,
+		0,
+		syncContinueWithoutResolving.ExitCode,
+		"stack restack --continue should return non-zero exit code if conflicts have not been resolved",
+	)
+	// resolve the conflict
+	err := os.WriteFile(filepath.Join(repo.RepoDir, "my-file"), []byte("1a\n1b\n2a\n"), 0644)
+	require.NoError(t, err)
+	repo.Git(t, "add", "my-file")
+	require.NoError(t, err, "failed to stage file")
+	// stack restack --continue should return zero exit code after resolving conflicts
+	RequireAv(t, "stack", "restack", "--continue")
+
+	// Make sure we've handled the rebase of stack-3 correctly (see the long
+	// comment above).
+	commits := repo.GetCommits(t, plumbing.NewBranchReferenceName("stack-3"), plumbing.NewBranchReferenceName("stack-2"))
+	require.Len(t, commits, 1)
+
+	mergeBases := repo.MergeBase(t, plumbing.NewBranchReferenceName("stack-1"), plumbing.NewBranchReferenceName("stack-2"))
+	stack1Head := repo.GetCommitAtRef(t, plumbing.NewBranchReferenceName("stack-1"))
+	require.Equal(t, mergeBases[0], stack1Head, "stack-2 should be up-to-date with stack-1")
+
+	// Further sync attemps should yield no-ops
+	syncNoop := RequireAv(t, "stack", "restack")
+	require.Contains(t, syncNoop.Stdout, "Restack done")
+
+	// Make sure we've not introduced any extra commits
+	// We should have 4 (corresponding to 1a, 1b, 2a, and 3a).
+	commits = repo.GetCommits(t, plumbing.NewBranchReferenceName("stack-3"), plumbing.NewBranchReferenceName("main"))
+	require.NoError(t, err)
+	require.Len(t, commits, 4)
+
+	stack1Commit := repo.GetCommitAtRef(t, plumbing.NewBranchReferenceName("stack-1"))
+	stack2Commit := repo.GetCommitAtRef(t, plumbing.NewBranchReferenceName("stack-2"))
+
+	require.Equal(t, meta.BranchState{
+		Name:  "main",
+		Trunk: true,
+	}, GetStoredParentBranchState(t, repo, "stack-1"))
+	require.Equal(t, meta.BranchState{
+		Name: "stack-1",
+		Head: stack1Commit.String(),
+	}, GetStoredParentBranchState(t, repo, "stack-2"))
+	require.Equal(t, meta.BranchState{
+		Name: "stack-2",
+		Head: stack2Commit.String(),
+	}, GetStoredParentBranchState(t, repo, "stack-3"))
+	require.Equal(t, meta.BranchState{
+		Name: "stack-1",
+		Head: stack1Commit.String(),
+	}, GetStoredParentBranchState(t, repo, "stack-4"))
+}
+
+func TestStackRestackAbort(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.RepoDir)
+
+	// Create a two stack...
+	repo.Git(t, "checkout", "-b", "stack-1")
+	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
+	RequireAv(t, "stack", "branch", "stack-2")
+	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
+
+	// Save the original parent HEAD for stack-2, which is the stack-1's commit.
+	origStack1Commit := repo.GetCommitAtRef(t, plumbing.NewBranchReferenceName("stack-1"))
+
+	// ... and introduce a commit onto stack-1 that will conflict with stack-2...
+	repo.CheckoutBranch(t, "refs/heads/stack-1")
+	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
+
+	// ... and make sure we get a conflict on sync...
+	syncConflict := Av(t, "stack", "restack")
+	require.NotEqual(
+		t,
+		0,
+		syncConflict.ExitCode,
+		"stack restack should return non-zero exit code if conflicts",
+	)
+	require.FileExists(
+		t,
+		filepath.Join(repo.GitDir, "REBASE_HEAD"),
+		"REBASE_HEAD should be created for conflict",
+	)
+
+	// ... and then abort the sync...
+	RequireAv(t, "stack", "restack", "--abort")
+	require.NoFileExists(
+		t,
+		filepath.Join(repo.GitDir, "REBASE_HEAD"),
+		"REBASE_HEAD should be removed after abort",
+	)
+
+	// ... and make sure that we return to stack-1 (where we started).
+	// (this also makes sure that we've actually aborted the rebase and are not
+	// in a detached HEAD state).
+	require.Equal(
+		t,
+		plumbing.ReferenceName("refs/heads/stack-1"),
+		repo.CurrentBranch(t),
+		"current branch should be reset to starting branch (stack-1) after abort",
+	)
+
+	// Because we aborted the sync, the stack-2 parent HEAD must stay at the original stack-1
+	// HEAD.
+	require.Equal(t, meta.BranchState{
+		Name: "stack-1",
+		Head: origStack1Commit.String(),
+	}, GetStoredParentBranchState(t, repo, "stack-2"))
+}
+
+func TestStackRestackWithLotsOfConflicts(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.RepoDir)
+
+	// Create a three stack...
+	repo.Git(t, "checkout", "-b", "stack-1")
+	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
+	RequireAv(t, "stack", "branch", "stack-2")
+	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
+	RequireAv(t, "stack", "branch", "stack-3")
+	repo.CommitFile(t, "my-file", "1a\n2a\n3a\n", gittest.WithMessage("Commit 3a"))
+
+	// Go back to the first branch (to make sure that the sync constructs the
+	// list of branches correctly).
+	repo.CheckoutBranch(t, "refs/heads/stack-1")
+
+	// Add new conflicting commits to each branch
+	repo.WithCheckoutBranch(t, "refs/heads/stack-1", func() {
+		repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
+	})
+	repo.WithCheckoutBranch(t, "refs/heads/stack-2", func() {
+		repo.CommitFile(
+			t,
+			"my-file",
+			"1a\n2a\n2b\n",
+			gittest.WithMessage("Commit 2b"),
+		)
+	})
+	repo.WithCheckoutBranch(t, "refs/heads/stack-3", func() {
+		repo.CommitFile(
+			t,
+			"my-file",
+			"1a\n2a\n3a\n3b\n",
+			gittest.WithMessage("Commit 3b"),
+		)
+	})
+
+	sync := Av(t, "stack", "restack")
+	require.NotEqual(
+		t,
+		0,
+		sync.ExitCode,
+		"stack restack should return non-zero exit code if conflicts",
+	)
+	require.Regexp(t, regexp.MustCompile("could not apply .+ Commit 2a"), sync.Stdout)
+	require.NoError(t, os.WriteFile("my-file", []byte("1a\n1b\n2a\n"), 0644))
+	repo.Git(t, "add", "my-file")
+
+	// Commit 2b should be able to be applied normally, then we should have a
+	// conflict with 3a
+	sync = Av(t, "stack", "restack", "--continue")
+	require.NotEqual(
+		t,
+		0,
+		sync.ExitCode,
+		"stack restack should return non-zero exit code if conflicts",
+	)
+	require.Regexp(t, regexp.MustCompile("could not apply .+ Commit 3a"), sync.Stdout)
+	require.NoError(t, os.WriteFile("my-file", []byte("1a\n1b\n2a\n2b\n3a\n"), 0644))
+	repo.Git(t, "add", "my-file")
+
+	// And finally, 3b should be able to be applied without conflict and our stack
+	// sync should be over.
+	RequireAv(t, "stack", "restack", "--continue")
+}
+
+func TestStackRestackAfterAmendingCommit(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	Chdir(t, repo.RepoDir)
+
+	// Create a three stack...
+	repo.Git(t, "checkout", "-b", "stack-1")
+	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
+	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
+	RequireAv(t, "stack", "branch", "stack-2")
+	repo.CommitFile(t, "my-file", "1a\n1b\n2a\n", gittest.WithMessage("Commit 2a"))
+	repo.CommitFile(
+		t,
+		"my-file",
+		"1a\n1b\n2a\n2b\n",
+		gittest.WithMessage("Commit 2b"),
+	)
+	RequireAv(t, "stack", "branch", "stack-3")
+	repo.CommitFile(
+		t,
+		"my-file",
+		"1a\n1b\n2a\n2b\n3a\n",
+		gittest.WithMessage("Commit 3a"),
+	)
+	repo.CommitFile(
+		t,
+		"my-file",
+		"1a\n1b\n2a\n2b\n3a\n3b\n",
+		gittest.WithMessage("Commit 3b"),
+	)
+
+	// Now we amend commit 1b and make sure the sync after succeeds
+	repo.CheckoutBranch(t, "refs/heads/stack-1")
+	repo.CommitFile(t, "my-file", "1a\n1c\n1b\n", gittest.WithAmend())
+	RequireAv(t, "stack", "restack")
+
+	repo.CheckoutBranch(t, "refs/heads/stack-3")
+	contents, err := os.ReadFile("my-file")
+	require.NoError(t, err)
+	require.Equal(t, "1a\n1c\n1b\n2a\n2b\n3a\n3b\n", string(contents))
+
+	// Now we amend commit 2a and make sure the sync succeeds
+	repo.CheckoutBranch(t, "refs/heads/stack-2")
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.1
 require (
 	emperror.dev/errors v0.8.1
 	github.com/charmbracelet/bubbletea v0.26.2
+	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/fatih/color v1.17.0
 	github.com/golangci/golangci-lint v1.58.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -88,7 +89,7 @@ require (
 	github.com/ccojocar/zxcvbn-go v1.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charithe/durationcheck v0.0.10 // indirect
-	github.com/charmbracelet/lipgloss v0.10.0
+	github.com/charmbracelet/bubbles v0.18.0
 	github.com/chavacava/garif v0.1.0 // indirect
 	github.com/ckaznocha/intrange v0.1.2 // indirect
 	github.com/curioswitch/go-reassign v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charithe/durationcheck v0.0.10 h1:wgw73BiocdBDQPik+zcEoBG/ob8uyBHf2iyoHGPf5w4=
 github.com/charithe/durationcheck v0.0.10/go.mod h1:bCWXb7gYRysD1CU3C+u4ceO49LoGOY1C1L6uouGNreQ=
+github.com/charmbracelet/bubbles v0.18.0 h1:PYv1A036luoBGroX6VWjQIE9Syf2Wby2oOl/39KLfy0=
+github.com/charmbracelet/bubbles v0.18.0/go.mod h1:08qhZhtIwzgrtBjAcJnij1t1H0ZRjwHyGsy6AL11PSw=
 github.com/charmbracelet/bubbletea v0.26.2 h1:Eeb+n75Om9gQ+I6YpbCXQRKHt5Pn4vMwusQpwLiEgJQ=
 github.com/charmbracelet/bubbletea v0.26.2/go.mod h1:6I0nZ3YHUrQj7YHIHlM8RySX4ZIthTliMY+W8X8b+Gs=
 github.com/charmbracelet/lipgloss v0.10.0 h1:KWeXFSexGcfahHX+54URiZGkBFazf70JNMtwg/AFW3s=

--- a/internal/git/state_file.go
+++ b/internal/git/state_file.go
@@ -11,6 +11,7 @@ type StateFileKind string
 const (
 	StateFileKindSync    StateFileKind = "stack-sync.state.json"
 	StateFileKindReorder StateFileKind = "stack-reorder.state.json"
+	StateFileKindRestack StateFileKind = "stack-restack.state.json"
 )
 
 func (r *Repo) ReadStateFile(kind StateFileKind, msg any) error {


### PR DESCRIPTION
This uses the new sequencer object to restack the branches.

![2024-05-16 13-55-08](https://github.com/aviator-co/av/assets/21878/7cf161c9-d904-4cf9-bdc7-359d561bbfa5)

This passes the same test as `av stack sync` for the local operation part. This should be compatible with it.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
