### PR TITLE
Use the same code as av stack restack in other commands

### DIFF
--- a/cmd/av/commit_common.go
+++ b/cmd/av/commit_common.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/actions"
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/sequencer"
+	"github.com/aviator-co/av/internal/sequencer/planner"
+	"github.com/aviator-co/av/internal/sequencer/sequencerui"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/mattn/go-isatty"
+)
+
+var nothingToRestackError = errors.Sentinel("nothing to restack")
+
+func runPostCommitRestack(repo *git.Repo, db meta.DB) error {
+	var opts []tea.ProgramOption
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		opts = []tea.ProgramOption{
+			tea.WithInput(nil),
+		}
+	}
+	p := tea.NewProgram(&postCommitRestackViewModel{repo: repo, db: db}, opts...)
+	model, err := p.Run()
+	if err != nil {
+		return err
+	}
+	if err := model.(*postCommitRestackViewModel).err; err != nil {
+		if errors.Is(err, nothingToRestackError) {
+			return nil
+		}
+		return actions.ErrExitSilently{ExitCode: 1}
+	}
+	if model.(*postCommitRestackViewModel).quitWithConflict {
+		return actions.ErrExitSilently{ExitCode: 1}
+	}
+	return nil
+}
+
+type postCommitRestackViewModel struct {
+	repo *git.Repo
+	db   meta.DB
+
+	restackModel *sequencerui.RestackModel
+
+	quitWithConflict bool
+	err              error
+}
+
+func (vm *postCommitRestackViewModel) Init() tea.Cmd {
+	state, err := vm.createState()
+	if err != nil {
+		return func() tea.Msg { return err }
+	}
+	vm.restackModel = sequencerui.NewRestackModel(vm.repo, vm.db)
+	vm.restackModel.State = state
+	return vm.restackModel.Init()
+}
+
+func (vm *postCommitRestackViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case *sequencerui.RestackProgress, spinner.TickMsg:
+		var cmd tea.Cmd
+		vm.restackModel, cmd = vm.restackModel.Update(msg)
+		return vm, cmd
+	case *sequencerui.RestackConflict:
+		if err := vm.writeState(vm.restackModel.State); err != nil {
+			return vm, func() tea.Msg { return err }
+		}
+		vm.quitWithConflict = true
+		return vm, tea.Quit
+	case *sequencerui.RestackAbort, *sequencerui.RestackDone:
+		if err := vm.writeState(nil); err != nil {
+			return vm, func() tea.Msg { return err }
+		}
+		return vm, tea.Quit
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			return vm, tea.Quit
+		}
+	case error:
+		vm.err = msg
+		return vm, tea.Quit
+	}
+	return vm, nil
+}
+
+func (vm *postCommitRestackViewModel) View() string {
+	sb := strings.Builder{}
+	if vm.restackModel != nil {
+		sb.WriteString(vm.restackModel.View())
+	}
+	if vm.err != nil {
+		sb.WriteString(vm.err.Error() + "\n")
+	}
+	return sb.String()
+}
+
+func (vm *postCommitRestackViewModel) writeState(state *sequencerui.RestackState) error {
+	if state == nil {
+		return vm.repo.WriteStateFile(git.StateFileKindRestack, nil)
+	}
+	return vm.repo.WriteStateFile(git.StateFileKindRestack, state)
+}
+
+func (vm *postCommitRestackViewModel) createState() (*sequencerui.RestackState, error) {
+	currentBranch, err := vm.repo.CurrentBranchName()
+	if err != nil {
+		return nil, err
+	}
+	if _, exist := vm.db.ReadTx().Branch(currentBranch); !exist {
+		return nil, errors.New("current branch is not adopted to av")
+	}
+	var state sequencerui.RestackState
+	state.InitialBranch = currentBranch
+	state.RelatedBranches = []string{currentBranch}
+	ops, err := planner.PlanForAmend(vm.db.ReadTx(), vm.repo, plumbing.NewBranchReferenceName(currentBranch))
+	if err != nil {
+		return nil, err
+	}
+	if len(ops) == 0 {
+		return nil, nothingToRestackError
+	}
+	state.Seq = sequencer.NewSequencer("origin", vm.db, ops)
+	return &state, nil
+}

--- a/cmd/av/commit_create.go
+++ b/cmd/av/commit_create.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
 	"github.com/aviator-co/av/internal/git"
-	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/spf13/cobra"
 )
@@ -30,27 +28,27 @@ var commitCreateCmd = &cobra.Command{
 			return err
 		}
 
-		currentBranchName, err := repo.CurrentBranchName()
+		db, err := getDB(repo)
 		if err != nil {
-			return errors.WrapIf(err, "failed to determine current branch")
-		}
-
-		if err := commitCreate(repo, currentBranchName); err != nil {
 			return err
 		}
 
-		return nil
+		// We need to run git commit before bubbletea grabs the terminal. Otherwise,
+		// we need to make p.ReleaseTerminal() and p.RestoreTerminal().
+		if err := runCreate(repo); err != nil {
+			fmt.Fprint(os.Stderr, "\n", colors.Failure("Failed to create commit."), "\n")
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
+
+		return runPostCommitRestack(repo, db)
 	},
 }
 
