### PR TITLE
Use detached HEAD when pruning branches

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -345,6 +345,24 @@ func (r *Repo) CheckoutBranch(opts *CheckoutBranch) (string, error) {
 	return previousBranchName, nil
 }
 
+// Detach detaches to the detached HEAD.
+func (r *Repo) Detach() error {
+	res, err := r.Run(&RunOpts{
+		Args: []string{"switch", "--detach"},
+	})
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		logrus.WithFields(logrus.Fields{
+			"stdout": string(res.Stdout),
+			"stderr": string(res.Stderr),
+		}).Debug("git checkout failed")
+		return errors.Errorf("failed to switch to the detached HEAD: %s", string(res.Stderr))
+	}
+	return nil
+}
+
 type RevParse struct {
 	// The name of the branch to parse.
 	// If empty, the current branch is parsed.

--- a/internal/git/gitui/prune.go
+++ b/internal/git/gitui/prune.go
@@ -202,13 +202,9 @@ func (vm *PruneBranchModel) runDelete() tea.Msg {
 	if err != nil {
 		return err
 	}
-	// Checkout the default branch so that we can delete the branches. We cannot delete the
+	// Checkout the detached HEAD so that we can delete the branches. We cannot delete the
 	// branches that are checked out.
-	defaultBranch, err := vm.repo.DefaultBranch()
-	if err != nil {
-		return err
-	}
-	if _, err := vm.repo.CheckoutBranch(&git.CheckoutBranch{Name: defaultBranch}); err != nil {
+	if err := vm.repo.Detach(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
`git checkout` can create a new branch. Intention here is to switch to
something that is not a branch, so we use `git switch --detach` instead.

Fixes #357.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
