### PR TITLE
Revive the `av stack reparent` command

### DIFF
--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -83,3 +83,23 @@ func getOrCreateDB(repo *git.Repo) (meta.DB, bool, error) {
 	}
 	return jsonfiledb.OpenPath(dbPath)
 }
+
+func allBranches() ([]string, error) {
+	repo, err := getRepo()
+	if err != nil {
+		return nil, err
+	}
+	db, err := getDB(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := db.ReadTx()
+
+	var branches []string
+	for b := range tx.AllBranches() {
+		branches = append(branches, b)
+	}
+
+	return branches, nil
+}

--- a/cmd/av/stack_adopt.go
+++ b/cmd/av/stack_adopt.go
@@ -418,4 +418,9 @@ func init() {
 		&stackAdoptFlags.Parent, "parent", "",
 		"force specifying the parent branch",
 	)
+
+	_ = stackSyncCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		branches, _ := allBranches()
+		return branches, cobra.ShellCompDirectiveDefault
+	})
 }

--- a/cmd/av/stack_branch.go
+++ b/cmd/av/stack_branch.go
@@ -185,8 +185,8 @@ func init() {
 	stackBranchCmd.Flags().
 		BoolVar(&stackBranchFlags.Force, "force", false, "force rename the current branch")
 
-	branches, _ := allBranches()
 	_ = stackBranchCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		branches, _ := allBranches()
 		return branches, cobra.ShellCompDirectiveDefault
 	})
 }

