### PR TITLE
Use the same test utilities

### DIFF
--- a/e2e_tests/av.go
+++ b/e2e_tests/av.go
@@ -72,12 +72,6 @@ func Cmd(t *testing.T, exe string, args ...string) AvOutput {
 	return output
 }
 
-func RequireCmd(t *testing.T, exe string, args ...string) AvOutput {
-	output := Cmd(t, exe, args...)
-	require.Equal(t, 0, output.ExitCode, "cmd %s: exited with %v", args, output.ExitCode)
-	return output
-}
-
 func Av(t *testing.T, args ...string) AvOutput {
 	args = append([]string{"--debug"}, args...)
 	return Cmd(t, avCmdPath, args...)

--- a/e2e_tests/commit_amend_test.go
+++ b/e2e_tests/commit_amend_test.go
@@ -11,7 +11,7 @@ import (
 func TestCommitAmendInStack(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
 	Chdir(t, repo.RepoDir)
-	RequireCmd(t, "git", "fetch")
+	repo.Git(t, "fetch")
 	initialTimestamp := GetFetchHeadTimestamp(t, repo)
 
 	// Create a branch and commit a file.
@@ -27,7 +27,7 @@ func TestCommitAmendInStack(t *testing.T) {
 	RequireAv(t, "commit", "create", "-m", "two")
 
 	// Go back to the first branch and amend the commit with another file.
-	RequireCmd(t, "git", "checkout", "one")
+	repo.Git(t, "checkout", "one")
 	filepath = repo.CreateFile(t, "one-b.txt", "one-b")
 	repo.AddFile(t, filepath)
 	RequireAv(t, "commit", "amend", "--no-edit")

--- a/e2e_tests/commit_create_test.go
+++ b/e2e_tests/commit_create_test.go
@@ -11,7 +11,7 @@ import (
 func TestCommitCreateInStack(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
 	Chdir(t, repo.RepoDir)
-	RequireCmd(t, "git", "fetch")
+	repo.Git(t, "fetch")
 	initialTimestamp := GetFetchHeadTimestamp(t, repo)
 
 	// Create a branch and commit a file.
@@ -27,7 +27,7 @@ func TestCommitCreateInStack(t *testing.T) {
 	RequireAv(t, "commit", "create", "-m", "two")
 
 	// Go back to the first branch and commit another file.
-	RequireCmd(t, "git", "checkout", "one")
+	repo.Git(t, "checkout", "one")
 	filepath = repo.CreateFile(t, "one-b.txt", "one-b")
 	repo.AddFile(t, filepath)
 	RequireAv(t, "commit", "create", "-m", "one-b")

--- a/e2e_tests/stack_branch_test.go
+++ b/e2e_tests/stack_branch_test.go
@@ -21,7 +21,7 @@ func TestStackBranchMove(t *testing.T) {
 	repo.CommitFile(t, "three.txt", "three")
 
 	// one -> un
-	RequireCmd(t, "git", "checkout", "one")
+	repo.Git(t, "checkout", "one")
 	RequireAv(t, "stack", "branch", "-m", "un")
 	RequireCurrentBranchName(t, repo, "refs/heads/un")
 
@@ -73,8 +73,8 @@ func TestStackBranchRetroactiveMove(t *testing.T) {
 	repo.CommitFile(t, "three.txt", "three")
 
 	// one -> un without av
-	RequireCmd(t, "git", "checkout", "one")
-	RequireCmd(t, "git", "branch", "-m", "un")
+	repo.Git(t, "checkout", "one")
+	repo.Git(t, "branch", "-m", "un")
 	RequireCurrentBranchName(t, repo, "refs/heads/un")
 
 	// Retroactive rename with av

--- a/e2e_tests/stack_branchcommit_test.go
+++ b/e2e_tests/stack_branchcommit_test.go
@@ -15,8 +15,7 @@ func TestStackBranchCommit(t *testing.T) {
 	t.Run("FlagAll", func(t *testing.T) {
 		require.NoError(t, os.WriteFile("myfile.txt", []byte("hello\n"), 0644))
 		RequireAv(t, "stack", "branch-commit", "--all", "-m", "branch one")
-		clean := repo.IsWorkdirClean(t)
-		require.True(t, clean)
+		require.True(t, repo.IsWorkdirClean(t))
 	})
 
 	t.Run("FlagAllModified", func(t *testing.T) {
@@ -24,10 +23,9 @@ func TestStackBranchCommit(t *testing.T) {
 		require.NoError(t, os.WriteFile("yourfile.txt", []byte("bonjour\n"), 0644))
 		RequireAv(t, "stack", "branch-commit", "--all-modified", "-m", "branch two")
 
-		clean := repo.IsWorkdirClean(t)
 		require.False(
 			t,
-			clean,
+			repo.IsWorkdirClean(t),
 			"workdir should not be clean since yourfile.txt should not be committed",
 		)
 

--- a/e2e_tests/stack_orphan_test.go
+++ b/e2e_tests/stack_orphan_test.go
@@ -19,7 +19,7 @@ func TestStackOrphan(t *testing.T) {
 	// Then stack-2 (and child branch stack-3) will be orphaned
 
 	// Setup initial state
-	require.Equal(t, 0, Cmd(t, "git", "checkout", "-b", "stack-1").ExitCode)
+	repo.Git(t, "checkout", "-b", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")
@@ -45,14 +45,13 @@ func TestStackOrphan(t *testing.T) {
 	)
 
 	RequireAv(t, "stack", "prev")
-	tree := Av(t, "stack", "tree")
+	tree := RequireAv(t, "stack", "tree")
 	require.Contains(t, tree.Stdout, "stack-2")
 	require.Contains(t, tree.Stdout, "stack-3")
 
 	RequireAv(t, "stack", "orphan")
 
-	tree = Av(t, "stack", "tree")
+	tree = RequireAv(t, "stack", "tree")
 	require.NotContains(t, tree.Stdout, "stack-2")
 	require.NotContains(t, tree.Stdout, "stack-3")
-
 }

--- a/e2e_tests/stack_reparent_test.go
+++ b/e2e_tests/stack_reparent_test.go
@@ -53,8 +53,6 @@ func TestStackSyncReparent(t *testing.T) {
 		"foo.txt should be set after reparenting onto foo branch",
 	)
 	require.NoFileExists(t, "bar.txt", "bar.txt should not exist after reparenting onto foo branch")
-
-	Cmd(t, "git", "log")
 }
 
 func TestStackSyncReparentTrunk(t *testing.T) {
@@ -68,7 +66,7 @@ func TestStackSyncReparentTrunk(t *testing.T) {
 	repo.CommitFile(t, "bar.txt", "bar")
 
 	// Delete the local main. av should use the remote tracking branch.
-	Cmd(t, "git", "branch", "-D", "main")
+	repo.Git(t, "branch", "-D", "main")
 
 	RequireAv(t, "stack", "sync", "--parent", "main", "--no-fetch", "--no-push")
 }

--- a/e2e_tests/stack_sync_adopt_test.go
+++ b/e2e_tests/stack_sync_adopt_test.go
@@ -6,21 +6,16 @@ import (
 	"github.com/aviator-co/av/internal/git/gittest"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStackSyncAdopt(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
 	Chdir(t, repo.RepoDir)
 
-	require.Equal(t, 0, Cmd(t, "git", "checkout", "-b", "stack-1").ExitCode)
+	repo.Git(t, "checkout", "-b", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 
-	require.Equal(
-		t,
-		0,
-		Av(t, "stack", "sync", "--no-fetch", "--no-push", "--parent", "main").ExitCode,
-	)
+	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push", "--parent", "main")
 
 	assert.Equal(t,
 		meta.BranchState{

--- a/e2e_tests/stack_sync_all_test.go
+++ b/e2e_tests/stack_sync_all_test.go
@@ -4,45 +4,36 @@ import (
 	"testing"
 
 	"github.com/aviator-co/av/internal/git/gittest"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStackSyncAll(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
 	Chdir(t, repo.RepoDir)
 
-	require.Equal(t, 0, Cmd(t, "git", "switch", "main").ExitCode)
+	repo.Git(t, "switch", "main")
 	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 
-	require.Equal(t, 0, Cmd(t, "git", "switch", "main").ExitCode)
+	repo.Git(t, "switch", "main")
 	RequireAv(t, "stack", "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "2a\n", gittest.WithMessage("Commit 2a"))
 
-	require.Equal(t, 0, Cmd(t, "git", "switch", "main").ExitCode)
+	repo.Git(t, "switch", "main")
 	repo.CommitFile(t, "other-file", "X2\n", gittest.WithMessage("Commit X2"))
-	require.Equal(t, 0, Cmd(t, "git", "push", "origin", "main").ExitCode)
+	repo.Git(t, "push", "origin", "main")
 
 	//     main:    X  -> X2
 	//     stack-1:  \ -> 1a
 	//     stack-2:  \ -> 2a
 
-	require.Equal(
-		t,
-		0,
-		Av(t, "stack", "sync", "--no-fetch", "--no-push", "--trunk", "--all").ExitCode,
-	)
+	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push", "--trunk", "--all")
 
 	//     main:    X  -> X2
 	//     stack-1:        \ -> 1a
 	//     stack-2:        \ -> 2a
 
-	require.Equal(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", "main", "stack-1").ExitCode,
-		"HEAD of main should be an ancestor of HEAD of stack-1",
-	)
-	require.Equal(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", "main", "stack-2").ExitCode,
-		"HEAD of main should be an ancestor of HEAD of stack-2",
-	)
+	// HEAD of main should be an ancestor of HEAD of stack-1
+	repo.Git(t, "merge-base", "--is-ancestor", "main", "stack-1")
+	// HEAD of main should be an ancestor of HEAD of stack-2
+	repo.Git(t, "merge-base", "--is-ancestor", "main", "stack-2")
 }

--- a/e2e_tests/stack_sync_amend_test.go
+++ b/e2e_tests/stack_sync_amend_test.go
@@ -13,7 +13,7 @@ func TestSyncAfterAmendingCommit(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
-	RequireCmd(t, "git", "checkout", "-b", "stack-1")
+	repo.Git(t, "checkout", "-b", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")
@@ -41,8 +41,7 @@ func TestSyncAfterAmendingCommit(t *testing.T) {
 	// Now we amend commit 1b and make sure the sync after succeeds
 	repo.CheckoutBranch(t, "refs/heads/stack-1")
 	repo.CommitFile(t, "my-file", "1a\n1c\n1b\n", gittest.WithAmend())
-	sync := Av(t, "stack", "sync", "--no-fetch", "--no-push")
-	require.Equal(t, 0, sync.ExitCode, "expected sync to succeed")
+	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
 	repo.CheckoutBranch(t, "refs/heads/stack-3")
 	contents, err := os.ReadFile("my-file")
 	require.NoError(t, err)

--- a/e2e_tests/stack_sync_delete_parent_test.go
+++ b/e2e_tests/stack_sync_delete_parent_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStackSyncDeleteParent(t *testing.T) {
@@ -19,7 +18,7 @@ func TestStackSyncDeleteParent(t *testing.T) {
 	//     stack-1: main -> 1a -> 2b
 	//     stack-2:                \ -> 2a -> 2b
 	//     stack-3:	                           \ -> 3a -> 3b
-	require.Equal(t, 0, Cmd(t, "git", "checkout", "-b", "stack-1").ExitCode)
+	repo.Git(t, "checkout", "-b", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")
@@ -45,25 +44,23 @@ func TestStackSyncDeleteParent(t *testing.T) {
 	)
 
 	// Everything up to date now, so this should be a no-op.
-	require.Equal(t, 0, Av(t, "stack", "sync", "--no-fetch", "--no-push").ExitCode)
+	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
 
 	// We simulate the stack-2 is deleted and submerged into stack-1
 	//     main:    X
 	//     stack-1:  \ -> 1a -> 1b -> 2a -> 2b
 	var newStack1Head plumbing.Hash
 	repo.WithCheckoutBranch(t, "refs/heads/stack-1", func() {
-		RequireCmd(t, "git", "merge", "--ff-only", "stack-2")
-		RequireCmd(t, "git", "branch", "-D", "stack-2")
+		repo.Git(t, "merge", "--ff-only", "stack-2")
+		repo.Git(t, "branch", "-D", "stack-2")
 
 		newStack1Head = repo.GetCommitAtRef(t, plumbing.HEAD)
 	})
 	RequireAv(t, "stack", "tidy")
 	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
 
-	assert.Equal(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", newStack1Head.String(), "stack-3").ExitCode,
-		"stack-1 should be an ancestor of stack-3 after running sync",
-	)
+	// stack-1 should be an ancestor of stack-3 after running sync
+	repo.Git(t, "merge-base", "--is-ancestor", newStack1Head.String(), "stack-3")
 	assert.Equal(t,
 		meta.BranchState{
 			Name: "stack-1",

--- a/e2e_tests/stack_sync_merge_commit_test.go
+++ b/e2e_tests/stack_sync_merge_commit_test.go
@@ -19,7 +19,7 @@ func TestStackSyncMergeCommit(t *testing.T) {
 	//     stack-1: main -> 1a -> 2b
 	//     stack-2:                \ -> 2a -> 2b
 	//     stack-3:			                   \ -> 3a -> 3b
-	require.Equal(t, 0, Cmd(t, "git", "checkout", "-b", "stack-1").ExitCode)
+	repo.Git(t, "checkout", "-b", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")
@@ -45,7 +45,7 @@ func TestStackSyncMergeCommit(t *testing.T) {
 	)
 
 	// Everything up to date now, so this should be a no-op.
-	require.Equal(t, 0, Av(t, "stack", "sync", "--no-fetch", "--no-push").ExitCode)
+	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
 
 	// We simulate a merge here so that our history looks like:
 	//     main:    X                         / -> 1S
@@ -57,10 +57,10 @@ func TestStackSyncMergeCommit(t *testing.T) {
 	repo.WithCheckoutBranch(t, "refs/heads/main", func() {
 		oldHead := repo.GetCommitAtRef(t, plumbing.HEAD)
 
-		RequireCmd(t, "git", "merge", "--squash", "stack-2")
+		repo.Git(t, "merge", "--squash", "stack-2")
 		// `git merge --squash` doesn't actually create the commit, so we have to
 		// do that separately.
-		RequireCmd(t, "git", "commit", "--no-edit")
+		repo.Git(t, "commit", "--no-edit")
 		squashCommit = repo.GetCommitAtRef(t, plumbing.HEAD)
 
 		require.NotEqual(
@@ -89,10 +89,8 @@ func TestStackSyncMergeCommit(t *testing.T) {
 
 	require.NoError(t, tx.Commit())
 
-	require.Equal(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", "stack-2", "stack-3").ExitCode,
-		"HEAD of stack-1 should be an ancestor of HEAD of stack-2 before running sync",
-	)
+	// HEAD of stack-1 should be an ancestor of HEAD of stack-2 before running sync
+	repo.Git(t, "merge-base", "--is-ancestor", "stack-2", "stack-3")
 	require.NotEqual(t, 0,
 		Cmd(t, "git", "merge-base", "--is-ancestor", squashCommit.String(), "stack-3").ExitCode,
 		"squash commit of stack-1 should not be an ancestor of HEAD of stack-1 before running sync",
@@ -100,10 +98,7 @@ func TestStackSyncMergeCommit(t *testing.T) {
 
 	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
 
-	assert.Equal(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", squashCommit.String(), "stack-3").ExitCode,
-		"squash commit of stack-2 should be an ancestor of HEAD of stack-3 after running sync",
-	)
+	repo.Git(t, "merge-base", "--is-ancestor", squashCommit.String(), "stack-3")
 	assert.Equal(t,
 		meta.BranchState{
 			Name:  "main",

--- a/e2e_tests/stack_sync_trunk_test.go
+++ b/e2e_tests/stack_sync_trunk_test.go
@@ -17,7 +17,7 @@ func TestStackSyncTrunk(t *testing.T) {
 	//     main:    X
 	//     stack-1:  \ -> 1a -> 1b
 	//     stack-2:              \ -> 2a -> 2b
-	require.Equal(t, 0, Cmd(t, "git", "checkout", "-b", "stack-1").ExitCode)
+	repo.Git(t, "checkout", "-b", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")
@@ -30,7 +30,7 @@ func TestStackSyncTrunk(t *testing.T) {
 	)
 
 	// Everything up to date now, so this should be a no-op.
-	require.Equal(t, 0, Av(t, "stack", "sync", "--no-fetch", "--no-push").ExitCode)
+	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
 
 	// We simulate a merge here so that our history looks like:
 	//     main:    X --------------> 1S -> 3a
@@ -41,16 +41,16 @@ func TestStackSyncTrunk(t *testing.T) {
 	var squashCommit plumbing.Hash
 	var threeACommit plumbing.Hash
 	repo.WithCheckoutBranch(t, "refs/heads/main", func() {
-		RequireCmd(t, "git", "merge", "--squash", "stack-1")
+		repo.Git(t, "merge", "--squash", "stack-1")
 		// `git merge --squash` doesn't actually create the commit, so we have to
 		// do that separately.
-		RequireCmd(t, "git", "commit", "--no-edit")
+		repo.Git(t, "commit", "--no-edit")
 		squashCommit = repo.GetCommitAtRef(t, plumbing.HEAD)
 
 		repo.CommitFile(t, "test-file", "3a\n", gittest.WithMessage("Commit 3a"))
 		threeACommit = repo.GetCommitAtRef(t, plumbing.HEAD)
 
-		RequireCmd(t, "git", "push", "origin", "main")
+		repo.Git(t, "push", "origin", "main")
 	})
 
 	// We shouldn't do this as part of an E2E test since it depends on internal
@@ -64,10 +64,8 @@ func TestStackSyncTrunk(t *testing.T) {
 	tx.SetBranch(stack1Meta)
 	require.NoError(t, tx.Commit())
 
-	require.Equal(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", "stack-1", "stack-2").ExitCode,
-		"HEAD of stack-1 should be an ancestor of HEAD of stack-2 before running sync",
-	)
+	// HEAD of stack-1 should be an ancestor of HEAD of stack-2 before running sync
+	repo.Git(t, "merge-base", "--is-ancestor", "stack-1", "stack-2")
 	require.NotEqual(t, 0,
 		Cmd(t, "git", "merge-base", "--is-ancestor", squashCommit.String(), "stack-2").ExitCode,
 		"squash commit of stack-1 should not be an ancestor of HEAD of stack-2 before running sync",
@@ -80,8 +78,6 @@ func TestStackSyncTrunk(t *testing.T) {
 	//     stack-1:  \ -> 1a -> 1b           \
 	//     stack-2:                           \ -> 2a -> 2b
 
-	require.Equal(t, 0,
-		Cmd(t, "git", "merge-base", "--is-ancestor", threeACommit.String(), "stack-2").ExitCode,
-		"commit 3a should be an ancestor of HEAD of stack-2 after running sync with --trunk",
-	)
+	// commit 3a should be an ancestor of HEAD of stack-2 after running sync with --trunk
+	repo.Git(t, "merge-base", "--is-ancestor", threeACommit.String(), "stack-2")
 }


### PR DESCRIPTION
There are some variations on the test utilities. This change unifies
them.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
