### PR TITLE
Run mock GitHub server for testing

### DIFF
--- a/e2e_tests/mock_ghgql_server.go
+++ b/e2e_tests/mock_ghgql_server.go
@@ -1,0 +1,118 @@
+package e2e_tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	// These are ugly, but this is easy way to tell which query is being used.
+	prQuery = "query($after:String$baseRefName:String$first:Int!$headRefName:String$owner:String!$repo:String!$states:[PullRequestState!]){repository(owner: $owner, name: $repo){pullRequests(states: $states, headRefName: $headRefName, baseRefName: $baseRefName, first: $first, after: $after){nodes{id,number,headRefName,baseRefName,isDraft,permalink,state,title,body,mergeCommit{oid},timelineItems(last: 10, itemTypes: CLOSED_EVENT){nodes{... on ClosedEvent{closer{... on Commit{oid}}}}}},pageInfo{endCursor,hasNextPage,hasPreviousPage,startCursor}}}}"
+)
+
+func RunMockGitHubServer(t *testing.T) *mockGitHubServer {
+	s := &mockGitHubServer{t: t, Server: nil}
+	s.Server = httptest.NewServer(s)
+	return s
+}
+
+type mockGitHubServer struct {
+	t *testing.T
+
+	pulls []mockPR
+
+	*httptest.Server
+}
+
+type mockPR struct {
+	ID          string
+	Number      int
+	HeadRefName string
+	BaseRefName string
+	IsDraft     bool
+	State       string
+	Title       string
+	Body        string
+
+	MergeCommitOID  string
+	ClosedCommitOID string
+}
+
+type graphqlRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+type graphqlResponse struct {
+	Data map[string]interface{} `json:"data"`
+}
+
+func (s *mockGitHubServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req graphqlRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.t.Logf("Failed to decode request: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if req.Query == prQuery {
+		s.t.Logf("Received PR query: %s", req.Variables)
+		if err := json.NewEncoder(w).Encode(s.handlePRQuery(req)); err != nil {
+			s.t.Logf("Failed to encode response: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+
+	s.t.Logf("Received unexpected query: %s", req.Query)
+	w.WriteHeader(http.StatusInternalServerError)
+}
+
+func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
+	headRefName := req.Variables["headRefName"].(string)
+	var prs []interface{}
+	for _, pr := range s.pulls {
+		if pr.HeadRefName != headRefName {
+			continue
+		}
+		gqlpr := map[string]interface{}{
+			"id":          pr.ID,
+			"number":      pr.Number,
+			"headRefName": pr.HeadRefName,
+			"baseRefName": pr.BaseRefName,
+			"isDraft":     pr.IsDraft,
+			"permalink":   fmt.Sprintf("https://github.invalid/mock/mock/pulls/%d", pr.Number),
+			"state":       pr.State,
+			"title":       pr.Title,
+			"body":        pr.Body,
+		}
+		if pr.MergeCommitOID != "" {
+			gqlpr["mergeCommit"] = map[string]string{"oid": pr.MergeCommitOID}
+		}
+		if pr.ClosedCommitOID != "" {
+			gqlpr["timelineItems"] = map[string]interface{}{
+				"nodes": []interface{}{
+					map[string]interface{}{
+						"__typename": "ClosedEvent",
+						"closer": map[string]interface{}{
+							"__typename": "Commit",
+							"oid":        pr.ClosedCommitOID,
+						},
+					},
+				},
+			}
+		}
+		prs = append(prs, gqlpr)
+	}
+	return graphqlResponse{
+		Data: map[string]interface{}{
+			"repository": map[string]interface{}{
+				"pullRequests": map[string]interface{}{
+					"nodes": prs,
+				},
+			},
+		},
+	}
+}

--- a/e2e_tests/stack_reparent_test.go
+++ b/e2e_tests/stack_reparent_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestStackSyncReparent(t *testing.T) {
-	repo := gittest.NewTempRepo(t)
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
 	RequireAv(t, "stack", "branch", "foo")
@@ -27,7 +29,7 @@ func TestStackSyncReparent(t *testing.T) {
 	requireFileContent(t, "spam.txt", "spam")
 
 	// Now, re-parent spam on top of bar (should be relatively a no-op)
-	RequireAv(t, "stack", "sync", "--parent", "bar", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync", "--parent", "bar")
 	requireFileContent(t, "spam.txt", "spam")
 	requireFileContent(
 		t,
@@ -37,7 +39,7 @@ func TestStackSyncReparent(t *testing.T) {
 	)
 
 	// Now, re-parent spam on top of foo
-	RequireAv(t, "stack", "sync", "--parent", "foo", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync", "--parent", "foo")
 	currentBranch := repo.CurrentBranch(t)
 	require.Equal(
 		t,
@@ -56,7 +58,9 @@ func TestStackSyncReparent(t *testing.T) {
 }
 
 func TestStackSyncReparentTrunk(t *testing.T) {
-	repo := gittest.NewTempRepo(t)
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
 	RequireAv(t, "stack", "branch", "foo")
@@ -68,7 +72,7 @@ func TestStackSyncReparentTrunk(t *testing.T) {
 	// Delete the local main. av should use the remote tracking branch.
 	repo.Git(t, "branch", "-D", "main")
 
-	RequireAv(t, "stack", "sync", "--parent", "main", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync", "--parent", "main")
 }
 
 func requireFileContent(t *testing.T, file string, expected string, args ...any) {

--- a/e2e_tests/stack_sync_adopt_test.go
+++ b/e2e_tests/stack_sync_adopt_test.go
@@ -9,13 +9,15 @@ import (
 )
 
 func TestStackSyncAdopt(t *testing.T) {
-	repo := gittest.NewTempRepo(t)
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
 	repo.Git(t, "checkout", "-b", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push", "--parent", "main")
+	RequireAv(t, "stack", "sync", "--parent", "main")
 
 	assert.Equal(t,
 		meta.BranchState{

--- a/e2e_tests/stack_sync_all_test.go
+++ b/e2e_tests/stack_sync_all_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestStackSyncAll(t *testing.T) {
-	repo := gittest.NewTempRepo(t)
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
 	repo.Git(t, "switch", "main")
@@ -26,7 +28,7 @@ func TestStackSyncAll(t *testing.T) {
 	//     stack-1:  \ -> 1a
 	//     stack-2:  \ -> 2a
 
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push", "--trunk", "--all")
+	RequireAv(t, "stack", "sync", "--trunk", "--all")
 
 	//     main:    X  -> X2
 	//     stack-1:        \ -> 1a

--- a/e2e_tests/stack_sync_amend_test.go
+++ b/e2e_tests/stack_sync_amend_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestSyncAfterAmendingCommit(t *testing.T) {
-	repo := gittest.NewTempRepo(t)
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
@@ -41,7 +43,7 @@ func TestSyncAfterAmendingCommit(t *testing.T) {
 	// Now we amend commit 1b and make sure the sync after succeeds
 	repo.CheckoutBranch(t, "refs/heads/stack-1")
 	repo.CommitFile(t, "my-file", "1a\n1c\n1b\n", gittest.WithAmend())
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync")
 	repo.CheckoutBranch(t, "refs/heads/stack-3")
 	contents, err := os.ReadFile("my-file")
 	require.NoError(t, err)

--- a/e2e_tests/stack_sync_delete_parent_test.go
+++ b/e2e_tests/stack_sync_delete_parent_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestStackSyncDeleteParent(t *testing.T) {
-	repo := gittest.NewTempRepo(t)
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
 	// To start, we create a simple two-stack where each stack has a single commit.
@@ -44,7 +46,7 @@ func TestStackSyncDeleteParent(t *testing.T) {
 	)
 
 	// Everything up to date now, so this should be a no-op.
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync")
 
 	// We simulate the stack-2 is deleted and submerged into stack-1
 	//     main:    X
@@ -57,7 +59,7 @@ func TestStackSyncDeleteParent(t *testing.T) {
 		newStack1Head = repo.GetCommitAtRef(t, plumbing.HEAD)
 	})
 	RequireAv(t, "stack", "tidy")
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync")
 
 	// stack-1 should be an ancestor of stack-3 after running sync
 	repo.Git(t, "merge-base", "--is-ancestor", newStack1Head.String(), "stack-3")

--- a/e2e_tests/stack_sync_merge_commit_test.go
+++ b/e2e_tests/stack_sync_merge_commit_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestStackSyncMergeCommit(t *testing.T) {
-	repo := gittest.NewTempRepo(t)
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
 	// To start, we create a simple two-stack where each stack has a single commit.
@@ -45,7 +47,7 @@ func TestStackSyncMergeCommit(t *testing.T) {
 	)
 
 	// Everything up to date now, so this should be a no-op.
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync")
 
 	// We simulate a merge here so that our history looks like:
 	//     main:    X                         / -> 1S
@@ -96,7 +98,7 @@ func TestStackSyncMergeCommit(t *testing.T) {
 		"squash commit of stack-1 should not be an ancestor of HEAD of stack-1 before running sync",
 	)
 
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync")
 
 	repo.Git(t, "merge-base", "--is-ancestor", squashCommit.String(), "stack-3")
 	assert.Equal(t,

--- a/e2e_tests/stack_sync_merged_parent_test.go
+++ b/e2e_tests/stack_sync_merged_parent_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestStackSyncMergedParent(t *testing.T) {
-	repo := gittest.NewTempRepo(t)
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
 	// To start, we create a simple two-stack where each stack has a single commit.
@@ -45,7 +47,7 @@ func TestStackSyncMergedParent(t *testing.T) {
 	)
 
 	// Everything up to date now, so this should be a no-op.
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync")
 
 	// We simulate a merge here so that our history looks like:
 	//     main:    X
@@ -89,7 +91,7 @@ func TestStackSyncMergedParent(t *testing.T) {
 		"squash commit of stack-1 should not be an ancestor of HEAD of stack-1 before running sync",
 	)
 
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync")
 
 	// squash commit of stack-2 should be an ancestor of HEAD of stack-3 after running sync
 	assert.Equal(t,

--- a/e2e_tests/stack_sync_trunk_test.go
+++ b/e2e_tests/stack_sync_trunk_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestStackSyncTrunk(t *testing.T) {
-	repo := gittest.NewTempRepo(t)
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
 	// To start, we create a simple two-stack where each stack has a single commit.
@@ -30,7 +32,7 @@ func TestStackSyncTrunk(t *testing.T) {
 	)
 
 	// Everything up to date now, so this should be a no-op.
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push")
+	RequireAv(t, "stack", "sync")
 
 	// We simulate a merge here so that our history looks like:
 	//     main:    X --------------> 1S -> 3a
@@ -71,7 +73,7 @@ func TestStackSyncTrunk(t *testing.T) {
 		"squash commit of stack-1 should not be an ancestor of HEAD of stack-2 before running sync",
 	)
 
-	RequireAv(t, "stack", "sync", "--no-fetch", "--no-push", "--trunk")
+	RequireAv(t, "stack", "sync", "--trunk")
 	// At this point, the stack should be:
 	//
 	//     main:    X --------------> 1S -> 3a

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -9,17 +9,11 @@ import (
 )
 
 type PullRequest struct {
-	ID     string
-	Number int64
-	Author struct {
-		Login string
-	}
+	ID                  string
+	Number              int64
 	HeadRefName         string
-	HeadRefOID          string
 	BaseRefName         string
 	IsDraft             bool
-	Mergeable           githubv4.MergeableState
-	Merged              bool
 	Permalink           string
 	State               githubv4.PullRequestState
 	Title               string

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -21,6 +21,10 @@ import (
 
 // NewTempRepo initializes a new git repository with reasonable defaults.
 func NewTempRepo(t *testing.T) *GitTestRepo {
+	return NewTempRepoWithGitHubServer(t, "http://github.invalid")
+}
+
+func NewTempRepoWithGitHubServer(t *testing.T, serverURL string) *GitTestRepo {
 	var dir string
 	var remoteDir string
 	if os.Getenv("AV_TEST_PRESERVE_TEMP_REPO") != "" {
@@ -89,6 +93,17 @@ func NewTempRepo(t *testing.T) *GitTestRepo {
 		Name:  "nonexistent",
 	})
 	require.NoError(t, tx.Commit(), "failed to write repository metadata")
+
+	err = os.WriteFile(
+		filepath.Join(repo.GitDir, "av", "config.yml"),
+		[]byte(fmt.Sprintf(`
+github:
+    token: "dummy_valid_token"
+    baseUrl: %q
+`, serverURL)),
+		0644,
+	)
+	require.NoError(t, err, "failed to write .git/av/config.yml")
 
 	return repo
 }


### PR DESCRIPTION
This allows us to test stack sync with the default option.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