-func init() {
-	commitCreateCmd.Flags().
-		StringVarP(&commitCreateFlags.Message, "message", "m", "", "the commit message")
-	commitCreateCmd.Flags().
-		BoolVarP(&commitCreateFlags.All, "all", "a", false, "automatically stage modified files (same as git commit --all)")
-}
+func runCreate(repo *git.Repo) error {
+	if _, err := repo.CurrentBranchName(); err != nil {
+		return errors.WrapIf(err, "failed to determine current branch")
+	}
 
-func commitCreate(repo *git.Repo, currentBranchName string) error {
 	commitArgs := []string{"commit"}
 	if commitCreateFlags.All {
 		commitArgs = append(commitArgs, "--all")
@@ -64,37 +62,14 @@ func commitCreate(repo *git.Repo, currentBranchName string) error {
 		ExitError:   true,
 		Interactive: true,
 	}); err != nil {
-		_, _ = fmt.Fprint(os.Stderr,
-			"\n", colors.Failure("Failed to create commit."), "\n",
-		)
-		return actions.ErrExitSilently{ExitCode: 1}
-	}
-
-	var state actions.StackSyncState
-	if err := repo.ReadStateFile(git.StateFileKindSync, &state); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-
-	state.OriginalBranch = currentBranchName
-	ctx := context.Background()
-	db, err := getDB(repo)
-	if err != nil {
-		return err
-	}
-	tx := db.WriteTx()
-	defer tx.Abort()
-
-	client, err := getGitHubClient()
-	if err != nil {
-		return err
-	}
-
-	branchesToSync := meta.SubsequentBranches(tx, currentBranchName)
-
-	err = actions.SyncStack(ctx, repo, client, tx, branchesToSync, state, actions.WithLocalOnly())
-	if err != nil {
-		return err
-	}
-
 	return nil
+}
+
+func init() {
+	commitCreateCmd.Flags().
+		StringVarP(&commitCreateFlags.Message, "message", "m", "", "the commit message")
+	commitCreateCmd.Flags().
+		BoolVarP(&commitCreateFlags.All, "all", "a", false, "automatically stage modified files (same as git commit --all)")
 }

--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -83,3 +83,23 @@ func getOrCreateDB(repo *git.Repo) (meta.DB, bool, error) {
 	}
 	return jsonfiledb.OpenPath(dbPath)
 }
+
+func allBranches() ([]string, error) {
+	repo, err := getRepo()
+	if err != nil {
+		return nil, err
+	}
+	db, err := getDB(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := db.ReadTx()
+
+	var branches []string
+	for b := range tx.AllBranches() {
+		branches = append(branches, b)
+	}
+
+	return branches, nil
+}

--- a/cmd/av/stack_adopt.go
+++ b/cmd/av/stack_adopt.go
@@ -418,4 +418,9 @@ func init() {
 		&stackAdoptFlags.Parent, "parent", "",
 		"force specifying the parent branch",
 	)
+
+	_ = stackSyncCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		branches, _ := allBranches()
+		return branches, cobra.ShellCompDirectiveDefault
+	})
 }

--- a/cmd/av/stack_branch.go
+++ b/cmd/av/stack_branch.go
@@ -185,8 +185,8 @@ func init() {
 	stackBranchCmd.Flags().
 		BoolVar(&stackBranchFlags.Force, "force", false, "force rename the current branch")
 
-	branches, _ := allBranches()
 	_ = stackBranchCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		branches, _ := allBranches()
 		return branches, cobra.ShellCompDirectiveDefault
 	})
 }

--- a/cmd/av/stack_reparent.go
+++ b/cmd/av/stack_reparent.go
@@ -10,11 +10,9 @@ import (
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/sequencer"
 	"github.com/aviator-co/av/internal/sequencer/planner"
-	"github.com/aviator-co/av/internal/utils/colors"
-	"github.com/aviator-co/av/internal/utils/stackutils"
+	"github.com/aviator-co/av/internal/sequencer/sequencerui"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
@@ -47,236 +45,131 @@ var stackReparentCmd = &cobra.Command{
 				tea.WithInput(nil),
 			}
 		}
-		p := tea.NewProgram(stackReparentViewModel{
-			repo:    repo,
-			db:      db,
-			spinner: spinner.New(spinner.WithSpinner(spinner.Dot)),
-		}, opts...)
+		p := tea.NewProgram(&stackReparentViewModel{repo: repo, db: db}, opts...)
 		model, err := p.Run()
 		if err != nil {
 			return err
 		}
-		if err := model.(stackReparentViewModel).err; err != nil {
+		if err := model.(*stackReparentViewModel).err; err != nil {
+			if errors.Is(err, nothingToRestackError) {
+				return nil
+			}
 			return actions.ErrExitSilently{ExitCode: 1}
 		}
-		if s := model.(stackReparentViewModel).rebaseConflictErrorHeadline; s != "" {
+		if model.(*stackReparentViewModel).quitWithConflict {
 			return actions.ErrExitSilently{ExitCode: 1}
 		}
 		return nil
 	},
 }
 
-type stackReparentState struct {
-	InitialBranch   string
-	NewParentBranch string
-	Seq             *sequencer.Sequencer
-}
-
-type stackReparentSeqResult struct {
-	result *git.RebaseResult
-	err    error
-}
-
 type stackReparentViewModel struct {
-	repo    *git.Repo
-	db      meta.DB
-	state   *stackReparentState
-	spinner spinner.Model
+	repo *git.Repo
+	db   meta.DB
 
-	rebaseConflictErrorHeadline string
-	rebaseConflictHint          string
-	abortedBranch               plumbing.ReferenceName
-	err                         error
+	restackModel *sequencerui.RestackModel
+
+	quitWithConflict bool
+	err              error
 }
 
