### PR TITLE
Update the release workflow to use the GITHUB_TOKEN and SSH key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,13 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: "write"
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -26,4 +28,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+          AVIATOR_CO_HOMEBREW_REPO_SSH_KEY: ${{ secrets.AVIATOR_CO_HOMEBREW_REPO_SSH_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - "rm -rf man"
@@ -53,8 +55,11 @@ nfpms:
 # Push to the homebrew tap
 brews:
   - repository:
-      owner: aviator-co
-      name: homebrew-tap
+      owner: "aviator-co"
+      name: "homebrew-tap"
+      git:
+        url: "ssh://git@github.com:aviator-co/homebrew-tap.git"
+        private_key: "{{ .Env.AVIATOR_CO_HOMEBREW_REPO_SSH_KEY }}"
     commit_author:
       name: "aviator-bot"
       email: "105820887+aviator-bot@users.noreply.github.com"


### PR DESCRIPTION
Also update the goreleaser configuration to use the latest version of
the config schema.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
