### PR TITLE
Check reparent arguments before running the command

### DIFF
--- a/cmd/av/stack_reparent.go
+++ b/cmd/av/stack_reparent.go
@@ -19,10 +19,7 @@ import (
 )
 
 var stackReparentFlags struct {
-	Parent   string
-	Abort    bool
-	Continue bool
-	Skip     bool
+	Parent string
 }
 
 var stackReparentCmd = &cobra.Command{
@@ -37,6 +34,18 @@ var stackReparentCmd = &cobra.Command{
 		db, err := getDB(repo)
 		if err != nil {
 			return err
+		}
+
+		if stackReparentFlags.Parent != "" && len(args) > 0 && args[0] != "" {
+			if stackReparentFlags.Parent != args[0] {
+				return errors.New("conflicting parent branch names")
+			}
+		}
+		if len(args) > 0 && args[0] != "" {
+			stackReparentFlags.Parent = args[0]
+		}
+		if stackReparentFlags.Parent == "" {
+			return errors.New("missing parent branch name")
 		}
 
 		var opts []tea.ProgramOption


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
