### PR TITLE
Add --all and --current options to `av stack restack`

### DIFF
--- a/docs/av-stack-restack.1.md
+++ b/docs/av-stack-restack.1.md
@@ -26,6 +26,13 @@ the branches.
 
 ## OPTIONS
 
+`--all`
+: Rebase all branches.
+
+`--current`
+: Only rebase up to the current branch. (Don't recurse into descendant
+  branches.)
+
 `--continue`
 : Continue an in-progress rebase.
 

--- a/internal/sequencer/planner/planner.go
+++ b/internal/sequencer/planner/planner.go
@@ -8,7 +8,20 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
-func PlanForRestack(tx meta.ReadTx, repo *git.Repo, targetBranches []plumbing.ReferenceName) ([]sequencer.RestackOp, error) {
+func PlanForRestack(tx meta.ReadTx, repo *git.Repo, currentBranch plumbing.ReferenceName, restackAll, restackCurrent bool) ([]sequencer.RestackOp, error) {
+	var targetBranches []plumbing.ReferenceName
+	var err error
+	if restackAll {
+		targetBranches, err = GetTargetBranches(tx, repo, false, AllBranches)
+	} else if restackCurrent {
+		targetBranches, err = GetTargetBranches(tx, repo, false, CurrentAndParents)
+	} else {
+		targetBranches, err = GetTargetBranches(tx, repo, false, CurrentStack)
+	}
+	if err != nil {
+		return nil, err
+	}
+
 	var ret []sequencer.RestackOp
 	for _, br := range targetBranches {
 		avbr, _ := tx.Branch(br.Short())


### PR DESCRIPTION
These are the same options as `av stack sync`.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"av_stack_reparent","parentHead":"6f6a90b011f846f3f2d2462cc7591805339a9754","parentPull":309,"trunk":"master"}
```
-->
