### PR TITLE
Update the PR metadata before pushing to the remote

### DIFF
--- a/internal/gh/ghui/push.go
+++ b/internal/gh/ghui/push.go
@@ -36,6 +36,7 @@ const (
 	reasonPRIsMerged        = "PR is already merged."
 	reasonPRIsClosed        = "PR is closed."
 	reasonParentNotPushed   = "Parent branch is not pushed to remote."
+	reasonNoPR              = "Some branches in a stack do not have a PR."
 )
 
 type pushCandidate struct {
@@ -431,6 +432,15 @@ func (vm *GitHubPushModel) calculateChangedBranches() tea.Msg {
 			})
 			continue
 		}
+		if !vm.allBranchesOnStackHavePRs(br) {
+			// If an ancestor branch doesn't have a PR, the PR cannot be made with the
+			// right metadata.
+			noPushBranches = append(noPushBranches, noPushBranch{
+				branch: br,
+				reason: reasonNoPR,
+			})
+			continue
+		}
 
 		remoteRefCommit, err := repo.CommitObject(remoteRef.Hash())
 		if err != nil {
@@ -464,6 +474,19 @@ func (vm *GitHubPushModel) allParentsHaveRemoteTrackingBranch(remoteConfig *conf
 		parent = avbr.Parent
 	}
 	return true
+}
+
+func (vm *GitHubPushModel) allBranchesOnStackHavePRs(br plumbing.ReferenceName) bool {
+	avbr, _ := vm.db.ReadTx().Branch(br.Short())
+	for {
+		if avbr.PullRequest == nil {
+			return false
+		}
+		if avbr.Parent.Trunk {
+			return true
+		}
+		avbr, _ = vm.db.ReadTx().Branch(avbr.Parent.Name)
+	}
 }
 
 func getFirstLine(s string) string {

--- a/internal/gh/ghui/push.go
+++ b/internal/gh/ghui/push.go
@@ -250,10 +250,10 @@ func (vm *GitHubPushModel) runUpdate() (ret tea.Msg) {
 			}
 		}
 	}()
-	if err := vm.runGitPush(); err != nil {
+	if err := vm.updatePRs(ghPRs); err != nil {
 		return err
 	}
-	if err := vm.updatePRs(ghPRs); err != nil {
+	if err := vm.runGitPush(); err != nil {
 		return err
 	}
 	return &GitHubPushProgress{gitPushDone: true}


### PR DESCRIPTION
https://linear.app/mergequeue/issue/MER-4307/swap-the-order-of-push-pr-update-to-avoid-the-unintended-ci-triggers

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"prevent_push_no_pr","parentHead":"f326d8235f9f29fd022938444759f35567f78cbc","parentPull":351,"trunk":"master"}
```
-->