--- a/cmd/av/stack_reparent.go
+++ b/cmd/av/stack_reparent.go
@@ -1,24 +1,284 @@
 package main
 
 import (
-	"fmt"
 	"os"
+	"strings"
 
+	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/actions"
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/sequencer"
+	"github.com/aviator-co/av/internal/sequencer/planner"
 	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/aviator-co/av/internal/utils/stackutils"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
+var stackReparentFlags struct {
+	Parent   string
+	Abort    bool
+	Continue bool
+	Skip     bool
+}
+
 var stackReparentCmd = &cobra.Command{
-	Use:    "reparent <new-parent>",
-	Hidden: true,
+	Use:   "reparent",
+	Short: "Reparent branches",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, _ = fmt.Fprint(os.Stderr,
-			colors.Failure("ERROR: "),
-			"The ", colors.CliCmd("av stack reparent"), " command is deprecated: ",
-			"use ", colors.CliCmd("av stack sync --parent <new-parent>"), " instead.",
-			"\n",
-		)
-		os.Exit(1)
+		repo, err := getRepo()
+		if err != nil {
+			return err
+		}
+
+		db, err := getDB(repo)
+		if err != nil {
+			return err
+		}
+
+		var opts []tea.ProgramOption
+		if !isatty.IsTerminal(os.Stdout.Fd()) {
+			opts = []tea.ProgramOption{
+				tea.WithInput(nil),
+			}
+		}
+		p := tea.NewProgram(stackReparentViewModel{
+			repo:    repo,
+			db:      db,
+			spinner: spinner.New(spinner.WithSpinner(spinner.Dot)),
+		}, opts...)
+		model, err := p.Run()
+		if err != nil {
+			return err
+		}
+		if err := model.(stackReparentViewModel).err; err != nil {
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
+		if s := model.(stackReparentViewModel).rebaseConflictErrorHeadline; s != "" {
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
 		return nil
 	},
+}
+
+type stackReparentState struct {
+	InitialBranch   string
+	NewParentBranch string
+	Seq             *sequencer.Sequencer
+}
+
+type stackReparentSeqResult struct {
+	result *git.RebaseResult
+	err    error
+}
+
+type stackReparentViewModel struct {
+	repo    *git.Repo
+	db      meta.DB
+	state   *stackReparentState
+	spinner spinner.Model
+
+	rebaseConflictErrorHeadline string
+	rebaseConflictHint          string
+	abortedBranch               plumbing.ReferenceName
+	err                         error
+}
+
+func (vm stackReparentViewModel) Init() tea.Cmd {
+	return tea.Batch(vm.spinner.Tick, vm.initCmd)
+}
+
+func (vm stackReparentViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case error:
+		vm.err = msg
+		return vm, tea.Quit
+	case *stackReparentState:
+		vm.state = msg
+		if stackReparentFlags.Skip || stackReparentFlags.Continue || stackReparentFlags.Abort {
+			if stackReparentFlags.Abort {
+				vm.abortedBranch = vm.state.Seq.CurrentSyncRef
+			}
+			return vm, vm.runSeqWithContinuationFlags
+		}
+		return vm, vm.runSeq
+	case *stackReparentSeqResult:
+		if msg.err == nil && msg.result == nil {
+			// Finished the sequence.
+			if err := vm.repo.WriteStateFile(git.StateFileKindReparent, nil); err != nil {
+				vm.err = err
+			}
+			if _, err := vm.repo.CheckoutBranch(&git.CheckoutBranch{Name: vm.state.InitialBranch}); err != nil {
+				vm.err = err
+			}
+			return vm, tea.Quit
+		}
+		if msg.result != nil && msg.result.Status == git.RebaseConflict {
+			vm.rebaseConflictErrorHeadline = msg.result.ErrorHeadline
+			vm.rebaseConflictHint = msg.result.Hint
+			if err := vm.repo.WriteStateFile(git.StateFileKindReparent, vm.state); err != nil {
+				vm.err = err
+			}
+			return vm, tea.Quit
+		}
+		vm.err = msg.err
+		if vm.err != nil {
+			return vm, tea.Quit
+		}
+		return vm, vm.runSeq
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		vm.spinner, cmd = vm.spinner.Update(msg)
+		return vm, cmd
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			return vm, tea.Quit
+		}
+	}
+	return vm, nil
+}
+
+func (vm stackReparentViewModel) View() string {
+	sb := strings.Builder{}
+	if vm.state != nil && vm.state.Seq != nil {
+		sb.WriteString("Reparenting " + vm.state.InitialBranch + " onto " + vm.state.NewParentBranch + "...\n")
+		if vm.state.Seq.CurrentSyncRef != "" {
+			sb.WriteString("Restacking " + vm.state.Seq.CurrentSyncRef.Short() + "...\n")
+		} else if vm.abortedBranch != "" {
+			sb.WriteString("Restack aborted\n")
+		} else {
+			sb.WriteString("Restack done\n")
+		}
+		// The sequencer operates from top to bottom. The branches that are synced before
+		// the current branches are already synced. The branches that come after the current
+		// branch are pending.
+		syncedBranches := map[plumbing.ReferenceName]bool{}
+		pendingBranches := map[plumbing.ReferenceName]bool{}
+		seenCurrent := false
+		for _, op := range vm.state.Seq.Operations {
+			if op.Name == vm.state.Seq.CurrentSyncRef || op.Name == vm.abortedBranch {
+				seenCurrent = true
+			} else if !seenCurrent {
+				syncedBranches[op.Name] = true
+			} else {
+				pendingBranches[op.Name] = true
+			}
+		}
+
+		nodes, err := stackutils.BuildStackTreeRelatedBranchStacks(vm.db.ReadTx(), vm.state.InitialBranch, true, []string{vm.state.InitialBranch, vm.state.NewParentBranch})
+		if err != nil {
+			sb.WriteString("Failed to build stack tree: " + err.Error() + "\n")
+		} else {
+			for _, node := range nodes {
+				sb.WriteString(stackutils.RenderTree(node, func(branchName string, isTrunk bool) string {
+					bn := plumbing.NewBranchReferenceName(branchName)
+					if syncedBranches[bn] {
+						return colors.Success("✓ " + branchName)
+					}
+					if pendingBranches[bn] {
+						return lipgloss.NewStyle().Foreground(colors.Amber500).Render(branchName)
+					}
+					if bn == vm.state.Seq.CurrentSyncRef {
+						return lipgloss.NewStyle().Foreground(colors.Amber500).Render(vm.spinner.View() + branchName)
+					}
+					if bn == vm.abortedBranch {
+						return colors.Failure("✗ " + branchName)
+					}
+					return branchName
+				}))
+			}
+		}
+	}
+	if vm.rebaseConflictErrorHeadline != "" {
+		sb.WriteString("\n")
+		sb.WriteString(colors.Failure("Rebase conflict while rebasing ", vm.state.Seq.CurrentSyncRef.Short()) + "\n")
+		sb.WriteString(vm.rebaseConflictErrorHeadline + "\n")
+		sb.WriteString(vm.rebaseConflictHint + "\n")
+		sb.WriteString("\n")
+		sb.WriteString("Resolve the conflicts and continue the reparent with " + colors.CliCmd("av stack reparent --continue") + "\n")
+	}
+	if vm.err != nil {
+		sb.WriteString(vm.err.Error() + "\n")
+	}
+	return sb.String()
+}
+
+func (vm stackReparentViewModel) initCmd() tea.Msg {
+	var state stackReparentState
+	if err := vm.repo.ReadStateFile(git.StateFileKindReparent, &state); err != nil && os.IsNotExist(err) {
+		currentBranch, err := vm.repo.CurrentBranchName()
+		if err != nil {
+			return err
+		}
+		if isCurrentBranchTrunk, err := vm.repo.IsTrunkBranch(currentBranch); err != nil {
+			return err
+		} else if isCurrentBranchTrunk {
+			return errors.New("current branch is a trunk branch")
+		}
+		if _, exist := vm.db.ReadTx().Branch(currentBranch); !exist {
+			return errors.New("current branch is not adopted to av")
+		}
+
+		if isParentBranchTrunk, err := vm.repo.IsTrunkBranch(stackReparentFlags.Parent); err != nil {
+			return err
+		} else if !isParentBranchTrunk {
+			if _, exist := vm.db.ReadTx().Branch(stackReparentFlags.Parent); !exist {
+				return errors.New("parent branch is not adopted to av")
+			}
+		}
+		state.InitialBranch = currentBranch
+		state.NewParentBranch = stackReparentFlags.Parent
+		ops, err := planner.PlanForReparent(vm.db.ReadTx(), vm.repo, plumbing.NewBranchReferenceName(currentBranch), plumbing.NewBranchReferenceName(stackReparentFlags.Parent))
+		if err != nil {
+			return err
+		}
+		if len(ops) == 0 {
+			return errors.New("nothing to restack")
+		}
+		state.Seq = sequencer.NewSequencer("origin", vm.db, ops)
+	} else if err != nil {
+		return err
+	}
+	return &state
+}
+
+func (vm stackReparentViewModel) runSeqWithContinuationFlags() tea.Msg {
+	result, err := vm.state.Seq.Run(vm.repo, vm.db, stackReparentFlags.Abort, stackReparentFlags.Continue, stackReparentFlags.Skip)
+	return &stackReparentSeqResult{result: result, err: err}
+}
+
+func (vm stackReparentViewModel) runSeq() tea.Msg {
+	result, err := vm.state.Seq.Run(vm.repo, vm.db, false, false, false)
+	return &stackReparentSeqResult{result: result, err: err}
+}
+
+func init() {
+	stackReparentCmd.Flags().BoolVar(
+		&stackReparentFlags.Continue, "continue", false,
+		"continue an in-progress reparent",
+	)
+	stackReparentCmd.Flags().BoolVar(
+		&stackReparentFlags.Abort, "abort", false,
+		"abort an in-progress reparent",
+	)
+	stackReparentCmd.Flags().BoolVar(
+		&stackReparentFlags.Skip, "skip", false,
+		"skip the current commit and continue an in-progress reparent",
+	)
+	stackReparentCmd.Flags().StringVar(
+		&stackReparentFlags.Parent, "parent", "",
+		"new parent branch name",
+	)
+
+	stackReparentCmd.MarkFlagsMutuallyExclusive("continue", "abort", "skip", "parent")
+	_ = stackReparentCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		branches, _ := allBranches()
+		return branches, cobra.ShellCompDirectiveDefault
+	})
 }

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -306,29 +306,8 @@ func init() {
 	stackSyncCmd.MarkFlagsMutuallyExclusive("current", "trunk")
 	stackSyncCmd.MarkFlagsMutuallyExclusive("trunk", "parent")
 	stackSyncCmd.MarkFlagsMutuallyExclusive("continue", "abort", "skip")
-
-	branches, _ := allBranches()
 	_ = stackSyncCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		branches, _ := allBranches()
 		return branches, cobra.ShellCompDirectiveDefault
 	})
