### PR TITLE
Add interactive `stack next`

### DIFF
--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -49,13 +49,17 @@ var stackNextCmd = &cobra.Command{
 			}
 		}
 		stackNext, err := newStackNextModel(stackNextFlags.Last, n)
+		if err != nil {
+			return err
+		}
+
 		p := tea.NewProgram(stackNext, opts...)
 		model, err := p.Run()
 		if err != nil {
 			return err
 		}
 
-		if err := model.(*stackNextModel).err; err != nil {
+		if err := model.(stackNextModel).err; err != nil {
 			return actions.ErrExitSilently{ExitCode: 1}
 		}
 		return nil
@@ -82,23 +86,23 @@ type stackNextModel struct {
 	nInStack    int
 }
 
-func newStackNextModel(lastInStack bool, nInStack int) (*stackNextModel, error) {
+func newStackNextModel(lastInStack bool, nInStack int) (stackNextModel, error) {
 	repo, err := getRepo()
 	if err != nil {
-		return nil, err
+		return stackNextModel{}, err
 	}
 
 	db, err := getDB(repo)
 	if err != nil {
-		return nil, err
+		return stackNextModel{}, err
 	}
 
 	currentBranch, err := repo.CurrentBranchName()
 	if err != nil {
-		return nil, err
+		return stackNextModel{}, err
 	}
 
-	return &stackNextModel{
+	return stackNextModel{
 		currentBranch: currentBranch,
 		db:            db,
 		repo:          repo,
@@ -106,7 +110,7 @@ func newStackNextModel(lastInStack bool, nInStack int) (*stackNextModel, error) 
 		lastInStack:   lastInStack,
 	}, nil
 }
-func (m *stackNextModel) currentBranchChildren() []string {
+func (m stackNextModel) currentBranchChildren() []string {
 	tx := m.db.ReadTx()
 	children := meta.Children(tx, m.currentBranch)
 	options := make([]string, 0, len(children))
@@ -119,7 +123,7 @@ func (m *stackNextModel) currentBranchChildren() []string {
 
 type branchCheckedOutMsg struct{}
 
-func (m *stackNextModel) checkoutCurrentBranch() tea.Msg {
+func (m stackNextModel) checkoutCurrentBranch() tea.Msg {
 	if _, err := m.repo.CheckoutBranch(&git.CheckoutBranch{
 		Name: m.currentBranch,
 	}); err != nil {
@@ -133,7 +137,7 @@ type checkoutBranchMsg struct{}
 type nextBranchMsg struct{}
 type showSelectionMsg struct{}
 
-func (m *stackNextModel) nextBranch() tea.Msg {
+func (m stackNextModel) nextBranch() tea.Msg {
 	if m.lastInStack && len(m.currentBranchChildren()) == 0 {
 		return checkoutBranchMsg{}
 	}
@@ -162,11 +166,11 @@ func (m *stackNextModel) nextBranch() tea.Msg {
 
 var _ tea.Model = &stackNextModel{}
 
-func (m *stackNextModel) Init() tea.Cmd {
+func (m stackNextModel) Init() tea.Cmd {
 	return m.nextBranch
 }
 
-func (m *stackNextModel) View() string {
+func (m stackNextModel) View() string {
 	sb := strings.Builder{}
 	if m.err != nil {
 		sb.WriteString(m.err.Error() + "\n")
@@ -180,7 +184,7 @@ func (m *stackNextModel) View() string {
 	return sb.String()
 }
 
-func (m *stackNextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m stackNextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case error:
 		m.err = msg

--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -49,17 +49,13 @@ var stackNextCmd = &cobra.Command{
 			}
 		}
 		stackNext, err := newStackNextModel(stackNextFlags.Last, n)
-		if err != nil {
-			return err
-		}
-
 		p := tea.NewProgram(stackNext, opts...)
 		model, err := p.Run()
 		if err != nil {
 			return err
 		}
 
-		if err := model.(stackNextModel).err; err != nil {
+		if err := model.(*stackNextModel).err; err != nil {
 			return actions.ErrExitSilently{ExitCode: 1}
 		}
 		return nil
@@ -86,23 +82,23 @@ type stackNextModel struct {
 	nInStack    int
 }
 
-func newStackNextModel(lastInStack bool, nInStack int) (stackNextModel, error) {
+func newStackNextModel(lastInStack bool, nInStack int) (*stackNextModel, error) {
 	repo, err := getRepo()
 	if err != nil {
-		return stackNextModel{}, err
+		return nil, err
 	}
 
 	db, err := getDB(repo)
 	if err != nil {
-		return stackNextModel{}, err
+		return nil, err
 	}
 
 	currentBranch, err := repo.CurrentBranchName()
 	if err != nil {
-		return stackNextModel{}, err
+		return nil, err
 	}
 
-	return stackNextModel{
+	return &stackNextModel{
 		currentBranch: currentBranch,
 		db:            db,
 		repo:          repo,
@@ -110,7 +106,7 @@ func newStackNextModel(lastInStack bool, nInStack int) (stackNextModel, error) {
 		lastInStack:   lastInStack,
 	}, nil
 }
-func (m stackNextModel) currentBranchChildren() []string {
+func (m *stackNextModel) currentBranchChildren() []string {
 	tx := m.db.ReadTx()
 	children := meta.Children(tx, m.currentBranch)
 	options := make([]string, 0, len(children))
@@ -123,7 +119,7 @@ func (m stackNextModel) currentBranchChildren() []string {
 
 type branchCheckedOutMsg struct{}
 
-func (m stackNextModel) checkoutCurrentBranch() tea.Msg {
+func (m *stackNextModel) checkoutCurrentBranch() tea.Msg {
 	if _, err := m.repo.CheckoutBranch(&git.CheckoutBranch{
 		Name: m.currentBranch,
 	}); err != nil {
@@ -137,7 +133,7 @@ type checkoutBranchMsg struct{}
 type nextBranchMsg struct{}
 type showSelectionMsg struct{}
 
-func (m stackNextModel) nextBranch() tea.Msg {
+func (m *stackNextModel) nextBranch() tea.Msg {
 	if m.lastInStack && len(m.currentBranchChildren()) == 0 {
 		return checkoutBranchMsg{}
 	}
@@ -166,11 +162,11 @@ func (m stackNextModel) nextBranch() tea.Msg {
 
 var _ tea.Model = &stackNextModel{}
 
-func (m stackNextModel) Init() tea.Cmd {
+func (m *stackNextModel) Init() tea.Cmd {
 	return m.nextBranch
 }
 
-func (m stackNextModel) View() string {
+func (m *stackNextModel) View() string {
 	sb := strings.Builder{}
 	if m.err != nil {
 		sb.WriteString(m.err.Error() + "\n")
@@ -184,7 +180,7 @@ func (m stackNextModel) View() string {
 	return sb.String()
 }
 
-func (m stackNextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *stackNextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case error:
 		m.err = msg

--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -138,7 +138,9 @@ type nextBranchMsg struct{}
 type showSelectionMsg struct{}
 
 func (m stackNextModel) nextBranch() tea.Msg {
-	if m.lastInStack && len(m.currentBranchChildren()) == 0 {
+	currentBanchChildren := m.currentBranchChildren()
+
+	if m.lastInStack && len(currentBanchChildren) == 0 {
 		return checkoutBranchMsg{}
 	}
 
@@ -146,15 +148,15 @@ func (m stackNextModel) nextBranch() tea.Msg {
 		return checkoutBranchMsg{}
 	}
 
-	if m.nInStack > 0 && len(m.currentBranchChildren()) == 0 {
+	if m.nInStack > 0 && len(currentBanchChildren) == 0 {
 		return errors.New("invalid number (there are not enough subsequent branches in the stack)")
 	}
 
-	if len(m.currentBranchChildren()) == 0 {
+	if len(currentBanchChildren) == 0 {
 		return fmt.Errorf("there are no children of branch %s", colors.UserInput(m.currentBranch))
 	}
 
-	if len(m.currentBranchChildren()) == 1 {
+	if len(currentBanchChildren) == 1 {
 		return nextBranchMsg{}
 	}
 

--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/erikgeiser/promptkit/selection"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +23,6 @@ var stackNextCmd = &cobra.Command{
 	Aliases: []string{"n"},
 	Short:   "checkout the next branch in the stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get the subsequent branches so we can checkout the nth one
 		repo, err := getRepo()
 		if err != nil {
 			return err
@@ -38,52 +38,53 @@ var stackNextCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		subsequentBranches := meta.SubsequentBranches(tx, currentBranch)
 
-		var branchToCheckout string
+		if len(meta.Children(tx, currentBranch)) == 0 {
+			return errors.New("there is no next branch")
+		}
+
 		if stackNextFlags.Last {
-			if len(subsequentBranches) == 0 {
-				return errors.New("already on last branch in stack\n")
-			}
-			branchToCheckout = subsequentBranches[len(subsequentBranches)-1]
-		} else {
-			if len(subsequentBranches) == 0 {
-				return errors.New("there is no next branch")
-			}
-			var n int = 1
-			if len(args) == 1 {
-				var err error
-				n, err = strconv.Atoi(args[0])
+			for len(meta.Children(tx, currentBranch)) > 0 {
+				selectedChild, err := nextChild(tx, currentBranch)
 				if err != nil {
-					return errors.New("invalid number (unable to parse)")
+					return err
 				}
-			} else if len(args) > 1 {
-				_ = cmd.Usage()
-				return errors.New("too many arguments")
+
+				currentBranch = selectedChild.Name
 			}
-			if n <= 0 {
-				return errors.New("invalid number (must be >= 1)")
-			}
-			if n > len(subsequentBranches) {
-				return fmt.Errorf("invalid number (there are only %d subsequent branches in the stack)", len(subsequentBranches))
-			}
-			branchToCheckout = subsequentBranches[n-1]
+			return checkoutBranch(currentBranch, repo)
 		}
 
-		if _, err := repo.CheckoutBranch(&git.CheckoutBranch{
-			Name: branchToCheckout,
-		}); err != nil {
-			return err
+		var n int = 1
+		if len(args) == 1 {
+			var err error
+			n, err = strconv.Atoi(args[0])
+			if err != nil {
+				return errors.New("invalid number (unable to parse)")
+			}
+		} else if len(args) > 1 {
+			_ = cmd.Usage()
+			return errors.New("too many arguments")
+		}
+		if n <= 0 {
+			return errors.New("invalid number (must be >= 1)")
 		}
 
-		_, _ = fmt.Fprint(
-			os.Stderr,
-			"Checked out branch ",
-			colors.UserInput(branchToCheckout),
-			"\n",
-		)
+		for i := 0; i < n; i++ {
+			if len(meta.Children(tx, currentBranch)) == 0 {
+				return fmt.Errorf("invalid number (there are only %d subsequent branches in the stack)", i)
+			}
 
-		return nil
+			selectedChild, err := nextChild(tx, currentBranch)
+			if err != nil {
+				return err
+			}
+
+			currentBranch = selectedChild.Name
+		}
+
+		return checkoutBranch(currentBranch, repo)
+
 	},
 }
 
@@ -92,4 +93,55 @@ func init() {
 		&stackNextFlags.Last, "last", false,
 		"go to the last branch in the current stack",
 	)
+}
+
+func checkoutBranch(branchname string, repo *git.Repo) error {
+	if _, err := repo.CheckoutBranch(&git.CheckoutBranch{
+		Name: branchname,
+	}); err != nil {
+		return err
+	}
+
+	fmt.Fprint(
+		os.Stderr,
+		"Checked out branch ",
+		colors.UserInput(branchname),
+		"\n",
+	)
+
+	return nil
+}
+
+// nextChild prompts the user to select the next child branch to follow or returns the only child if there is only one.
+func nextChild(tx meta.ReadTx, branchName string) (meta.Branch, error) {
+	children := meta.Children(tx, branchName)
+	if len(children) == 0 {
+		return meta.Branch{}, errors.New("no children")
+	}
+
+	if len(children) == 1 {
+		return children[0], nil
+	}
+
+	options := make([]string, 0, len(children))
+	for _, child := range children {
+		options = append(options, child.Name)
+	}
+
+	sp := selection.New(fmt.Sprintf("There are multiple children of branch %s. Which branch would you like to follow?", colors.UserInput(branchName)), options)
+	sp.PageSize = 4
+	sp.Filter = nil
+
+	choice, err := sp.RunPrompt()
+	if err != nil {
+		return meta.Branch{}, err
+	}
+
+	for _, child := range children {
+		if child.Name == choice {
+			return child, nil
+		}
+	}
+
+	return meta.Branch{}, errors.New("could not find next branch")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.1
 
 require (
 	emperror.dev/errors v0.8.1
+	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.4
 	github.com/charmbracelet/lipgloss v0.11.0
 	github.com/fatih/color v1.17.0
@@ -32,6 +33,7 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/x/ansi v0.1.2 // indirect
 	github.com/charmbracelet/x/input v0.1.0 // indirect
@@ -50,6 +52,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
@@ -93,7 +96,6 @@ require (
 	github.com/ccojocar/zxcvbn-go v1.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charithe/durationcheck v0.0.10 // indirect
-	github.com/charmbracelet/bubbles v0.18.0
 	github.com/chavacava/garif v0.1.0 // indirect
 	github.com/ckaznocha/intrange v0.1.2 // indirect
 	github.com/curioswitch/go-reassign v0.2.0 // indirect
@@ -101,6 +103,7 @@ require (
 	github.com/dave/dst v0.27.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
+	github.com/erikgeiser/promptkit v0.9.0
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/firefart/nonamedreturns v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/ashanbrown/forbidigo v1.6.0 h1:D3aewfM37Yb3pxHujIPSpTf6oQk9sc9WZi8ger
 github.com/ashanbrown/forbidigo v1.6.0/go.mod h1:Y8j9jy9ZYAEHXdu723cUlraTqbzjKF1MUyfOKL+AjcU=
 github.com/ashanbrown/makezero v1.1.1 h1:iCQ87C0V0vSyO+M9E/FZYbu65auqH0lnsOkf5FcB28s=
 github.com/ashanbrown/makezero v1.1.1/go.mod h1:i1bJLCRSCHOcOa9Y6MyF2FTfMZMFdHvxKHxgO5Z1axI=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -129,6 +131,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/erikgeiser/promptkit v0.9.0 h1:3qL1mS/ntCrXdb8sTP/ka82CJ9kEQaGuYXNrYJkWYBc=
+github.com/erikgeiser/promptkit v0.9.0/go.mod h1:pU9dtogSe3Jlc2AY77EP7R4WFP/vgD4v+iImC83KsCo=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
 github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
@@ -309,6 +313,7 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mgechev/revive v1.3.7 h1:502QY0vQGe9KtYJ9FpxMz9rL+Fc/P13CI5POL4uHCcE=
@@ -325,6 +330,8 @@ github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
+github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
+github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81U=
@@ -381,6 +388,7 @@ github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 h1:TCg2WBOl
 github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727/go.mod h1:rlzQ04UMyJXu/aOvhd8qT+hvDrFpiwqp8MRXDY9szc0=
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 h1:M8mH9eK4OUR4lu7Gd+PU1fV2/qnDNfzT635KRSObncs=
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567/go.mod h1:DWNGW8A4Y+GyBgPuaQJuWiy0XYftx4Xm/y5Jqk9I6VQ=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
![out](https://github.com/aviator-co/av/assets/10200358/a5bfd83e-e390-44e8-accd-905591123b25)

## Proposal

A stack next command that supports interactively selecting the path you want to navigate through. 

For example if you have multiple stacks on top of your trunk (like below) and you run `av stack next`
<img width="383" alt="image" src="https://github.com/aviator-co/av/assets/10200358/44189309-4f3d-47bc-b4b5-f7ba9f743636">


It will now prompt you to ask which one you want to use:
<img width="627" alt="image" src="https://github.com/aviator-co/av/assets/10200358/7470c6d2-bb79-47b6-90aa-97be63ea5bf1">

This is a proposal and uses the github.com/erikgeiser/promptkit library, if this is accepted and you have a preferred prompt library let me know.


