### PR TITLE
Exit when a deprecated flag is specified

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -560,9 +560,9 @@ func init() {
 	)
 	_ = stackSyncCmd.Flags().MarkDeprecated("no-fetch", "please use av stack restack for offline restacking")
 	stackSyncCmd.Flags().Bool("trunk", false,
-		"(deprecated; use av stack sync without this option, or use av stack restack for not restacking on the trunk branch) rebase the stack on the trunk branch",
+		"(deprecated; now av stack sync automatically restacks on the trunk branch without this option. Use av stack restack for stacking without the trunk branch) rebase the stack on the trunk branch",
 	)
-	_ = stackSyncCmd.Flags().MarkDeprecated("trunk", "please use av stack sync without this option or use av stack restack for not restacking on the trunk branch")
+	_ = stackSyncCmd.Flags().MarkDeprecated("trunk", "now av stack sync automatically restacks on the trunk branch without this option. Use av stack restack for restacking without the trunk branch")
 	stackSyncCmd.Flags().String("parent", "",
 		"(deprecated; use av stack adopt or av stack reparent) parent branch to rebase onto",
 	)

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -70,6 +70,15 @@ base branch.
 		if !sliceutils.Contains([]string{"ask", "yes", "no"}, strings.ToLower(stackSyncFlags.Prune)) {
 			return errors.New("invalid value for --prune; must be one of ask, yes, no")
 		}
+		if cmd.Flags().Changed("no-fetch") {
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
+		if cmd.Flags().Changed("trunk") {
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
+		if cmd.Flags().Changed("parent") {
+			return actions.ErrExitSilently{ExitCode: 1}
+		}
 		repo, err := getRepo()
 		if err != nil {
 			return err
@@ -551,8 +560,9 @@ func init() {
 	)
 	_ = stackSyncCmd.Flags().MarkDeprecated("no-fetch", "please use av stack restack for offline restacking")
 	stackSyncCmd.Flags().Bool("trunk", false,
-		"(deprecated; use av stack restack for prevent rebasing on trunk) rebase the stack on the trunk branch",
+		"(deprecated; use av stack sync without this option, or use av stack restack for not restacking on the trunk branch) rebase the stack on the trunk branch",
 	)
+	_ = stackSyncCmd.Flags().MarkDeprecated("trunk", "please use av stack sync without this option or use av stack restack for not restacking on the trunk branch")
 	stackSyncCmd.Flags().String("parent", "",
 		"(deprecated; use av stack adopt or av stack reparent) parent branch to rebase onto",
 	)

--- a/e2e_tests/stack_sync_all_test.go
+++ b/e2e_tests/stack_sync_all_test.go
@@ -28,7 +28,7 @@ func TestStackSyncAll(t *testing.T) {
 	//     stack-1:  \ -> 1a
 	//     stack-2:  \ -> 2a
 
-	RequireAv(t, "stack", "sync", "--trunk", "--all")
+	RequireAv(t, "stack", "sync", "--all")
 
 	//     main:    X  -> X2
 	//     stack-1:        \ -> 1a

--- a/e2e_tests/stack_sync_delete_merged_test.go
+++ b/e2e_tests/stack_sync_delete_merged_test.go
@@ -75,7 +75,7 @@ func TestStackSyncDeleteMerged(t *testing.T) {
 	tx.SetBranch(stack1Meta)
 	require.NoError(t, tx.Commit())
 
-	RequireAv(t, "stack", "sync", "--trunk", "--prune=yes")
+	RequireAv(t, "stack", "sync", "--prune=yes")
 
 	require.Equal(t, 1,
 		Cmd(t, "git", "show-ref", "refs/heads/stack-1").ExitCode,

--- a/e2e_tests/stack_sync_trunk_test.go
+++ b/e2e_tests/stack_sync_trunk_test.go
@@ -73,13 +73,13 @@ func TestStackSyncTrunk(t *testing.T) {
 		"squash commit of stack-1 should not be an ancestor of HEAD of stack-2 before running sync",
 	)
 
-	RequireAv(t, "stack", "sync", "--trunk")
+	RequireAv(t, "stack", "sync")
 	// At this point, the stack should be:
 	//
 	//     main:    X --------------> 1S -> 3a
 	//     stack-1:  \ -> 1a -> 1b           \
 	//     stack-2:                           \ -> 2a -> 2b
 
-	// commit 3a should be an ancestor of HEAD of stack-2 after running sync with --trunk
+	// commit 3a should be an ancestor of HEAD of stack-2 after running sync
 	repo.Git(t, "merge-base", "--is-ancestor", threeACommit.String(), "stack-2")
 }


### PR DESCRIPTION
![image](https://github.com/aviator-co/av/assets/21878/e96a340c-e065-4b44-83b3-41e80b6e9d0f)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
