### PR TITLE
Use git-merge-base for the fast merge-base detection

### DIFF
--- a/cmd/av/stack_adopt.go
+++ b/cmd/av/stack_adopt.go
@@ -197,7 +197,7 @@ func (vm stackAdoptViewModel) initCmd() tea.Msg {
 	for _, branch := range trunkBranches {
 		refs = append(refs, plumbing.NewBranchReferenceName(branch))
 	}
-	allBranches, err := treedetector.DetectBranchTree(vm.repo.GoGitRepo(), vm.repo.GetRemoteName(), refs)
+	allBranches, err := treedetector.DetectBranchTree(vm.repo, vm.repo.GetRemoteName(), refs)
 	if err != nil {
 		return err
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -397,6 +397,16 @@ func (r *Repo) MergeBase(mb *MergeBase) (string, error) {
 	return r.Git(args...)
 }
 
+func (r *Repo) MergeBases(commitishes ...string) ([]string, error) {
+	args := []string{"merge-base"}
+	args = append(args, commitishes...)
+	ret, err := r.Git(args...)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(strings.TrimSpace(ret), "\n"), nil
+}
+
 type UpdateRef struct {
 	// The name of the ref (e.g., refs/heads/my-branch).
 	Ref string


### PR DESCRIPTION
As described in https://github.com/aviator-co/av/issues/364, it's
possible that Git has a more efficient way to calculate the merge bases.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
