### PR TITLE
Rename the stackutils methods

### DIFF
--- a/cmd/av/stack_switch.go
+++ b/cmd/av/stack_switch.go
@@ -38,7 +38,7 @@ var stackSwitchCmd = &cobra.Command{
 			}
 		}
 
-		rootNodes := stackutils.BuildStackTree(tx, currentBranch)
+		rootNodes := stackutils.BuildStackTreeAllBranches(tx, currentBranch, true)
 		var branchList []*stackTreeBranchInfo
 		branches := map[string]*stackTreeBranchInfo{}
 		for _, node := range rootNodes {

--- a/cmd/av/stack_tree.go
+++ b/cmd/av/stack_tree.go
@@ -38,7 +38,7 @@ var stackTreeCmd = &cobra.Command{
 			}
 		}
 
-		rootNodes := stackutils.BuildStackTree(tx, currentBranch)
+		rootNodes := stackutils.BuildStackTreeAllBranches(tx, currentBranch, true)
 		for _, node := range rootNodes {
 			fmt.Print(stackutils.RenderTree(node, func(branchName string, isTrunk bool) string {
 				stbi := getStackTreeBranchInfo(repo, tx, branchName)

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -879,7 +879,8 @@ func UpdatePullRequestWithStack(
 
 	repoMeta := tx.Repository()
 
-	stackToWrite, err := stackutils.BuildStackTreeForPullRequest(tx, branchName)
+	// Don't sort based on the current branch so that the output is consistent between branches.
+	stackToWrite, err := stackutils.BuildStackTreeCurrentStack(tx, branchName, false)
 	if err != nil {
 		return err
 	}

--- a/internal/actions/sync_branch.go
+++ b/internal/actions/sync_branch.go
@@ -606,7 +606,7 @@ func syncBranchPushAndUpdatePullRequest(
 
 	var stackToWrite *stackutils.StackTreeNode
 	if config.Av.PullRequest.WriteStack {
-		if stackToWrite, err = stackutils.BuildStackTreeForPullRequest(tx, branchName); err != nil {
+		if stackToWrite, err = stackutils.BuildStackTreeCurrentStack(tx, branchName, false); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
We want to use this outside of PR context.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
