### PR TITLE
Fix SSH URL

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,7 +58,7 @@ brews:
       owner: "aviator-co"
       name: "homebrew-tap"
       git:
-        url: "ssh://git@github.com:aviator-co/homebrew-tap.git"
+        url: "git@github.com:aviator-co/homebrew-tap.git"
         private_key: "{{ .Env.AVIATOR_CO_HOMEBREW_REPO_SSH_KEY }}"
     commit_author:
       name: "aviator-bot"


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
