### PR TITLE
Conditionally sync the branches

### DIFF
--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -28,13 +28,14 @@ import (
 )
 
 var stackSyncFlags struct {
-	All      bool
-	Current  bool
-	Abort    bool
-	Continue bool
-	Skip     bool
-	Push     string
-	Prune    string
+	All           bool
+	RebaseToTrunk bool
+	Current       bool
+	Abort         bool
+	Continue      bool
+	Skip          bool
+	Push          string
+	Prune         string
 }
 
 const (
@@ -543,7 +544,7 @@ func (vm *stackSyncViewModel) createState() (*savedStackSyncState, error) {
 	if currentBranch != "" {
 		currentBranchRef = plumbing.NewBranchReferenceName(currentBranch)
 	}
-	ops, err := planner.PlanForSync(vm.db.ReadTx(), vm.repo, currentBranchRef, stackSyncFlags.All, stackSyncFlags.Current)
+	ops, err := planner.PlanForSync(vm.db.ReadTx(), vm.repo, currentBranchRef, stackSyncFlags.All, stackSyncFlags.Current, stackSyncFlags.RebaseToTrunk)
 	if err != nil {
 		return nil, err
 	}
@@ -581,6 +582,10 @@ func init() {
 		"delete branches that have been merged into the parent branch\n(ask|yes|no)",
 	)
 	stackSyncCmd.Flags().Lookup("prune").NoOptDefVal = "ask"
+	stackSyncCmd.Flags().BoolVar(
+		&stackSyncFlags.RebaseToTrunk, "rebase-to-trunk", false,
+		"rebase the branches to the latest trunk always",
+	)
 
 	stackSyncCmd.Flags().BoolVar(
 		&stackSyncFlags.Continue, "continue", false,

--- a/docs/av-stack-sync.1.md
+++ b/docs/av-stack-sync.1.md
@@ -31,6 +31,23 @@ resolve the conflict, and continue with `av stack sync --continue`. This is
 similar to `git rebase --continue`, but it continues with syncing the rest of
 the branches.
 
+## REBASING THE STACK ROOT TO TRUNK
+
+By default, the branches are conditionally rebased if needed:
+
+* If a part of the stack is merged, the rest of the stack is rebased to the
+  latest trunk commit.
+* If a branch is a stack root (the first topic branch next to trunk), it's
+  rebased if `--rebase-to-trunk` option is specified.
+* If a branch is not a stack root, it's rebased to the parent branch.
+
+While you are developing in a topic branch, it's possible that the trunk branch
+is updated by somebody else. In some cases, you may need to rebase onto that
+latest trunk branch to resolve the conflicts. For example, if somebody else
+updates the same file you are working on, you need to rebase your branch onto
+the latest trunk branch. In this case, you can use `--rebase-to-trunk` option to
+rebase the stacks to the latest trunk branch.
+
 ## OPTIONS
 
 `--all`
@@ -39,6 +56,9 @@ the branches.
 `--current`
 : Only sync changes to the current branch. (Don't recurse into descendant
 branches.)
+
+`--rebase-to-trunk`
+: Rebase the branches to trunk.
 
 `--push=(yes|no|ask)`
 : Push the changes to the remote. If `ask`, it prompts to you when push is


### PR DESCRIPTION
See https://github.com/aviator-co/av/issues/348#issuecomment-2243950078


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