-func (vm stackReparentViewModel) Init() tea.Cmd {
-	return tea.Batch(vm.spinner.Tick, vm.initCmd)
+func (vm *stackReparentViewModel) Init() tea.Cmd {
+	state, err := vm.createState()
+	if err != nil {
+		return func() tea.Msg { return err }
+	}
+	vm.restackModel = sequencerui.NewRestackModel(vm.repo, vm.db)
+	vm.restackModel.State = state
+	return vm.restackModel.Init()
 }
 
-func (vm stackReparentViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (vm *stackReparentViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-	case error:
-		vm.err = msg
-		return vm, tea.Quit
-	case *stackReparentState:
-		vm.state = msg
-		if stackReparentFlags.Skip || stackReparentFlags.Continue || stackReparentFlags.Abort {
-			if stackReparentFlags.Abort {
-				vm.abortedBranch = vm.state.Seq.CurrentSyncRef
-			}
-			return vm, vm.runSeqWithContinuationFlags
-		}
-		return vm, vm.runSeq
-	case *stackReparentSeqResult:
-		if msg.err == nil && msg.result == nil {
-			// Finished the sequence.
-			if err := vm.repo.WriteStateFile(git.StateFileKindReparent, nil); err != nil {
-				vm.err = err
-			}
-			if _, err := vm.repo.CheckoutBranch(&git.CheckoutBranch{Name: vm.state.InitialBranch}); err != nil {
-				vm.err = err
-			}
-			return vm, tea.Quit
-		}
-		if msg.result != nil && msg.result.Status == git.RebaseConflict {
-			vm.rebaseConflictErrorHeadline = msg.result.ErrorHeadline
-			vm.rebaseConflictHint = msg.result.Hint
-			if err := vm.repo.WriteStateFile(git.StateFileKindReparent, vm.state); err != nil {
-				vm.err = err
-			}
-			return vm, tea.Quit
-		}
-		vm.err = msg.err
-		if vm.err != nil {
-			return vm, tea.Quit
-		}
-		return vm, vm.runSeq
-	case spinner.TickMsg:
+	case *sequencerui.RestackProgress, spinner.TickMsg:
 		var cmd tea.Cmd
-		vm.spinner, cmd = vm.spinner.Update(msg)
+		vm.restackModel, cmd = vm.restackModel.Update(msg)
 		return vm, cmd
+	case *sequencerui.RestackConflict:
+		if err := vm.writeState(vm.restackModel.State); err != nil {
+			return vm, func() tea.Msg { return err }
+		}
+		vm.quitWithConflict = true
+		return vm, tea.Quit
+	case *sequencerui.RestackAbort, *sequencerui.RestackDone:
+		if err := vm.writeState(nil); err != nil {
+			return vm, func() tea.Msg { return err }
+		}
+		return vm, tea.Quit
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c":
 			return vm, tea.Quit
 		}
+	case error:
+		vm.err = msg
+		return vm, tea.Quit
 	}
 	return vm, nil
 }
 