-}
-
-func allBranches() ([]string, error) {
-	repo, err := getRepo()
-	if err != nil {
-		return nil, err
-	}
-	db, err := getDB(repo)
-	if err != nil {
-		return nil, err
-	}
-
-	tx := db.ReadTx()
-
-	var branches []string
-	for b := range tx.AllBranches() {
-		branches = append(branches, b)
-	}
-
-	return branches, nil
 }

--- a/docs/av-stack-reparent.1.md
+++ b/docs/av-stack-reparent.1.md
@@ -1,0 +1,30 @@
+# av-stack-reparent
+
+## NAME
+
+av-stack-reparent - Reparent a branch to a new parent
+
+## SYNOPSIS
+
+```synopsis
+av stack sync [--continue | --abort | --skip | --parent=<parent>]
+```
+
+## DESCRIPTION
+
+This rebases the current branch onto the new parent and runs the restack
+operations on the children.
+
+## OPTIONS
+
+`--continue`
+: Continue an in-progress rebase.
+
+`--abort`
+: Abort an in-progress rebase.
+
+`--skip`
+: Skip the current commit and continue an in-progress rebase.
+
+`--parent=<parent>`
+: Parent branch to rebase onto.

--- a/e2e_tests/stack_reparent_test.go
+++ b/e2e_tests/stack_reparent_test.go
@@ -75,6 +75,72 @@ func TestStackSyncReparentTrunk(t *testing.T) {
 	RequireAv(t, "stack", "sync", "--parent", "main")
 }
 
