### PR TITLE
Improve the stack branch command to handle trunk branches as parents

### DIFF
--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -172,8 +172,6 @@ func discoverGitHubAPIToken() string {
 	return ""
 }
 
-var errNoGitHubToken = errors.Sentinel("No GitHub token is set (do you need to configure one?).")
-
 func getGitHubClient() (*gh.Client, error) {
 	token := discoverGitHubAPIToken()
 	if token == "" {

--- a/e2e_tests/stack_orphan_test.go
+++ b/e2e_tests/stack_orphan_test.go
@@ -19,7 +19,7 @@ func TestStackOrphan(t *testing.T) {
 	// Then stack-2 (and child branch stack-3) will be orphaned
 
 	// Setup initial state
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")

--- a/e2e_tests/stack_restack_test.go
+++ b/e2e_tests/stack_restack_test.go
@@ -24,7 +24,7 @@ func TestStackRestack(t *testing.T) {
 	//     stack-4:           \ -> 4a
 	// Note: we create the first branch with a "vanilla" git checkout just to
 	// make sure that's working as intended.
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	RequireAv(t, "stack", "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
@@ -155,7 +155,7 @@ func TestStackRestackAbort(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a two stack...
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	RequireAv(t, "stack", "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
@@ -212,7 +212,7 @@ func TestStackRestackWithLotsOfConflicts(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	RequireAv(t, "stack", "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
@@ -278,7 +278,7 @@ func TestStackRestackAfterAmendingCommit(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")

--- a/e2e_tests/stack_sync_amend_test.go
+++ b/e2e_tests/stack_sync_amend_test.go
@@ -15,7 +15,7 @@ func TestSyncAfterAmendingCommit(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")

--- a/e2e_tests/stack_sync_delete_merged_test.go
+++ b/e2e_tests/stack_sync_delete_merged_test.go
@@ -20,7 +20,7 @@ func TestStackSyncDeleteMerged(t *testing.T) {
 	//     main:    X
 	//     stack-1:  \ -> 1a -> 1b
 	//     stack-2:              \ -> 2a -> 2b
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")

--- a/e2e_tests/stack_sync_delete_parent_test.go
+++ b/e2e_tests/stack_sync_delete_parent_test.go
@@ -20,7 +20,7 @@ func TestStackSyncDeleteParent(t *testing.T) {
 	//     stack-1: main -> 1a -> 2b
 	//     stack-2:                \ -> 2a -> 2b
 	//     stack-3:	                           \ -> 3a -> 3b
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")

--- a/e2e_tests/stack_sync_merge_commit_test.go
+++ b/e2e_tests/stack_sync_merge_commit_test.go
@@ -21,7 +21,7 @@ func TestStackSyncMergeCommit(t *testing.T) {
 	//     stack-1: main -> 1a -> 2b
 	//     stack-2:                \ -> 2a -> 2b
 	//     stack-3:			                   \ -> 3a -> 3b
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")

--- a/e2e_tests/stack_sync_merged_parent_test.go
+++ b/e2e_tests/stack_sync_merged_parent_test.go
@@ -21,7 +21,7 @@ func TestStackSyncMergedParent(t *testing.T) {
 	//     stack-1: main -> 1a -> 2b
 	//     stack-2:                \ -> 2a -> 2b
 	//     stack-3:                             \ -> 3a -> 3b
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")

--- a/e2e_tests/stack_sync_test.go
+++ b/e2e_tests/stack_sync_test.go
@@ -30,7 +30,7 @@ func TestStackSync(t *testing.T) {
 	//     stack-4:           \ -> 4a
 	// Note: we create the first branch with a "vanilla" git checkout just to
 	// make sure that's working as intended.
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	RequireAv(t, "stack", "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
@@ -163,7 +163,7 @@ func TestStackSyncAbort(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a two stack...
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	RequireAv(t, "stack", "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
@@ -222,7 +222,7 @@ func TestStackSyncWithLotsOfConflicts(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	RequireAv(t, "stack", "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))

--- a/e2e_tests/stack_sync_trunk_test.go
+++ b/e2e_tests/stack_sync_trunk_test.go
@@ -19,7 +19,7 @@ func TestStackSyncTrunk(t *testing.T) {
 	//     main:    X
 	//     stack-1:  \ -> 1a -> 1b
 	//     stack-2:              \ -> 2a -> 2b
-	repo.Git(t, "checkout", "-b", "stack-1")
+	RequireAv(t, "stack", "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 	RequireAv(t, "stack", "branch", "stack-2")


### PR DESCRIPTION
When creating a new branch from a trunk branch, the stack branch command
is better to start off from the remote tracking branch instead of the
local branch. This way, the new branch will be created from the latest
state of the trunk branch.

While we are here, accept `origin/HEAD` as the parent branch name and
resolve it to the default branch.

Previously, this command automatically "adopts" the parent branch to av
automatically, assuming that the parent branch's parent is the default
branch, which might not be true. Instead, this command checks if the
parent branch is already adopted or not.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