-func (vm stackReparentViewModel) View() string {
+func (vm *stackReparentViewModel) View() string {
 	sb := strings.Builder{}
-	if vm.state != nil && vm.state.Seq != nil {
-		sb.WriteString("Reparenting " + vm.state.InitialBranch + " onto " + vm.state.NewParentBranch + "...\n")
-		if vm.state.Seq.CurrentSyncRef != "" {
-			sb.WriteString("Restacking " + vm.state.Seq.CurrentSyncRef.Short() + "...\n")
-		} else if vm.abortedBranch != "" {
-			sb.WriteString("Restack aborted\n")
-		} else {
-			sb.WriteString("Restack done\n")
-		}
-		// The sequencer operates from top to bottom. The branches that are synced before
-		// the current branches are already synced. The branches that come after the current
-		// branch are pending.
-		syncedBranches := map[plumbing.ReferenceName]bool{}
-		pendingBranches := map[plumbing.ReferenceName]bool{}
-		seenCurrent := false
-		for _, op := range vm.state.Seq.Operations {
-			if op.Name == vm.state.Seq.CurrentSyncRef || op.Name == vm.abortedBranch {
-				seenCurrent = true
-			} else if !seenCurrent {
-				syncedBranches[op.Name] = true
-			} else {
-				pendingBranches[op.Name] = true
-			}
-		}
-
-		nodes, err := stackutils.BuildStackTreeRelatedBranchStacks(vm.db.ReadTx(), vm.state.InitialBranch, true, []string{vm.state.InitialBranch, vm.state.NewParentBranch})
-		if err != nil {
-			sb.WriteString("Failed to build stack tree: " + err.Error() + "\n")
-		} else {
-			for _, node := range nodes {
-				sb.WriteString(stackutils.RenderTree(node, func(branchName string, isTrunk bool) string {
-					bn := plumbing.NewBranchReferenceName(branchName)
-					if syncedBranches[bn] {
-						return colors.Success("✓ " + branchName)
-					}
-					if pendingBranches[bn] {
-						return lipgloss.NewStyle().Foreground(colors.Amber500).Render(branchName)
-					}
-					if bn == vm.state.Seq.CurrentSyncRef {
-						return lipgloss.NewStyle().Foreground(colors.Amber500).Render(vm.spinner.View() + branchName)
-					}
-					if bn == vm.abortedBranch {
-						return colors.Failure("✗ " + branchName)
-					}
-					return branchName
-				}))
-			}
-		}
-	}
-	if vm.rebaseConflictErrorHeadline != "" {
-		sb.WriteString("\n")
-		sb.WriteString(colors.Failure("Rebase conflict while rebasing ", vm.state.Seq.CurrentSyncRef.Short()) + "\n")
-		sb.WriteString(vm.rebaseConflictErrorHeadline + "\n")
-		sb.WriteString(vm.rebaseConflictHint + "\n")
-		sb.WriteString("\n")
-		sb.WriteString("Resolve the conflicts and continue the reparent with " + colors.CliCmd("av stack reparent --continue") + "\n")
-	}
+	sb.WriteString("Reparenting onto " + stackReparentFlags.Parent + "...\n")
+	sb.WriteString(vm.restackModel.View())
 	if vm.err != nil {
 		sb.WriteString(vm.err.Error() + "\n")
 	}
 	return sb.String()
 }
 
-func (vm stackReparentViewModel) initCmd() tea.Msg {
-	var state stackReparentState
-	if err := vm.repo.ReadStateFile(git.StateFileKindReparent, &state); err != nil && os.IsNotExist(err) {
-		currentBranch, err := vm.repo.CurrentBranchName()
-		if err != nil {
-			return err
-		}
-		if isCurrentBranchTrunk, err := vm.repo.IsTrunkBranch(currentBranch); err != nil {
-			return err
-		} else if isCurrentBranchTrunk {
-			return errors.New("current branch is a trunk branch")
-		}
-		if _, exist := vm.db.ReadTx().Branch(currentBranch); !exist {
-			return errors.New("current branch is not adopted to av")
-		}
-
-		if isParentBranchTrunk, err := vm.repo.IsTrunkBranch(stackReparentFlags.Parent); err != nil {
-			return err
-		} else if !isParentBranchTrunk {
-			if _, exist := vm.db.ReadTx().Branch(stackReparentFlags.Parent); !exist {
-				return errors.New("parent branch is not adopted to av")
-			}
-		}
-		state.InitialBranch = currentBranch
-		state.NewParentBranch = stackReparentFlags.Parent
-		ops, err := planner.PlanForReparent(vm.db.ReadTx(), vm.repo, plumbing.NewBranchReferenceName(currentBranch), plumbing.NewBranchReferenceName(stackReparentFlags.Parent))
-		if err != nil {
-			return err
-		}
-		if len(ops) == 0 {
-			return errors.New("nothing to restack")
-		}
-		state.Seq = sequencer.NewSequencer("origin", vm.db, ops)
-	} else if err != nil {
-		return err
+func (vm *stackReparentViewModel) writeState(state *sequencerui.RestackState) error {
+	if state == nil {
+		return vm.repo.WriteStateFile(git.StateFileKindRestack, nil)
 	}
-	return &state
+	return vm.repo.WriteStateFile(git.StateFileKindRestack, state)
 }
 
-func (vm stackReparentViewModel) runSeqWithContinuationFlags() tea.Msg {
-	result, err := vm.state.Seq.Run(vm.repo, vm.db, stackReparentFlags.Abort, stackReparentFlags.Continue, stackReparentFlags.Skip)
-	return &stackReparentSeqResult{result: result, err: err}
-}
+func (vm *stackReparentViewModel) createState() (*sequencerui.RestackState, error) {
+	currentBranch, err := vm.repo.CurrentBranchName()
+	if err != nil {
+		return nil, err
+	}
+	if isCurrentBranchTrunk, err := vm.repo.IsTrunkBranch(currentBranch); err != nil {
+		return nil, err
+	} else if isCurrentBranchTrunk {
+		return nil, errors.New("current branch is a trunk branch")
+	}
+	if _, exist := vm.db.ReadTx().Branch(currentBranch); !exist {
+		return nil, errors.New("current branch is not adopted to av")
+	}
 
-func (vm stackReparentViewModel) runSeq() tea.Msg {
-	result, err := vm.state.Seq.Run(vm.repo, vm.db, false, false, false)
-	return &stackReparentSeqResult{result: result, err: err}
+	if isParentBranchTrunk, err := vm.repo.IsTrunkBranch(stackReparentFlags.Parent); err != nil {
+		return nil, err
+	} else if !isParentBranchTrunk {
+		if _, exist := vm.db.ReadTx().Branch(stackReparentFlags.Parent); !exist {
+			return nil, errors.New("parent branch is not adopted to av")
+		}
+	}
+	var state sequencerui.RestackState
+	state.InitialBranch = currentBranch
+	state.RelatedBranches = []string{currentBranch, stackReparentFlags.Parent}
+	ops, err := planner.PlanForReparent(vm.db.ReadTx(), vm.repo, plumbing.NewBranchReferenceName(currentBranch), plumbing.NewBranchReferenceName(stackReparentFlags.Parent))
+	if err != nil {
+		return nil, err
+	}
+	if len(ops) == 0 {
+		return nil, nothingToRestackError
+	}
+	state.Seq = sequencer.NewSequencer("origin", vm.db, ops)
+	return &state, nil
 }
 
 func init() {
-	stackReparentCmd.Flags().BoolVar(
-		&stackReparentFlags.Continue, "continue", false,
-		"continue an in-progress reparent",
-	)
-	stackReparentCmd.Flags().BoolVar(
-		&stackReparentFlags.Abort, "abort", false,
-		"abort an in-progress reparent",
-	)
-	stackReparentCmd.Flags().BoolVar(
-		&stackReparentFlags.Skip, "skip", false,
-		"skip the current commit and continue an in-progress reparent",
-	)
 	stackReparentCmd.Flags().StringVar(
 		&stackReparentFlags.Parent, "parent", "",
 		"new parent branch name",
 	)
 
-	stackReparentCmd.MarkFlagsMutuallyExclusive("continue", "abort", "skip", "parent")
 	_ = stackReparentCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		branches, _ := allBranches()
 		return branches, cobra.ShellCompDirectiveDefault

--- a/cmd/av/stack_reparent.go
+++ b/cmd/av/stack_reparent.go
@@ -1,24 +1,284 @@
 package main
 
 import (
-	"fmt"
 	"os"
+	"strings"
 
+	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/actions"
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/sequencer"
+	"github.com/aviator-co/av/internal/sequencer/planner"
 	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/aviator-co/av/internal/utils/stackutils"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
+var stackReparentFlags struct {
+	Parent   string
+	Abort    bool
+	Continue bool
+	Skip     bool
+}
+
 var stackReparentCmd = &cobra.Command{
-	Use:    "reparent <new-parent>",
-	Hidden: true,
+	Use:   "reparent",
+	Short: "Reparent branches",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, _ = fmt.Fprint(os.Stderr,
-			colors.Failure("ERROR: "),
-			"The ", colors.CliCmd("av stack reparent"), " command is deprecated: ",
-			"use ", colors.CliCmd("av stack sync --parent <new-parent>"), " instead.",
-			"\n",
-		)
-		os.Exit(1)
+		repo, err := getRepo()
+		if err != nil {
+			return err
+		}
+
+		db, err := getDB(repo)
+		if err != nil {
+			return err
+		}
+
+		var opts []tea.ProgramOption
+		if !isatty.IsTerminal(os.Stdout.Fd()) {
+			opts = []tea.ProgramOption{
+				tea.WithInput(nil),
+			}
+		}
+		p := tea.NewProgram(stackReparentViewModel{
+			repo:    repo,
+			db:      db,
+			spinner: spinner.New(spinner.WithSpinner(spinner.Dot)),
+		}, opts...)
+		model, err := p.Run()
+		if err != nil {
+			return err
+		}
+		if err := model.(stackReparentViewModel).err; err != nil {
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
+		if s := model.(stackReparentViewModel).rebaseConflictErrorHeadline; s != "" {
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
 		return nil
 	},
+}
+
+type stackReparentState struct {
+	InitialBranch   string
+	NewParentBranch string
+	Seq             *sequencer.Sequencer
+}
+
+type stackReparentSeqResult struct {
+	result *git.RebaseResult
+	err    error
+}
+
+type stackReparentViewModel struct {
+	repo    *git.Repo
+	db      meta.DB
+	state   *stackReparentState
+	spinner spinner.Model
+
+	rebaseConflictErrorHeadline string
+	rebaseConflictHint          string
+	abortedBranch               plumbing.ReferenceName
+	err                         error
+}
+
+func (vm stackReparentViewModel) Init() tea.Cmd {
+	return tea.Batch(vm.spinner.Tick, vm.initCmd)
+}
+
+func (vm stackReparentViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case error:
+		vm.err = msg
+		return vm, tea.Quit
+	case *stackReparentState:
+		vm.state = msg
+		if stackReparentFlags.Skip || stackReparentFlags.Continue || stackReparentFlags.Abort {
+			if stackReparentFlags.Abort {
+				vm.abortedBranch = vm.state.Seq.CurrentSyncRef
+			}
+			return vm, vm.runSeqWithContinuationFlags
+		}
+		return vm, vm.runSeq
+	case *stackReparentSeqResult:
+		if msg.err == nil && msg.result == nil {
+			// Finished the sequence.
+			if err := vm.repo.WriteStateFile(git.StateFileKindReparent, nil); err != nil {
+				vm.err = err
+			}
+			if _, err := vm.repo.CheckoutBranch(&git.CheckoutBranch{Name: vm.state.InitialBranch}); err != nil {
+				vm.err = err
+			}
+			return vm, tea.Quit
+		}
+		if msg.result != nil && msg.result.Status == git.RebaseConflict {
+			vm.rebaseConflictErrorHeadline = msg.result.ErrorHeadline
+			vm.rebaseConflictHint = msg.result.Hint
+			if err := vm.repo.WriteStateFile(git.StateFileKindReparent, vm.state); err != nil {
+				vm.err = err
+			}
+			return vm, tea.Quit
+		}
+		vm.err = msg.err
+		if vm.err != nil {
+			return vm, tea.Quit
+		}
+		return vm, vm.runSeq
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		vm.spinner, cmd = vm.spinner.Update(msg)
+		return vm, cmd
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			return vm, tea.Quit
+		}
+	}
+	return vm, nil
+}
+
+func (vm stackReparentViewModel) View() string {
+	sb := strings.Builder{}
+	if vm.state != nil && vm.state.Seq != nil {
+		sb.WriteString("Reparenting " + vm.state.InitialBranch + " onto " + vm.state.NewParentBranch + "...\n")
+		if vm.state.Seq.CurrentSyncRef != "" {
+			sb.WriteString("Restacking " + vm.state.Seq.CurrentSyncRef.Short() + "...\n")
+		} else if vm.abortedBranch != "" {
+			sb.WriteString("Restack aborted\n")
+		} else {
+			sb.WriteString("Restack done\n")
+		}
+		// The sequencer operates from top to bottom. The branches that are synced before
+		// the current branches are already synced. The branches that come after the current
+		// branch are pending.
+		syncedBranches := map[plumbing.ReferenceName]bool{}
+		pendingBranches := map[plumbing.ReferenceName]bool{}
+		seenCurrent := false
+		for _, op := range vm.state.Seq.Operations {
+			if op.Name == vm.state.Seq.CurrentSyncRef || op.Name == vm.abortedBranch {
+				seenCurrent = true
+			} else if !seenCurrent {
+				syncedBranches[op.Name] = true
+			} else {
+				pendingBranches[op.Name] = true
+			}
+		}
+
+		nodes, err := stackutils.BuildStackTreeRelatedBranchStacks(vm.db.ReadTx(), vm.state.InitialBranch, true, []string{vm.state.InitialBranch, vm.state.NewParentBranch})
+		if err != nil {
+			sb.WriteString("Failed to build stack tree: " + err.Error() + "\n")
+		} else {
+			for _, node := range nodes {
+				sb.WriteString(stackutils.RenderTree(node, func(branchName string, isTrunk bool) string {
+					bn := plumbing.NewBranchReferenceName(branchName)
+					if syncedBranches[bn] {
+						return colors.Success("✓ " + branchName)
+					}
+					if pendingBranches[bn] {
+						return lipgloss.NewStyle().Foreground(colors.Amber500).Render(branchName)
+					}
+					if bn == vm.state.Seq.CurrentSyncRef {
+						return lipgloss.NewStyle().Foreground(colors.Amber500).Render(vm.spinner.View() + branchName)
+					}
+					if bn == vm.abortedBranch {
+						return colors.Failure("✗ " + branchName)
+					}
+					return branchName
+				}))
+			}
+		}
+	}
+	if vm.rebaseConflictErrorHeadline != "" {
+		sb.WriteString("\n")
+		sb.WriteString(colors.Failure("Rebase conflict while rebasing ", vm.state.Seq.CurrentSyncRef.Short()) + "\n")
+		sb.WriteString(vm.rebaseConflictErrorHeadline + "\n")
+		sb.WriteString(vm.rebaseConflictHint + "\n")
+		sb.WriteString("\n")
+		sb.WriteString("Resolve the conflicts and continue the reparent with " + colors.CliCmd("av stack reparent --continue") + "\n")
+	}
+	if vm.err != nil {
+		sb.WriteString(vm.err.Error() + "\n")
+	}
+	return sb.String()
+}
+
+func (vm stackReparentViewModel) initCmd() tea.Msg {
+	var state stackReparentState
+	if err := vm.repo.ReadStateFile(git.StateFileKindReparent, &state); err != nil && os.IsNotExist(err) {
+		currentBranch, err := vm.repo.CurrentBranchName()
+		if err != nil {
+			return err
+		}
+		if isCurrentBranchTrunk, err := vm.repo.IsTrunkBranch(currentBranch); err != nil {
+			return err
+		} else if isCurrentBranchTrunk {
+			return errors.New("current branch is a trunk branch")
+		}
+		if _, exist := vm.db.ReadTx().Branch(currentBranch); !exist {
+			return errors.New("current branch is not adopted to av")
+		}
+
+		if isParentBranchTrunk, err := vm.repo.IsTrunkBranch(stackReparentFlags.Parent); err != nil {
+			return err
+		} else if !isParentBranchTrunk {
+			if _, exist := vm.db.ReadTx().Branch(stackReparentFlags.Parent); !exist {
+				return errors.New("parent branch is not adopted to av")
+			}
+		}
+		state.InitialBranch = currentBranch
+		state.NewParentBranch = stackReparentFlags.Parent
+		ops, err := planner.PlanForReparent(vm.db.ReadTx(), vm.repo, plumbing.NewBranchReferenceName(currentBranch), plumbing.NewBranchReferenceName(stackReparentFlags.Parent))
+		if err != nil {
+			return err
+		}
+		if len(ops) == 0 {
+			return errors.New("nothing to restack")
+		}
+		state.Seq = sequencer.NewSequencer("origin", vm.db, ops)
+	} else if err != nil {
+		return err
+	}
+	return &state
+}
+
+func (vm stackReparentViewModel) runSeqWithContinuationFlags() tea.Msg {
+	result, err := vm.state.Seq.Run(vm.repo, vm.db, stackReparentFlags.Abort, stackReparentFlags.Continue, stackReparentFlags.Skip)
+	return &stackReparentSeqResult{result: result, err: err}
+}
+
+func (vm stackReparentViewModel) runSeq() tea.Msg {
+	result, err := vm.state.Seq.Run(vm.repo, vm.db, false, false, false)
+	return &stackReparentSeqResult{result: result, err: err}
+}
+
+func init() {
+	stackReparentCmd.Flags().BoolVar(
+		&stackReparentFlags.Continue, "continue", false,
+		"continue an in-progress reparent",
+	)
+	stackReparentCmd.Flags().BoolVar(
+		&stackReparentFlags.Abort, "abort", false,
+		"abort an in-progress reparent",
+	)
+	stackReparentCmd.Flags().BoolVar(
+		&stackReparentFlags.Skip, "skip", false,
+		"skip the current commit and continue an in-progress reparent",
+	)
+	stackReparentCmd.Flags().StringVar(
+		&stackReparentFlags.Parent, "parent", "",
+		"new parent branch name",
+	)
+
+	stackReparentCmd.MarkFlagsMutuallyExclusive("continue", "abort", "skip", "parent")
+	_ = stackReparentCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		branches, _ := allBranches()
+		return branches, cobra.ShellCompDirectiveDefault
+	})
 }

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -306,29 +306,8 @@ func init() {
 	stackSyncCmd.MarkFlagsMutuallyExclusive("current", "trunk")
 	stackSyncCmd.MarkFlagsMutuallyExclusive("trunk", "parent")
 	stackSyncCmd.MarkFlagsMutuallyExclusive("continue", "abort", "skip")
-
-	branches, _ := allBranches()
 	_ = stackSyncCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		branches, _ := allBranches()
 		return branches, cobra.ShellCompDirectiveDefault
 	})
-}
-
-func allBranches() ([]string, error) {
-	repo, err := getRepo()
-	if err != nil {
-		return nil, err
-	}
-	db, err := getDB(repo)
-	if err != nil {
-		return nil, err
-	}
-
-	tx := db.ReadTx()
-
-	var branches []string
-	for b := range tx.AllBranches() {
-		branches = append(branches, b)
-	}
-
-	return branches, nil
 }

--- a/docs/av-stack-reparent.1.md
+++ b/docs/av-stack-reparent.1.md
@@ -1,0 +1,30 @@
+# av-stack-reparent
+
+## NAME
+
+av-stack-reparent - Reparent a branch to a new parent
+
+## SYNOPSIS
+
+```synopsis
+av stack sync [--continue | --abort | --skip | --parent=<parent>]
+```
+
+## DESCRIPTION
+
+This rebases the current branch onto the new parent and runs the restack
+operations on the children.
+
+## OPTIONS
+
+`--continue`
+: Continue an in-progress rebase.
+
+`--abort`
+: Abort an in-progress rebase.
+
+`--skip`
+: Skip the current commit and continue an in-progress rebase.
+
+`--parent=<parent>`
+: Parent branch to rebase onto.

--- a/docs/av-stack-reparent.1.md
+++ b/docs/av-stack-reparent.1.md
@@ -7,7 +7,7 @@ av-stack-reparent - Reparent a branch to a new parent
 ## SYNOPSIS
 
 ```synopsis
-av stack sync [--continue | --abort | --skip | --parent=<parent>]
+av stack reparent [--parent=<parent>]
 ```
 
 ## DESCRIPTION
@@ -16,15 +16,6 @@ This rebases the current branch onto the new parent and runs the restack
 operations on the children.
 
 ## OPTIONS
-
-`--continue`
-: Continue an in-progress rebase.
-
-`--abort`
-: Abort an in-progress rebase.
-
-`--skip`
-: Skip the current commit and continue an in-progress rebase.
 
 `--parent=<parent>`
 : Parent branch to rebase onto.

--- a/docs/av-stack-restack.1.md
+++ b/docs/av-stack-restack.1.md
@@ -26,6 +26,13 @@ the branches.
 
 ## OPTIONS
 
+`--all`
+: Rebase all branches.
+
+`--current`
+: Only rebase up to the current branch. (Don't recurse into descendant
+  branches.)
+
 `--continue`
 : Continue an in-progress rebase.
 

--- a/e2e_tests/stack_reparent_test.go
+++ b/e2e_tests/stack_reparent_test.go
@@ -75,6 +75,72 @@ func TestStackSyncReparentTrunk(t *testing.T) {
 	RequireAv(t, "stack", "sync", "--parent", "main")
 }
 
+func TestStackReparent(t *testing.T) {
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
+	Chdir(t, repo.RepoDir)
+
+	RequireAv(t, "stack", "branch", "foo")
+	repo.CommitFile(t, "foo.txt", "foo")
+	requireFileContent(t, "foo.txt", "foo")
+
+	RequireAv(t, "stack", "branch", "bar")
+	repo.CommitFile(t, "bar.txt", "bar")
+	requireFileContent(t, "bar.txt", "bar")
+	requireFileContent(t, "foo.txt", "foo")
+
+	RequireAv(t, "stack", "branch", "spam")
+	repo.CommitFile(t, "spam.txt", "spam")
+	requireFileContent(t, "spam.txt", "spam")
+
+	// Now, re-parent spam on top of bar (should be relatively a no-op)
+	RequireAv(t, "stack", "reparent", "--parent", "bar")
+	requireFileContent(t, "spam.txt", "spam")
+	requireFileContent(
+		t,
+		"bar.txt",
+		"bar",
+		"bar.txt should still be set after reparenting onto same branch",
+	)
+
+	// Now, re-parent spam on top of foo
+	RequireAv(t, "stack", "reparent", "--parent", "foo")
+	currentBranch := repo.CurrentBranch(t)
+	require.Equal(
+		t,
+		plumbing.ReferenceName("refs/heads/spam"),
+		currentBranch,
+		"branch should be set to original branch (spam) after reparenting onto foo",
+	)
+	requireFileContent(t, "spam.txt", "spam")
+	requireFileContent(
+		t,
+		"foo.txt",
+		"foo",
+		"foo.txt should be set after reparenting onto foo branch",
+	)
+	require.NoFileExists(t, "bar.txt", "bar.txt should not exist after reparenting onto foo branch")
+}
+
+func TestStackReparentTrunk(t *testing.T) {
+	server := RunMockGitHubServer(t)
+	defer server.Close()
+	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
+	Chdir(t, repo.RepoDir)
+
+	RequireAv(t, "stack", "branch", "foo")
+	repo.CommitFile(t, "foo.txt", "foo")
+
+	RequireAv(t, "stack", "branch", "bar")
+	repo.CommitFile(t, "bar.txt", "bar")
+
+	// Delete the local main. av should use the remote tracking branch.
+	repo.Git(t, "branch", "-D", "main")
+
+	RequireAv(t, "stack", "reparent", "--parent", "main")
+}
+
 func requireFileContent(t *testing.T, file string, expected string, args ...any) {
 	actual, err := os.ReadFile(file)
 	if err != nil {

--- a/internal/git/state_file.go
+++ b/internal/git/state_file.go
@@ -9,9 +9,10 @@ import (
 type StateFileKind string
 
 const (
-	StateFileKindSync    StateFileKind = "stack-sync.state.json"
-	StateFileKindReorder StateFileKind = "stack-reorder.state.json"
-	StateFileKindRestack StateFileKind = "stack-restack.state.json"
+	StateFileKindSync     StateFileKind = "stack-sync.state.json"
+	StateFileKindReorder  StateFileKind = "stack-reorder.state.json"
+	StateFileKindRestack  StateFileKind = "stack-restack.state.json"
+	StateFileKindReparent StateFileKind = "stack-reparent.state.json"
 )
 
 func (r *Repo) ReadStateFile(kind StateFileKind, msg any) error {

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -140,16 +140,10 @@ func StackBranches(tx ReadTx, name string) ([]string, error) {
 	return res, nil
 }
 
-// StackBranchesMap returns a map of branch names to their metadata for the stack
-// associated with the given branch.
-func StackBranchesMap(tx ReadTx, name string) (map[string]Branch, error) {
-	branchNames, err := StackBranches(tx, name)
-	if err != nil {
-		return nil, err
-	}
-
-	branches := make(map[string]Branch, len(branchNames))
-	for _, branchName := range branchNames {
+// BranchesMap returns a map of branch names to their metadata.
+func BranchesMap(tx ReadTx, names []string) (map[string]Branch, error) {
+	branches := make(map[string]Branch, len(names))
+	for _, branchName := range names {
 		branch, ok := tx.Branch(branchName)
 		if !ok {
 			return nil, errors.Errorf("branch metadata not found for %q", branchName)

--- a/internal/sequencer/planner/planner.go
+++ b/internal/sequencer/planner/planner.go
@@ -8,7 +8,20 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
-func PlanForRestack(tx meta.ReadTx, repo *git.Repo, targetBranches []plumbing.ReferenceName) ([]sequencer.RestackOp, error) {
+func PlanForRestack(tx meta.ReadTx, repo *git.Repo, currentBranch plumbing.ReferenceName, restackAll, restackCurrent bool) ([]sequencer.RestackOp, error) {
+	var targetBranches []plumbing.ReferenceName
+	var err error
+	if restackAll {
+		targetBranches, err = GetTargetBranches(tx, repo, false, AllBranches)
+	} else if restackCurrent {
+		targetBranches, err = GetTargetBranches(tx, repo, false, CurrentAndParents)
+	} else {
+		targetBranches, err = GetTargetBranches(tx, repo, false, CurrentStack)
+	}
+	if err != nil {
+		return nil, err
+	}
+
 	var ret []sequencer.RestackOp
 	for _, br := range targetBranches {
 		avbr, _ := tx.Branch(br.Short())

--- a/internal/sequencer/sequencerui/ui.go
+++ b/internal/sequencer/sequencerui/ui.go
@@ -1,0 +1,178 @@
+package sequencerui
+
+import (
+	"strings"
+
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/sequencer"
+	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/aviator-co/av/internal/utils/stackutils"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func NewRestackModel(repo *git.Repo, db meta.DB) *RestackModel {
+	return &RestackModel{
+		repo:    repo,
+		db:      db,
+		spinner: spinner.New(spinner.WithSpinner(spinner.Dot)),
+	}
+}
+
+type RestackState struct {
+	InitialBranch   string
+	RestackingAll   bool
+	RelatedBranches []string
+	Seq             *sequencer.Sequencer
+}
+
+type RestackProgress struct {
+	result *git.RebaseResult
+	err    error
+}
+
+type RestackConflict struct{}
+type RestackAbort struct{}
+type RestackDone struct{}
+
+type RestackModel struct {
+	Skip     bool
+	Continue bool
+	Abort    bool
+	DryRun   bool
+	State    *RestackState
+
+	repo *git.Repo
+	db   meta.DB
+
+	spinner                     spinner.Model
+	rebaseConflictErrorHeadline string
+	rebaseConflictHint          string
+	abortedBranch               plumbing.ReferenceName
+}
+
+func (vm *RestackModel) Init() tea.Cmd {
+	return tea.Batch(vm.spinner.Tick, vm.initCmd)
+}
+
+func (vm *RestackModel) initCmd() tea.Msg {
+	if vm.Skip || vm.Continue || vm.Abort {
+		if vm.Abort {
+			vm.abortedBranch = vm.State.Seq.CurrentSyncRef
+		}
+		return vm.runSeqWithContinuationFlags()
+	}
+	return vm.runSeq()
+}
+
+func (vm *RestackModel) Update(msg tea.Msg) (*RestackModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case *RestackProgress:
+		if msg.err == nil && msg.result == nil {
+			// Finished the sequence.
+			if vm.State.InitialBranch != "" {
+				if _, err := vm.repo.CheckoutBranch(&git.CheckoutBranch{Name: vm.State.InitialBranch}); err != nil {
+					return vm, func() tea.Msg { return err }
+				}
+			}
+			if vm.abortedBranch != "" {
+				return vm, func() tea.Msg { return &RestackAbort{} }
+			}
+			return vm, func() tea.Msg { return &RestackDone{} }
+		}
+		if msg.result != nil && msg.result.Status == git.RebaseConflict {
+			vm.rebaseConflictErrorHeadline = msg.result.ErrorHeadline
+			vm.rebaseConflictHint = msg.result.Hint
+			return vm, func() tea.Msg { return &RestackConflict{} }
+		}
+		if msg.err != nil {
+			return vm, func() tea.Msg { return msg.err }
+		}
+		return vm, vm.runSeq
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		vm.spinner, cmd = vm.spinner.Update(msg)
+		return vm, cmd
+	}
+	return vm, nil
+}
+
+func (vm *RestackModel) View() string {
+	sb := strings.Builder{}
+	if vm.State != nil && vm.State.Seq != nil {
+		if vm.State.Seq.CurrentSyncRef != "" {
+			sb.WriteString("Restacking " + vm.State.Seq.CurrentSyncRef.Short() + "...\n")
+		} else if vm.abortedBranch != "" {
+			sb.WriteString("Restack aborted\n")
+		} else {
+			sb.WriteString("Restack done\n")
+		}
+		// The sequencer operates from top to bottom. The branches that are synced before
+		// the current branches are already synced. The branches that come after the current
+		// branch are pending.
+		syncedBranches := map[plumbing.ReferenceName]bool{}
+		pendingBranches := map[plumbing.ReferenceName]bool{}
+		seenCurrent := false
+		for _, op := range vm.State.Seq.Operations {
+			if op.Name == vm.State.Seq.CurrentSyncRef || op.Name == vm.abortedBranch {
+				seenCurrent = true
+			} else if !seenCurrent {
+				syncedBranches[op.Name] = true
+			} else {
+				pendingBranches[op.Name] = true
+			}
+		}
+
+		var nodes []*stackutils.StackTreeNode
+		var err error
+		if vm.State.RestackingAll {
+			nodes = stackutils.BuildStackTreeAllBranches(vm.db.ReadTx(), vm.State.InitialBranch, true)
+		} else {
+			nodes, err = stackutils.BuildStackTreeRelatedBranchStacks(vm.db.ReadTx(), vm.State.InitialBranch, true, vm.State.RelatedBranches)
+		}
+		if err != nil {
+			sb.WriteString("Failed to build stack tree: " + err.Error() + "\n")
+		} else {
+			for _, node := range nodes {
+				sb.WriteString(stackutils.RenderTree(node, func(branchName string, isTrunk bool) string {
+					bn := plumbing.NewBranchReferenceName(branchName)
+					if syncedBranches[bn] {
+						return colors.Success("✓ " + branchName)
+					}
+					if pendingBranches[bn] {
+						return lipgloss.NewStyle().Foreground(colors.Amber500).Render(branchName)
+					}
+					if bn == vm.State.Seq.CurrentSyncRef {
+						return lipgloss.NewStyle().Foreground(colors.Amber500).Render(vm.spinner.View() + branchName)
+					}
+					if bn == vm.abortedBranch {
+						return colors.Failure("✗ " + branchName)
+					}
+					return branchName
+				}))
+			}
+		}
+	}
+	if vm.rebaseConflictErrorHeadline != "" {
+		sb.WriteString("\n")
+		sb.WriteString(colors.Failure("Rebase conflict while rebasing ", vm.State.Seq.CurrentSyncRef.Short()) + "\n")
+		sb.WriteString(vm.rebaseConflictErrorHeadline + "\n")
+		sb.WriteString(vm.rebaseConflictHint + "\n")
+		sb.WriteString("\n")
+		sb.WriteString("Resolve the conflicts and continue the restack with " + colors.CliCmd("av stack restack --continue") + "\n")
+	}
+	return sb.String()
+}
+
+func (vm *RestackModel) runSeqWithContinuationFlags() tea.Msg {
+	result, err := vm.State.Seq.Run(vm.repo, vm.db, vm.Abort, vm.Continue, vm.Skip)
+	return &RestackProgress{result: result, err: err}
+}
+
+func (vm *RestackModel) runSeq() tea.Msg {
+	result, err := vm.State.Seq.Run(vm.repo, vm.db, false, false, false)
+	return &RestackProgress{result: result, err: err}
+}


### PR DESCRIPTION
This extracts the UI component for restacking and uses it in av stack
restack, av stack reparent, av commit amend, and av commit create.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"av_stack_restack_more_opts","parentHead":"952d034b94332110ab8f15fbf453c41943c3e1b3","parentPull":310,"trunk":"master"}
```
-->
