### PR TITLE
Unify the styles of the command output

### DIFF
--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
@@ -12,6 +11,7 @@ import (
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/colors"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/erikgeiser/promptkit/selection"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
@@ -169,18 +169,25 @@ func (m stackNextModel) Init() tea.Cmd {
 	return m.nextBranch
 }
 
-func (m stackNextModel) View() string {
-	sb := strings.Builder{}
-	if m.err != nil {
-		sb.WriteString(m.err.Error() + "\n")
-		return sb.String()
+func (vm stackNextModel) View() string {
+	var ss []string
+	if vm.selection != nil {
+		ss = append(ss, vm.selection.View())
 	}
 
-	if m.selection != nil {
-		sb.WriteString(m.selection.View())
+	var ret string
+	if len(ss) != 0 {
+		ret = lipgloss.NewStyle().MarginTop(1).MarginBottom(1).MarginLeft(2).Render(
+			lipgloss.JoinVertical(0, ss...),
+		)
 	}
-
-	return sb.String()
+	if vm.err != nil {
+		if len(ret) != 0 {
+			ret += "\n"
+		}
+		ret += renderError(vm.err)
+	}
+	return ret
 }
 
 func (m stackNextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/cmd/av/stack_reparent.go
+++ b/cmd/av/stack_reparent.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
@@ -13,6 +12,7 @@ import (
 	"github.com/aviator-co/av/internal/sequencer/sequencerui"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
@@ -113,13 +113,25 @@ func (vm *stackReparentViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (vm *stackReparentViewModel) View() string {
-	sb := strings.Builder{}
-	sb.WriteString("Reparenting onto " + stackReparentFlags.Parent + "...\n")
-	sb.WriteString(vm.restackModel.View())
-	if vm.err != nil {
-		sb.WriteString(vm.err.Error() + "\n")
+	var ss []string
+	ss = append(ss, "Reparenting onto "+stackReparentFlags.Parent+"...")
+	if vm.restackModel != nil {
+		ss = append(ss, vm.restackModel.View())
 	}
-	return sb.String()
+
+	var ret string
+	if len(ss) != 0 {
+		ret = lipgloss.NewStyle().MarginTop(1).MarginBottom(1).MarginLeft(2).Render(
+			lipgloss.JoinVertical(0, ss...),
+		)
+	}
+	if vm.err != nil {
+		if len(ret) != 0 {
+			ret += "\n"
+		}
+		ret += renderError(vm.err)
+	}
+	return ret
 }
 
 func (vm *stackReparentViewModel) writeState(state *sequencerui.RestackState) error {

--- a/cmd/av/stack_restack.go
+++ b/cmd/av/stack_restack.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/actions"
@@ -13,6 +12,7 @@ import (
 	"github.com/aviator-co/av/internal/sequencer/sequencerui"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
@@ -132,14 +132,24 @@ func (vm *stackRestackViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (vm *stackRestackViewModel) View() string {
-	sb := strings.Builder{}
+	var ss []string
 	if vm.restackModel != nil {
-		sb.WriteString(vm.restackModel.View())
+		ss = append(ss, vm.restackModel.View())
+	}
+
+	var ret string
+	if len(ss) != 0 {
+		ret = lipgloss.NewStyle().MarginTop(1).MarginBottom(1).MarginLeft(2).Render(
+			lipgloss.JoinVertical(0, ss...),
+		)
 	}
 	if vm.err != nil {
-		sb.WriteString(vm.err.Error() + "\n")
+		if len(ret) != 0 {
+			ret += "\n"
+		}
+		ret += renderError(vm.err)
 	}
-	return sb.String()
+	return ret
 }
 
 func (vm *stackRestackViewModel) readState() (*sequencerui.RestackState, error) {

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -300,12 +300,20 @@ func (vm *stackSyncViewModel) View() string {
 	if vm.pruneBranchModel != nil {
 		ss = append(ss, vm.pruneBranchModel.View())
 	}
-	if vm.err != nil {
-		ss = append(ss, vm.err.Error())
+
+	var ret string
+	if len(ss) != 0 {
+		ret = lipgloss.NewStyle().MarginTop(1).MarginBottom(1).MarginLeft(2).Render(
+			lipgloss.JoinVertical(0, ss...),
+		)
 	}
-	return lipgloss.NewStyle().MarginTop(1).MarginBottom(1).MarginLeft(2).Render(
-		lipgloss.JoinVertical(0, ss...),
-	)
+	if vm.err != nil {
+		if len(ret) != 0 {
+			ret += "\n"
+		}
+		ret += renderError(vm.err)
+	}
+	return ret
 }
 
 var commandStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))

--- a/cmd/av/stack_tree.go
+++ b/cmd/av/stack_tree.go
@@ -40,7 +40,7 @@ var stackTreeCmd = &cobra.Command{
 
 		rootNodes := stackutils.BuildStackTreeAllBranches(tx, currentBranch, true)
 		for _, node := range rootNodes {
-			fmt.Print(stackutils.RenderTree(node, func(branchName string, isTrunk bool) string {
+			fmt.Println(stackutils.RenderTree(node, func(branchName string, isTrunk bool) string {
 				stbi := getStackTreeBranchInfo(repo, tx, branchName)
 				return renderStackTreeBranchInfo(stackTreeStackBranchInfoStyles, stbi, currentBranch, branchName, isTrunk)
 			}))

--- a/internal/sequencer/sequencerui/ui.go
+++ b/internal/sequencer/sequencerui/ui.go
@@ -168,6 +168,7 @@ func (vm *RestackModel) View() string {
 					return branchName + suffix
 				}))
 			}
+			sb.WriteString("\n")
 		}
 	}
 	if vm.rebaseConflictErrorHeadline != "" {

--- a/internal/utils/stackutils/render_tree.go
+++ b/internal/utils/stackutils/render_tree.go
@@ -7,7 +7,7 @@ import (
 )
 
 func RenderTree(node *StackTreeNode, branchDataFn func(branchName string, isTrunk bool) string) string {
-	return renderTreeInternal(0, node, true, branchDataFn)
+	return strings.TrimSuffix(renderTreeInternal(0, node, true, branchDataFn), "\n")
 }
 
 func renderTreeInternal(columns int, node *StackTreeNode, isTrunk bool, branchDataFn func(branchName string, isTrunk bool) string) string {


### PR DESCRIPTION
Fixes #324

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