+func TestStackReparent(t *testing.T) {
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
+	Chdir(t, repo.RepoDir)
+
+	RequireAv(t, "stack", "branch", "foo")
+	repo.CommitFile(t, "foo.txt", "foo")
+	requireFileContent(t, "foo.txt", "foo")
+
+	RequireAv(t, "stack", "branch", "bar")
+	repo.CommitFile(t, "bar.txt", "bar")
+	requireFileContent(t, "bar.txt", "bar")
+	requireFileContent(t, "foo.txt", "foo")
+
+	RequireAv(t, "stack", "branch", "spam")
+	repo.CommitFile(t, "spam.txt", "spam")
+	requireFileContent(t, "spam.txt", "spam")
+
+	// Now, re-parent spam on top of bar (should be relatively a no-op)
+	RequireAv(t, "stack", "reparent", "--parent", "bar")
+	requireFileContent(t, "spam.txt", "spam")
+	requireFileContent(
+		t,
+		"bar.txt",
+		"bar",
+		"bar.txt should still be set after reparenting onto same branch",
+	)
+
+	// Now, re-parent spam on top of foo
+	RequireAv(t, "stack", "reparent", "--parent", "foo")
+	currentBranch := repo.CurrentBranch(t)
+	require.Equal(
+		t,
+		plumbing.ReferenceName("refs/heads/spam"),
+		currentBranch,
+		"branch should be set to original branch (spam) after reparenting onto foo",
+	)
+	requireFileContent(t, "spam.txt", "spam")
+	requireFileContent(
+		t,
+		"foo.txt",
+		"foo",
+		"foo.txt should be set after reparenting onto foo branch",
+	)
+	require.NoFileExists(t, "bar.txt", "bar.txt should not exist after reparenting onto foo branch")
+}
+
+func TestStackReparentTrunk(t *testing.T) {
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
+	Chdir(t, repo.RepoDir)
+
+	RequireAv(t, "stack", "branch", "foo")
+	repo.CommitFile(t, "foo.txt", "foo")
+
+	RequireAv(t, "stack", "branch", "bar")
+	repo.CommitFile(t, "bar.txt", "bar")
+
+	// Delete the local main. av should use the remote tracking branch.
+	repo.Git(t, "branch", "-D", "main")
+
+	RequireAv(t, "stack", "reparent", "--parent", "main")
+}
+
 func requireFileContent(t *testing.T, file string, expected string, args ...any) {
 	actual, err := os.ReadFile(file)
 	if err != nil {

--- a/internal/git/state_file.go
+++ b/internal/git/state_file.go
@@ -9,9 +9,10 @@ import (
 type StateFileKind string
 
 const (
-	StateFileKindSync    StateFileKind = "stack-sync.state.json"
-	StateFileKindReorder StateFileKind = "stack-reorder.state.json"
-	StateFileKindRestack StateFileKind = "stack-restack.state.json"
+	StateFileKindSync     StateFileKind = "stack-sync.state.json"
+	StateFileKindReorder  StateFileKind = "stack-reorder.state.json"
+	StateFileKindRestack  StateFileKind = "stack-restack.state.json"
+	StateFileKindReparent StateFileKind = "stack-reparent.state.json"
 )
 
 func (r *Repo) ReadStateFile(kind StateFileKind, msg any) error {

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -140,16 +140,10 @@ func StackBranches(tx ReadTx, name string) ([]string, error) {
 	return res, nil
 }
 
-// StackBranchesMap returns a map of branch names to their metadata for the stack
-// associated with the given branch.
-func StackBranchesMap(tx ReadTx, name string) (map[string]Branch, error) {
-	branchNames, err := StackBranches(tx, name)
-	if err != nil {
-		return nil, err
-	}
-
-	branches := make(map[string]Branch, len(branchNames))
-	for _, branchName := range branchNames {
+// BranchesMap returns a map of branch names to their metadata.
+func BranchesMap(tx ReadTx, names []string) (map[string]Branch, error) {
+	branches := make(map[string]Branch, len(names))
+	for _, branchName := range names {
 		branch, ok := tx.Branch(branchName)
 		if !ok {
 			return nil, errors.Errorf("branch metadata not found for %q", branchName)


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
