### PR TITLE
Fix av stack adopt to detect the trunk branch first

### DIFF
--- a/internal/treedetector/detector.go
+++ b/internal/treedetector/detector.go
@@ -157,10 +157,6 @@ func (d *detector) detectBranchTree(ref *plumbing.Reference) (*BranchPiece, erro
 	// Do a commit traversal. We can stop the traversal when we hit the trunk or if we find a
 	// commit that has multiple parents.
 	err = object.NewCommitPreorderIter(commit, nil, nil).ForEach(func(c *object.Commit) error {
-		if c.NumParents() > 1 {
-			ret.ContainsMergeCommit = true
-			return iterStopErr
-		}
 		if trunkBranchNames, ok := trunkBases[c.Hash]; ok {
 			if len(trunkBranchNames) > 1 {
 				ret.PossibleParents = trunkBranchNames
@@ -169,6 +165,10 @@ func (d *detector) detectBranchTree(ref *plumbing.Reference) (*BranchPiece, erro
 			ret.Parent = trunkBranchNames[0]
 			ret.ParentIsTrunk = true
 			ret.ParentMergeBase = c.Hash
+			return iterStopErr
+		}
+		if c.NumParents() > 1 {
+			ret.ContainsMergeCommit = true
 			return iterStopErr
 		}
 		if c.Hash != commit.Hash {


### PR DESCRIPTION
Without this, if the trunk branch points to a merge commit, av stack
adopt won't work.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
