### PR TITLE
Apply pre-commit hook formatters

### DIFF
--- a/cmd/av/commit_amend.go
+++ b/cmd/av/commit_amend.go
@@ -65,7 +65,11 @@ func runAmend(repo *git.Repo, db meta.DB) error {
 
 	branch, _ := tx.Branch(currentBranch)
 	if branch.PullRequest != nil && branch.PullRequest.State == githubv4.PullRequestStateMerged {
-		fmt.Fprint(os.Stderr, colors.Failure("This branch has already been merged, amending is not allowed"), "\n")
+		fmt.Fprint(
+			os.Stderr,
+			colors.Failure("This branch has already been merged, amending is not allowed"),
+			"\n",
+		)
 		return errors.New("this branch has already been merged, amending is not allowed")
 	}
 

--- a/cmd/av/commit_common.go
+++ b/cmd/av/commit_common.go
@@ -121,7 +121,11 @@ func (vm *postCommitRestackViewModel) createState() (*sequencerui.RestackState, 
 	var state sequencerui.RestackState
 	state.InitialBranch = currentBranch
 	state.RelatedBranches = []string{currentBranch}
-	ops, err := planner.PlanForAmend(vm.db.ReadTx(), vm.repo, plumbing.NewBranchReferenceName(currentBranch))
+	ops, err := planner.PlanForAmend(
+		vm.db.ReadTx(),
+		vm.repo,
+		plumbing.NewBranchReferenceName(currentBranch),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/av/commit_create.go
+++ b/cmd/av/commit_create.go
@@ -65,7 +65,11 @@ func runCreate(repo *git.Repo, db meta.DB) error {
 
 	branch, _ := tx.Branch(currentBranch)
 	if branch.PullRequest != nil && branch.PullRequest.State == githubv4.PullRequestStateMerged {
-		fmt.Fprint(os.Stderr, colors.Failure("This branch has already been merged, commit is not allowed"), "\n")
+		fmt.Fprint(
+			os.Stderr,
+			colors.Failure("This branch has already been merged, commit is not allowed"),
+			"\n",
+		)
 		return errors.New("this branch has already been merged, commit is not allowed")
 	}
 

--- a/cmd/av/stack_adopt.go
+++ b/cmd/av/stack_adopt.go
@@ -223,7 +223,9 @@ func (vm stackAdoptViewModel) initCmd() tea.Msg {
 	}
 }
 
-func (vm stackAdoptViewModel) getAdoptionTargets(node *stackutils.StackTreeNode) []plumbing.ReferenceName {
+func (vm stackAdoptViewModel) getAdoptionTargets(
+	node *stackutils.StackTreeNode,
+) []plumbing.ReferenceName {
 	var ret []plumbing.ReferenceName
 	for _, child := range node.Children {
 		ret = append(ret, vm.getAdoptionTargets(child)...)
@@ -328,15 +330,20 @@ func (vm stackAdoptViewModel) View() string {
 		} else {
 			sb.WriteString("Choose which branches to adopt (Use space to select / deselect).\n")
 		}
-		sb.WriteString(stackutils.RenderTree(vm.treeInfo.rootNode, func(branchName string, isTrunk bool) string {
-			bn := plumbing.NewBranchReferenceName(branchName)
-			out := vm.renderBranch(bn, isTrunk)
-			if bn == vm.currentCursor {
-				out = strings.TrimSuffix(out, "\n")
-				out = lipgloss.NewStyle().Background(colors.Slate300).Render(out)
-			}
-			return out
-		}))
+		sb.WriteString(
+			stackutils.RenderTree(
+				vm.treeInfo.rootNode,
+				func(branchName string, isTrunk bool) string {
+					bn := plumbing.NewBranchReferenceName(branchName)
+					out := vm.renderBranch(bn, isTrunk)
+					if bn == vm.currentCursor {
+						out = strings.TrimSuffix(out, "\n")
+						out = lipgloss.NewStyle().Background(colors.Slate300).Render(out)
+					}
+					return out
+				},
+			),
+		)
 		if len(vm.treeInfo.possibleChildren) != 0 {
 			sb.WriteString("\n")
 			sb.WriteString("For the following branches we cannot detect the graph structure:\n")
@@ -419,8 +426,11 @@ func init() {
 		"force specifying the parent branch",
 	)
 
-	_ = stackSyncCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		branches, _ := allBranches()
-		return branches, cobra.ShellCompDirectiveDefault
-	})
+	_ = stackSyncCmd.RegisterFlagCompletionFunc(
+		"parent",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			branches, _ := allBranches()
+			return branches, cobra.ShellCompDirectiveDefault
+		},
+	)
 }

--- a/cmd/av/stack_branch.go
+++ b/cmd/av/stack_branch.go
@@ -156,10 +156,13 @@ func init() {
 	stackBranchCmd.Flags().
 		BoolVar(&stackBranchFlags.Force, "force", false, "force rename the current branch")
 
-	_ = stackBranchCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		branches, _ := allBranches()
-		return branches, cobra.ShellCompDirectiveDefault
-	})
+	_ = stackBranchCmd.RegisterFlagCompletionFunc(
+		"parent",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			branches, _ := allBranches()
+			return branches, cobra.ShellCompDirectiveDefault
+		},
+	)
 }
 
 func stackBranchMove(

--- a/cmd/av/stack_orphan.go
+++ b/cmd/av/stack_orphan.go
@@ -46,7 +46,11 @@ var stackOrphanCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Fprintf(os.Stderr, "These branched are orphaned: %s\n", strings.Join(branchesToOrphan, ", "))
+		fmt.Fprintf(
+			os.Stderr,
+			"These branched are orphaned: %s\n",
+			strings.Join(branchesToOrphan, ", "),
+		)
 
 		return nil
 	},

--- a/cmd/av/stack_reparent.go
+++ b/cmd/av/stack_reparent.go
@@ -174,7 +174,12 @@ func (vm *stackReparentViewModel) createState() (*sequencerui.RestackState, erro
 	var state sequencerui.RestackState
 	state.InitialBranch = currentBranch
 	state.RelatedBranches = []string{currentBranch, stackReparentFlags.Parent}
-	ops, err := planner.PlanForReparent(vm.db.ReadTx(), vm.repo, plumbing.NewBranchReferenceName(currentBranch), plumbing.NewBranchReferenceName(stackReparentFlags.Parent))
+	ops, err := planner.PlanForReparent(
+		vm.db.ReadTx(),
+		vm.repo,
+		plumbing.NewBranchReferenceName(currentBranch),
+		plumbing.NewBranchReferenceName(stackReparentFlags.Parent),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -191,8 +196,11 @@ func init() {
 		"new parent branch name",
 	)
 
-	_ = stackReparentCmd.RegisterFlagCompletionFunc("parent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		branches, _ := allBranches()
-		return branches, cobra.ShellCompDirectiveDefault
-	})
+	_ = stackReparentCmd.RegisterFlagCompletionFunc(
+		"parent",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			branches, _ := allBranches()
+			return branches, cobra.ShellCompDirectiveDefault
+		},
+	)
 }

--- a/cmd/av/stack_restack.go
+++ b/cmd/av/stack_restack.go
@@ -154,7 +154,8 @@ func (vm *stackRestackViewModel) View() string {
 
 func (vm *stackRestackViewModel) readState() (*sequencerui.RestackState, error) {
 	var state sequencerui.RestackState
-	if err := vm.repo.ReadStateFile(git.StateFileKindRestack, &state); err != nil && os.IsNotExist(err) {
+	if err := vm.repo.ReadStateFile(git.StateFileKindRestack, &state); err != nil &&
+		os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -196,7 +197,13 @@ func (vm *stackRestackViewModel) createState() (*sequencerui.RestackState, error
 		currentBranchRef = plumbing.NewBranchReferenceName(currentBranch)
 	}
 
-	ops, err := planner.PlanForRestack(vm.db.ReadTx(), vm.repo, currentBranchRef, stackRestackFlags.All, stackRestackFlags.Current)
+	ops, err := planner.PlanForRestack(
+		vm.db.ReadTx(),
+		vm.repo,
+		currentBranchRef,
+		stackRestackFlags.All,
+		stackRestackFlags.Current,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -90,7 +90,10 @@ If the --current flag is given, this command will create pull requests up to the
 				return err
 			}
 			if result.Created {
-				createdPullRequestPermalinks = append(createdPullRequestPermalinks, result.Branch.PullRequest.Permalink)
+				createdPullRequestPermalinks = append(
+					createdPullRequestPermalinks,
+					result.Branch.PullRequest.Permalink,
+				)
 			}
 			// make sure the base branch of the PR is up to date if it already exists
 			if !result.Created && result.Pull.BaseRefName != result.Branch.Parent.Name {

--- a/cmd/av/stack_switch.go
+++ b/cmd/av/stack_switch.go
@@ -102,7 +102,12 @@ func getInitialChoosenBranch(branchList []*stackTreeBranchInfo, currentBranch st
 	return branchList[0].BranchName
 }
 
-func stackSwitchBranchList(repo *git.Repo, tx meta.ReadTx, branches map[string]*stackTreeBranchInfo, node *stackutils.StackTreeNode) []*stackTreeBranchInfo {
+func stackSwitchBranchList(
+	repo *git.Repo,
+	tx meta.ReadTx,
+	branches map[string]*stackTreeBranchInfo,
+	node *stackutils.StackTreeNode,
+) []*stackTreeBranchInfo {
 	var ret []*stackTreeBranchInfo
 	for _, child := range node.Children {
 		ret = append(ret, stackSwitchBranchList(repo, tx, branches, child)...)
@@ -247,11 +252,26 @@ func (vm stackSwitchViewModel) View() string {
 		sb.WriteString(stackutils.RenderTree(node, func(branchName string, isTrunk bool) string {
 			stbi := vm.branches[branchName]
 			if branchName == vm.currentChoosenBranch {
-				out := strings.TrimSuffix(renderStackTreeBranchInfo(stackSwitchStackBranchInfoStyles, stbi, vm.currentHEADBranch, branchName, isTrunk), "\n")
+				out := strings.TrimSuffix(
+					renderStackTreeBranchInfo(
+						stackSwitchStackBranchInfoStyles,
+						stbi,
+						vm.currentHEADBranch,
+						branchName,
+						isTrunk,
+					),
+					"\n",
+				)
 				out = lipgloss.NewStyle().Background(colors.Slate300).Render(out)
 				return out
 			}
-			return renderStackTreeBranchInfo(stackTreeStackBranchInfoStyles, stbi, vm.currentHEADBranch, branchName, isTrunk)
+			return renderStackTreeBranchInfo(
+				stackTreeStackBranchInfoStyles,
+				stbi,
+				vm.currentHEADBranch,
+				branchName,
+				isTrunk,
+			)
 		}))
 	}
 	sb.WriteString("\n")

--- a/cmd/av/stack_sync.go
+++ b/cmd/av/stack_sync.go
@@ -65,10 +65,16 @@ base branch.
 `),
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !sliceutils.Contains([]string{"ask", "yes", "no"}, strings.ToLower(stackSyncFlags.Push)) {
+		if !sliceutils.Contains(
+			[]string{"ask", "yes", "no"},
+			strings.ToLower(stackSyncFlags.Push),
+		) {
 			return errors.New("invalid value for --push; must be one of ask, yes, no")
 		}
-		if !sliceutils.Contains([]string{"ask", "yes", "no"}, strings.ToLower(stackSyncFlags.Prune)) {
+		if !sliceutils.Contains(
+			[]string{"ask", "yes", "no"},
+			strings.ToLower(stackSyncFlags.Prune),
+		) {
 			return errors.New("invalid value for --prune; must be one of ask, yes, no")
 		}
 		if cmd.Flags().Changed("no-fetch") {
@@ -162,7 +168,10 @@ type stackSyncViewModel struct {
 
 func (vm *stackSyncViewModel) Init() tea.Cmd {
 	if vm.askingStackSyncChange && os.Getenv("AV_STACK_SYNC_CHANGE_NO_ASK") != "1" {
-		vm.changeNoticePrompt = uiutils.NewPromptModel(changeNoticePrompt, []string{continueWithSyncChoice, abortSyncChoice})
+		vm.changeNoticePrompt = uiutils.NewPromptModel(
+			changeNoticePrompt,
+			[]string{continueWithSyncChoice, abortSyncChoice},
+		)
 		return vm.changeNoticePrompt.Init()
 	}
 	return vm.initSync()
@@ -363,18 +372,52 @@ var commandStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
 func (vm *stackSyncViewModel) viewChangeNotice() string {
 	boldStyle := lipgloss.NewStyle().Bold(true)
 	sb := strings.Builder{}
-	sb.WriteString(boldStyle.Render("The behavior of ") + commandStyle.Bold(true).Render("av stack sync") + boldStyle.Render(" has changed. We will now ask for confirmation before syncing the stack.\n"))
+	sb.WriteString(
+		boldStyle.Render(
+			"The behavior of ",
+		) + commandStyle.Bold(true).
+			Render("av stack sync") +
+			boldStyle.Render(
+				" has changed. We will now ask for confirmation before syncing the stack.\n",
+			),
+	)
 	sb.WriteString("\n")
 	sb.WriteString("* " + commandStyle.Render("av stack sync") + " is split into four commands:\n")
-	sb.WriteString("  * " + commandStyle.Render("av stack adopt") + " to adopt a new branch into the stack.\n")
-	sb.WriteString("  * " + commandStyle.Render("av stack reparent") + " to change the parent branch.\n")
-	sb.WriteString("  * " + commandStyle.Render("av stack restack") + " to rebase the stack locally.\n")
-	sb.WriteString("  * " + commandStyle.Render("av stack sync") + " to rebase the stack with the remote repository.\n")
-	sb.WriteString("* " + commandStyle.Render("av stack sync") + " will ask if you want to push to the remote repository.\n")
-	sb.WriteString("* " + commandStyle.Render("av stack sync") + " will ask if you want to delete the branches that have been merged.\n")
+	sb.WriteString(
+		"  * " + commandStyle.Render("av stack adopt") + " to adopt a new branch into the stack.\n",
+	)
+	sb.WriteString(
+		"  * " + commandStyle.Render("av stack reparent") + " to change the parent branch.\n",
+	)
+	sb.WriteString(
+		"  * " + commandStyle.Render("av stack restack") + " to rebase the stack locally.\n",
+	)
+	sb.WriteString(
+		"  * " + commandStyle.Render(
+			"av stack sync",
+		) + " to rebase the stack with the remote repository.\n",
+	)
+	sb.WriteString(
+		"* " + commandStyle.Render(
+			"av stack sync",
+		) + " will ask if you want to push to the remote repository.\n",
+	)
+	sb.WriteString(
+		"* " + commandStyle.Render(
+			"av stack sync",
+		) + " will ask if you want to delete the branches that have been merged.\n",
+	)
 	sb.WriteString("\n")
-	sb.WriteString("With this change, " + commandStyle.Render("av stack sync") + " will always rebase onto the remote trunk branch (e.g., main or\n")
-	sb.WriteString("master). If you do not want to rebase onto the remote trunk branch, please use " + commandStyle.Render("av stack restack") + ".\n")
+	sb.WriteString(
+		"With this change, " + commandStyle.Render(
+			"av stack sync",
+		) + " will always rebase onto the remote trunk branch (e.g., main or\n",
+	)
+	sb.WriteString(
+		"master). If you do not want to rebase onto the remote trunk branch, please use " + commandStyle.Render(
+			"av stack restack",
+		) + ".\n",
+	)
 	sb.WriteString("\n")
 	sb.WriteString(vm.changeNoticePrompt.View())
 	sb.WriteString(vm.help.ShortHelpView(uiutils.PromptKeys))
@@ -437,7 +480,8 @@ func (vm *stackSyncViewModel) continueWithState(state *savedStackSyncState) tea.
 
 func (vm *stackSyncViewModel) readState() (*savedStackSyncState, error) {
 	var state savedStackSyncState
-	if err := vm.repo.ReadStateFile(git.StateFileKindSyncV2, &state); err != nil && os.IsNotExist(err) {
+	if err := vm.repo.ReadStateFile(git.StateFileKindSyncV2, &state); err != nil &&
+		os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -469,7 +513,12 @@ func (vm *stackSyncViewModel) createGitHubFetchModel() (*ghui.GitHubFetchModel, 
 	var targetBranches []plumbing.ReferenceName
 	if stackSyncFlags.All {
 		var err error
-		targetBranches, err = planner.GetTargetBranches(vm.db.ReadTx(), vm.repo, true, planner.AllBranches)
+		targetBranches, err = planner.GetTargetBranches(
+			vm.db.ReadTx(),
+			vm.repo,
+			true,
+			planner.AllBranches,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -493,7 +542,13 @@ func (vm *stackSyncViewModel) createGitHubFetchModel() (*ghui.GitHubFetchModel, 
 		currentBranchRef = plumbing.NewBranchReferenceName(currentBranch)
 	}
 
-	return ghui.NewGitHubFetchModel(vm.repo, vm.db, vm.client, currentBranchRef, targetBranches), nil
+	return ghui.NewGitHubFetchModel(
+		vm.repo,
+		vm.db,
+		vm.client,
+		currentBranchRef,
+		targetBranches,
+	), nil
 }
 
 func (vm *stackSyncViewModel) createState() (*savedStackSyncState, error) {
@@ -518,7 +573,12 @@ func (vm *stackSyncViewModel) createState() (*savedStackSyncState, error) {
 	var targetBranches []plumbing.ReferenceName
 	if stackSyncFlags.All {
 		var err error
-		targetBranches, err = planner.GetTargetBranches(vm.db.ReadTx(), vm.repo, true, planner.AllBranches)
+		targetBranches, err = planner.GetTargetBranches(
+			vm.db.ReadTx(),
+			vm.repo,
+			true,
+			planner.AllBranches,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -544,7 +604,14 @@ func (vm *stackSyncViewModel) createState() (*savedStackSyncState, error) {
 	if currentBranch != "" {
 		currentBranchRef = plumbing.NewBranchReferenceName(currentBranch)
 	}
-	ops, err := planner.PlanForSync(vm.db.ReadTx(), vm.repo, currentBranchRef, stackSyncFlags.All, stackSyncFlags.Current, stackSyncFlags.RebaseToTrunk)
+	ops, err := planner.PlanForSync(
+		vm.db.ReadTx(),
+		vm.repo,
+		currentBranchRef,
+		stackSyncFlags.All,
+		stackSyncFlags.Current,
+		stackSyncFlags.RebaseToTrunk,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -553,13 +620,25 @@ func (vm *stackSyncViewModel) createState() (*savedStackSyncState, error) {
 }
 
 func (vm *stackSyncViewModel) initPushBranches() tea.Cmd {
-	vm.githubPushModel = ghui.NewGitHubPushModel(vm.repo, vm.db, vm.client, vm.state.Push, vm.state.TargetBranches)
+	vm.githubPushModel = ghui.NewGitHubPushModel(
+		vm.repo,
+		vm.db,
+		vm.client,
+		vm.state.Push,
+		vm.state.TargetBranches,
+	)
 	vm.pushingToGitHub = true
 	return vm.githubPushModel.Init()
 }
 
 func (vm *stackSyncViewModel) initPruneBranches() tea.Cmd {
-	vm.pruneBranchModel = gitui.NewPruneBranchModel(vm.repo, vm.db, vm.state.Prune, vm.state.TargetBranches, vm.restackModel.State.InitialBranch)
+	vm.pruneBranchModel = gitui.NewPruneBranchModel(
+		vm.repo,
+		vm.db,
+		vm.state.Prune,
+		vm.state.TargetBranches,
+		vm.restackModel.State.InitialBranch,
+	)
 	vm.pruningBranches = true
 	return vm.pruneBranchModel.Init()
 }
@@ -606,13 +685,16 @@ func init() {
 	stackSyncCmd.Flags().Bool("no-fetch", false,
 		"(deprecated; use av stack restack for offline restacking) do not fetch the latest status from GitHub",
 	)
-	_ = stackSyncCmd.Flags().MarkDeprecated("no-fetch", "please use av stack restack for offline restacking")
+	_ = stackSyncCmd.Flags().
+		MarkDeprecated("no-fetch", "please use av stack restack for offline restacking")
 	stackSyncCmd.Flags().Bool("trunk", false,
 		"(deprecated; now av stack sync automatically restacks on the trunk branch without this option. Use av stack restack for stacking without the trunk branch) rebase the stack on the trunk branch",
 	)
-	_ = stackSyncCmd.Flags().MarkDeprecated("trunk", "now av stack sync automatically restacks on the trunk branch without this option. Use av stack restack for restacking without the trunk branch")
+	_ = stackSyncCmd.Flags().
+		MarkDeprecated("trunk", "now av stack sync automatically restacks on the trunk branch without this option. Use av stack restack for restacking without the trunk branch")
 	stackSyncCmd.Flags().String("parent", "",
 		"(deprecated; use av stack adopt or av stack reparent) parent branch to rebase onto",
 	)
-	_ = stackSyncCmd.Flags().MarkDeprecated("parent", "please use av stack adopt or av stack reparent")
+	_ = stackSyncCmd.Flags().
+		MarkDeprecated("parent", "please use av stack adopt or av stack reparent")
 }

--- a/cmd/av/stack_tree.go
+++ b/cmd/av/stack_tree.go
@@ -42,7 +42,13 @@ var stackTreeCmd = &cobra.Command{
 		for _, node := range rootNodes {
 			fmt.Println(stackutils.RenderTree(node, func(branchName string, isTrunk bool) string {
 				stbi := getStackTreeBranchInfo(repo, tx, branchName)
-				return renderStackTreeBranchInfo(stackTreeStackBranchInfoStyles, stbi, currentBranch, branchName, isTrunk)
+				return renderStackTreeBranchInfo(
+					stackTreeStackBranchInfoStyles,
+					stbi,
+					currentBranch,
+					branchName,
+					isTrunk,
+				)
 			}))
 		}
 		return nil
@@ -65,7 +71,13 @@ var stackTreeStackBranchInfoStyles = stackBranchInfoStyles{
 	PullRequestLink: lipgloss.NewStyle(),
 }
 
-func renderStackTreeBranchInfo(styles stackBranchInfoStyles, stbi *stackTreeBranchInfo, currentBranchName string, branchName string, isTrunk bool) string {
+func renderStackTreeBranchInfo(
+	styles stackBranchInfoStyles,
+	stbi *stackTreeBranchInfo,
+	currentBranchName string,
+	branchName string,
+	isTrunk bool,
+) string {
 	sb := strings.Builder{}
 	sb.WriteString(styles.BranchName.Render(branchName))
 	var stats []string
@@ -103,7 +115,11 @@ type stackTreeBranchInfo struct {
 	PullRequestLink string
 }
 
-func getStackTreeBranchInfo(repo *git.Repo, tx meta.ReadTx, branchName string) *stackTreeBranchInfo {
+func getStackTreeBranchInfo(
+	repo *git.Repo,
+	tx meta.ReadTx,
+	branchName string,
+) *stackTreeBranchInfo {
 	bi, _ := tx.Branch(branchName)
 	branchInfo := stackTreeBranchInfo{
 		BranchName: branchName,

--- a/e2e_tests/helpers.go
+++ b/e2e_tests/helpers.go
@@ -11,10 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func RequireCurrentBranchName(t *testing.T, repo *gittest.GitTestRepo, name plumbing.ReferenceName) {
+func RequireCurrentBranchName(
+	t *testing.T,
+	repo *gittest.GitTestRepo,
+	name plumbing.ReferenceName,
+) {
 	ref, err := repo.GoGit.Reference(plumbing.HEAD, false)
 	require.NoError(t, err, "failed to determine current branch name")
-	require.Equal(t, plumbing.SymbolicReference, ref.Type(), "expected HEAD to be a symbolic reference")
+	require.Equal(
+		t,
+		plumbing.SymbolicReference,
+		ref.Type(),
+		"expected HEAD to be a symbolic reference",
+	)
 	require.Equal(
 		t,
 		name,
@@ -31,7 +40,11 @@ func GetFetchHeadTimestamp(t *testing.T, repo *gittest.GitTestRepo) time.Time {
 	return fileInfo.ModTime()
 }
 
-func GetStoredParentBranchState(t *testing.T, repo *gittest.GitTestRepo, name string) meta.BranchState {
+func GetStoredParentBranchState(
+	t *testing.T,
+	repo *gittest.GitTestRepo,
+	name string,
+) meta.BranchState {
 	// We shouldn't do this as part of an E2E test, but it's hard to ensure otherwise.
 	db := repo.OpenDB(t)
 	br, _ := db.ReadTx().Branch(name)

--- a/e2e_tests/stack_restack_test.go
+++ b/e2e_tests/stack_restack_test.go
@@ -112,10 +112,18 @@ func TestStackRestack(t *testing.T) {
 
 	// Make sure we've handled the rebase of stack-3 correctly (see the long
 	// comment above).
-	commits := repo.GetCommits(t, plumbing.NewBranchReferenceName("stack-3"), plumbing.NewBranchReferenceName("stack-2"))
+	commits := repo.GetCommits(
+		t,
+		plumbing.NewBranchReferenceName("stack-3"),
+		plumbing.NewBranchReferenceName("stack-2"),
+	)
 	require.Len(t, commits, 1)
 
-	mergeBases := repo.MergeBase(t, plumbing.NewBranchReferenceName("stack-1"), plumbing.NewBranchReferenceName("stack-2"))
+	mergeBases := repo.MergeBase(
+		t,
+		plumbing.NewBranchReferenceName("stack-1"),
+		plumbing.NewBranchReferenceName("stack-2"),
+	)
 	stack1Head := repo.GetCommitAtRef(t, plumbing.NewBranchReferenceName("stack-1"))
 	require.Equal(t, mergeBases[0], stack1Head, "stack-2 should be up-to-date with stack-1")
 
@@ -125,7 +133,11 @@ func TestStackRestack(t *testing.T) {
 
 	// Make sure we've not introduced any extra commits
 	// We should have 4 (corresponding to 1a, 1b, 2a, and 3a).
-	commits = repo.GetCommits(t, plumbing.NewBranchReferenceName("stack-3"), plumbing.NewBranchReferenceName("main"))
+	commits = repo.GetCommits(
+		t,
+		plumbing.NewBranchReferenceName("stack-3"),
+		plumbing.NewBranchReferenceName("main"),
+	)
 	require.NoError(t, err)
 	require.Len(t, commits, 4)
 

--- a/e2e_tests/stack_sync_test.go
+++ b/e2e_tests/stack_sync_test.go
@@ -118,10 +118,18 @@ func TestStackSync(t *testing.T) {
 
 	// Make sure we've handled the rebase of stack-3 correctly (see the long
 	// comment above).
-	commits := repo.GetCommits(t, plumbing.NewBranchReferenceName("stack-3"), plumbing.NewBranchReferenceName("stack-2"))
+	commits := repo.GetCommits(
+		t,
+		plumbing.NewBranchReferenceName("stack-3"),
+		plumbing.NewBranchReferenceName("stack-2"),
+	)
 	require.Len(t, commits, 1)
 
-	mergeBases := repo.MergeBase(t, plumbing.NewBranchReferenceName("stack-1"), plumbing.NewBranchReferenceName("stack-2"))
+	mergeBases := repo.MergeBase(
+		t,
+		plumbing.NewBranchReferenceName("stack-1"),
+		plumbing.NewBranchReferenceName("stack-2"),
+	)
 	stack1Head := repo.GetCommitAtRef(t, plumbing.NewBranchReferenceName("stack-1"))
 	require.Equal(t, mergeBases[0], stack1Head, "stack-2 should be up-to-date with stack-1")
 
@@ -131,7 +139,11 @@ func TestStackSync(t *testing.T) {
 
 	// Make sure we've not introduced any extra commits
 	// We should have 4 (corresponding to 1a, 1b, 2a, and 3a).
-	commits = repo.GetCommits(t, plumbing.NewBranchReferenceName("stack-3"), plumbing.NewBranchReferenceName("main"))
+	commits = repo.GetCommits(
+		t,
+		plumbing.NewBranchReferenceName("stack-3"),
+		plumbing.NewBranchReferenceName("main"),
+	)
 	require.NoError(t, err)
 	require.Len(t, commits, 4)
 

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -257,7 +257,11 @@ func CreatePullRequest(
 		prCompareRef = fmt.Sprintf("%s/%s", repo.GetRemoteName(), parentState.Name)
 	}
 
-	commitsList, err := repo.Git("rev-list", "--reverse", fmt.Sprintf("%s..%s", prCompareRef, opts.BranchName))
+	commitsList, err := repo.Git(
+		"rev-list",
+		"--reverse",
+		fmt.Sprintf("%s..%s", prCompareRef, opts.BranchName),
+	)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to determine commits to include in PR")
 	}
@@ -267,7 +271,10 @@ func CreatePullRequest(
 
 	// Check if a parent branch has already been merged or not
 	if parentMeta.MergeCommit != "" {
-		return nil, errors.Errorf("failed to create a pull request. The parent branch %q has already been merged\nPlease run av stack sync to rebase the branch first.", parentMeta.Name)
+		return nil, errors.Errorf(
+			"failed to create a pull request. The parent branch %q has already been merged\nPlease run av stack sync to rebase the branch first.",
+			parentMeta.Name,
+		)
 	}
 
 	if existingPR != nil {
@@ -534,8 +541,12 @@ func ensurePR(
 		BaseRefName:  githubv4.String(opts.baseRefName),
 		HeadRefName:  githubv4.String(opts.headRefName),
 		Title:        githubv4.String(opts.title),
-		Body:         gh.Ptr(githubv4.String(AddPRMetadataAndStack(opts.body, opts.meta, opts.headRefName, initialStack, tx))),
-		Draft:        gh.Ptr(githubv4.Boolean(opts.draft)),
+		Body: gh.Ptr(
+			githubv4.String(
+				AddPRMetadataAndStack(opts.body, opts.meta, opts.headRefName, initialStack, tx),
+			),
+		),
+		Draft: gh.Ptr(githubv4.Boolean(opts.draft)),
 	})
 	if err != nil {
 		return nil, false, errors.WithStack(err)
@@ -568,7 +579,10 @@ func UpdatePullRequestState(
 		HeadRefName: branchName,
 	})
 	if err != nil {
-		return nil, errors.WrapIf(err, "querying GitHub pull requests. Make sure GitHub token is set or refresh.\nSee: https://docs.aviator.co/aviator-cli#getting-started")
+		return nil, errors.WrapIf(
+			err,
+			"querying GitHub pull requests. Make sure GitHub token is set or refresh.\nSee: https://docs.aviator.co/aviator-cli#getting-started",
+		)
 	}
 
 	if len(page.PullRequests) == 0 {
@@ -821,7 +835,8 @@ func AddPRMetadataAndStack(
 	sb := strings.Builder{}
 
 	// Don't write out a stack unless there is more than one PR in it.
-	hasMultilevelStack := stack != nil && len(stack.Children) > 0 && len(stack.Children[0].Children) > 0
+	hasMultilevelStack := stack != nil && len(stack.Children) > 0 &&
+		len(stack.Children[0].Children) > 0
 	if hasMultilevelStack {
 		bi, _ := tx.Branch(branchName)
 		stackString := walkStack(tx, stack, branchName)
@@ -838,7 +853,9 @@ func AddPRMetadataAndStack(
 			sb.WriteString(strconv.FormatInt(parentBi.PullRequest.Number, 10))
 			sb.WriteString(".</b> ")
 		}
-		sb.WriteString("This PR is part of a stack created with <a href=\"https://github.com/aviator-co/av\">Aviator</a>.")
+		sb.WriteString(
+			"This PR is part of a stack created with <a href=\"https://github.com/aviator-co/av\">Aviator</a>.",
+		)
 		sb.WriteString("</summary>")
 		sb.WriteString("\n\n")
 		sb.WriteString(stackString)
@@ -879,7 +896,9 @@ func UpdatePullRequestWithStack(
 	branchName string,
 ) error {
 	branchMeta, _ := tx.Branch(branchName)
-	logrus.WithField("branch", branchName).WithField("pr", branchMeta.PullRequest.ID).Debug("Updating pull requests with stack")
+	logrus.WithField("branch", branchName).
+		WithField("pr", branchMeta.PullRequest.ID).
+		Debug("Updating pull requests with stack")
 
 	repoMeta := tx.Repository()
 

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -19,7 +19,13 @@ func TestReadPRMetadata(t *testing.T) {
 		ParentPull: 123,
 		Trunk:      "baz",
 	}
-	prBody := actions.AddPRMetadataAndStack("Hello! This is a cool PR that does some neat things.", prMeta, "foo", nil, tx)
+	prBody := actions.AddPRMetadataAndStack(
+		"Hello! This is a cool PR that does some neat things.",
+		prMeta,
+		"foo",
+		nil,
+		tx,
+	)
 	prMeta2, err := actions.ReadPRMetadata(prBody)
 	require.NoError(t, err)
 	assert.Equal(t, prMeta.Parent, prMeta2.Parent)

--- a/internal/gh/ghui/fetch.go
+++ b/internal/gh/ghui/fetch.go
@@ -18,7 +18,13 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
-func NewGitHubFetchModel(repo *git.Repo, db meta.DB, client *gh.Client, currentBranch plumbing.ReferenceName, targetBranches []plumbing.ReferenceName) *GitHubFetchModel {
+func NewGitHubFetchModel(
+	repo *git.Repo,
+	db meta.DB,
+	client *gh.Client,
+	currentBranch plumbing.ReferenceName,
+	targetBranches []plumbing.ReferenceName,
+) *GitHubFetchModel {
 	return &GitHubFetchModel{
 		repo:           repo,
 		db:             db,
@@ -131,7 +137,12 @@ func (vm *GitHubFetchModel) View() string {
 		}
 		var nodes []*stackutils.StackTreeNode
 		var err error
-		nodes, err = stackutils.BuildStackTreeRelatedBranchStacks(vm.db.ReadTx(), vm.currentBranch.Short(), true, brs)
+		nodes, err = stackutils.BuildStackTreeRelatedBranchStacks(
+			vm.db.ReadTx(),
+			vm.currentBranch.Short(),
+			true,
+			brs,
+		)
 		if err != nil {
 			sb.WriteString("Failed to build stack tree: " + err.Error())
 		} else {
@@ -293,7 +304,10 @@ func (vm *GitHubFetchModel) updateMergeCommitsFromChildren() tea.Msg {
 	return &GitHubFetchProgress{mergeCommitPropagationIsDone: true}
 }
 
-func mapToRemoteTrackingBranch(remoteConfig *config.RemoteConfig, refName plumbing.ReferenceName) *plumbing.ReferenceName {
+func mapToRemoteTrackingBranch(
+	remoteConfig *config.RemoteConfig,
+	refName plumbing.ReferenceName,
+) *plumbing.ReferenceName {
 	for _, fetch := range remoteConfig.Fetch {
 		if fetch.Match(refName) {
 			dst := fetch.Dst(refName)

--- a/internal/git/cherrypick_test.go
+++ b/internal/git/cherrypick_test.go
@@ -20,14 +20,21 @@ func TestRepo_CherryPick(t *testing.T) {
 
 	// Switch back to c1 and test that we can cherry-pick c2 on top of it
 	repo.CheckoutCommit(t, c1)
-	require.NoError(t, repo.AsAvGitRepo().CherryPick(git.CherryPick{Commits: []string{c2.String()}}))
+	require.NoError(
+		t,
+		repo.AsAvGitRepo().CherryPick(git.CherryPick{Commits: []string{c2.String()}}),
+	)
 	contents, err := os.ReadFile(filepath.Join(repo.RepoDir, "file"))
 	require.NoError(t, err)
 	assert.Equal(t, "first commit\nsecond commit\n", string(contents))
 
 	// Switch back to c1 and check that we can fast-forward to c2
 	repo.CheckoutCommit(t, c1)
-	require.NoError(t, repo.AsAvGitRepo().CherryPick(git.CherryPick{Commits: []string{c2.String()}, FastForward: true}))
+	require.NoError(
+		t,
+		repo.AsAvGitRepo().
+			CherryPick(git.CherryPick{Commits: []string{c2.String()}, FastForward: true}),
+	)
 	_, err = os.ReadFile(filepath.Join(repo.RepoDir, "file"))
 	require.NoError(t, err)
 

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -233,7 +233,10 @@ func (r *GitTestRepo) CreateRef(t *testing.T, ref plumbing.ReferenceName) {
 }
 
 // CheckoutBranch checks out the specified branch and returns the original branch.
-func (r *GitTestRepo) CheckoutBranch(t *testing.T, branch plumbing.ReferenceName) plumbing.ReferenceName {
+func (r *GitTestRepo) CheckoutBranch(
+	t *testing.T,
+	branch plumbing.ReferenceName,
+) plumbing.ReferenceName {
 	original := r.CurrentBranch(t)
 	wt, err := r.GoGit.Worktree()
 	require.NoError(t, err, "failed to get worktree")
@@ -257,7 +260,10 @@ func (r *GitTestRepo) WithCheckoutBranch(t *testing.T, branch plumbing.Reference
 	f()
 }
 
-func (r *GitTestRepo) GetCommits(t *testing.T, includedFromRef, excludedFromRef plumbing.ReferenceName) []plumbing.Hash {
+func (r *GitTestRepo) GetCommits(
+	t *testing.T,
+	includedFromRef, excludedFromRef plumbing.ReferenceName,
+) []plumbing.Hash {
 	from := r.GetCommitAtRef(t, includedFromRef)
 	excluded := r.GetCommitAtRef(t, excludedFromRef)
 

--- a/internal/git/gitui/prune.go
+++ b/internal/git/gitui/prune.go
@@ -38,7 +38,13 @@ type noDeleteBranch struct {
 	reason string
 }
 
-func NewPruneBranchModel(repo *git.Repo, db meta.DB, pruneFlag string, targetBranches []plumbing.ReferenceName, initialBranch string) *PruneBranchModel {
+func NewPruneBranchModel(
+	repo *git.Repo,
+	db meta.DB,
+	pruneFlag string,
+	targetBranches []plumbing.ReferenceName,
+	initialBranch string,
+) *PruneBranchModel {
 	return &PruneBranchModel{
 		repo:           repo,
 		db:             db,
@@ -230,7 +236,8 @@ func (vm *PruneBranchModel) runDelete() tea.Msg {
 
 func (vm *PruneBranchModel) CheckoutInitialState() error {
 	if vm.initialBranch != "" {
-		initialHead, err := vm.repo.GoGitRepo().Reference(plumbing.NewBranchReferenceName(vm.initialBranch), true)
+		initialHead, err := vm.repo.GoGitRepo().
+			Reference(plumbing.NewBranchReferenceName(vm.initialBranch), true)
 		if err == nil {
 			if initialHead.Type() == plumbing.HashReference {
 				// Normal reference that points to a commit. Checking out.
@@ -292,16 +299,25 @@ func (vm *PruneBranchModel) calculateMergedBranches() tea.Msg {
 			continue
 		}
 		if vm.hasOpenChildren(br) {
-			noDeleteBranches = append(noDeleteBranches, noDeleteBranch{branch: br, reason: reasonHasChild})
+			noDeleteBranches = append(
+				noDeleteBranches,
+				noDeleteBranch{branch: br, reason: reasonHasChild},
+			)
 			continue
 		}
 		if avbr.PullRequest == nil {
-			noDeleteBranches = append(noDeleteBranches, noDeleteBranch{branch: br, reason: reasonNoPullRequest})
+			noDeleteBranches = append(
+				noDeleteBranches,
+				noDeleteBranch{branch: br, reason: reasonNoPullRequest},
+			)
 			continue
 		}
 		remoteHash, ok := remoteBranches[fmt.Sprintf("refs/pull/%d/head", avbr.PullRequest.Number)]
 		if !ok {
-			noDeleteBranches = append(noDeleteBranches, noDeleteBranch{branch: br, reason: reasonPRHeadNotFound})
+			noDeleteBranches = append(
+				noDeleteBranches,
+				noDeleteBranch{branch: br, reason: reasonPRHeadNotFound},
+			)
 			continue
 		}
 		ref, err := vm.repo.GoGitRepo().Reference(plumbing.ReferenceName(br), true)
@@ -309,7 +325,10 @@ func (vm *PruneBranchModel) calculateMergedBranches() tea.Msg {
 			return err
 		}
 		if ref.Hash().String() != remoteHash {
-			noDeleteBranches = append(noDeleteBranches, noDeleteBranch{branch: br, reason: reasonPRHeadIsDifferent})
+			noDeleteBranches = append(
+				noDeleteBranches,
+				noDeleteBranch{branch: br, reason: reasonPRHeadIsDifferent},
+			)
 			continue
 		}
 		deleteCandidates = append(deleteCandidates, deleteCandidate{branch: br, commit: ref.Hash()})
@@ -329,7 +348,10 @@ func (vm *PruneBranchModel) hasOpenChildren(br plumbing.ReferenceName) bool {
 	return false
 }
 
-func mapToRemoteTrackingBranch(remoteConfig *config.RemoteConfig, refName plumbing.ReferenceName) *plumbing.ReferenceName {
+func mapToRemoteTrackingBranch(
+	remoteConfig *config.RemoteConfig,
+	refName plumbing.ReferenceName,
+) *plumbing.ReferenceName {
 	for _, fetch := range remoteConfig.Fetch {
 		if fetch.Match(refName) {
 			dst := fetch.Dst(refName)

--- a/internal/git/log_test.go
+++ b/internal/git/log_test.go
@@ -23,7 +23,8 @@ func TestRepo_Log(t *testing.T) {
 		gittest.WithMessage("commit 2\n\ncommit 2 body"),
 	)
 
-	cis, err := repo.AsAvGitRepo().Log(git.LogOpts{RevisionRange: []string{c2.String(), "^" + c1.String() + "^1"}})
+	cis, err := repo.AsAvGitRepo().
+		Log(git.LogOpts{RevisionRange: []string{c2.String(), "^" + c1.String() + "^1"}})
 	assert.NoError(t, err)
 	assert.Equal(t, []*git.CommitInfo{
 		{

--- a/internal/git/state_file.go
+++ b/internal/git/state_file.go
@@ -25,7 +25,8 @@ func (r *Repo) ReadStateFile(kind StateFileKind, msg any) error {
 
 func (r *Repo) WriteStateFile(kind StateFileKind, msg any) error {
 	if msg == nil {
-		if err := os.Remove(filepath.Join(r.AvDir(), string(kind))); err != nil && !os.IsNotExist(err) {
+		if err := os.Remove(filepath.Join(r.AvDir(), string(kind))); err != nil &&
+			!os.IsNotExist(err) {
 			return err
 		}
 		return nil

--- a/internal/reorder/pick_test.go
+++ b/internal/reorder/pick_test.go
@@ -31,7 +31,12 @@ func TestPickCmd_Execute(t *testing.T) {
 			PickCmd{Commit: next.String()}.Execute(ctx),
 			"PickCmd.Execute should succeed with a fast-forward",
 		)
-		require.Equal(t, next.String(), ctx.State.Head, "PickCmd.Execute should update the state's head")
+		require.Equal(
+			t,
+			next.String(),
+			ctx.State.Head,
+			"PickCmd.Execute should update the state's head",
+		)
 	})
 
 	t.Run("conflicting commit", func(t *testing.T) {

--- a/internal/sequencer/planner/planner.go
+++ b/internal/sequencer/planner/planner.go
@@ -8,7 +8,12 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
-func PlanForRestack(tx meta.ReadTx, repo *git.Repo, currentBranch plumbing.ReferenceName, restackAll, restackCurrent bool) ([]sequencer.RestackOp, error) {
+func PlanForRestack(
+	tx meta.ReadTx,
+	repo *git.Repo,
+	currentBranch plumbing.ReferenceName,
+	restackAll, restackCurrent bool,
+) ([]sequencer.RestackOp, error) {
 	var targetBranches []plumbing.ReferenceName
 	var err error
 	if restackAll {
@@ -42,7 +47,12 @@ func PlanForRestack(tx meta.ReadTx, repo *git.Repo, currentBranch plumbing.Refer
 	return ret, nil
 }
 
-func PlanForSync(tx meta.ReadTx, repo *git.Repo, currentBranch plumbing.ReferenceName, restackAll, restackCurrent, restackStackRoots bool) ([]sequencer.RestackOp, error) {
+func PlanForSync(
+	tx meta.ReadTx,
+	repo *git.Repo,
+	currentBranch plumbing.ReferenceName,
+	restackAll, restackCurrent, restackStackRoots bool,
+) ([]sequencer.RestackOp, error) {
 	var targetBranches []plumbing.ReferenceName
 	var err error
 	if restackAll {
@@ -92,7 +102,11 @@ func PlanForSync(tx meta.ReadTx, repo *git.Repo, currentBranch plumbing.Referenc
 	return ret, nil
 }
 
-func PlanForReparent(tx meta.ReadTx, repo *git.Repo, currentBranch, newParentBranch plumbing.ReferenceName) ([]sequencer.RestackOp, error) {
+func PlanForReparent(
+	tx meta.ReadTx,
+	repo *git.Repo,
+	currentBranch, newParentBranch plumbing.ReferenceName,
+) ([]sequencer.RestackOp, error) {
 	if newParentBranch == currentBranch {
 		return nil, errors.New("cannot re-parent to self")
 	}
@@ -127,7 +141,11 @@ func PlanForReparent(tx meta.ReadTx, repo *git.Repo, currentBranch, newParentBra
 	return ret, nil
 }
 
-func PlanForAmend(tx meta.ReadTx, repo *git.Repo, currentBranch plumbing.ReferenceName) ([]sequencer.RestackOp, error) {
+func PlanForAmend(
+	tx meta.ReadTx,
+	repo *git.Repo,
+	currentBranch plumbing.ReferenceName,
+) ([]sequencer.RestackOp, error) {
 	var ret []sequencer.RestackOp
 	for _, child := range meta.SubsequentBranches(tx, currentBranch.Short()) {
 		avbr, _ := tx.Branch(child)

--- a/internal/sequencer/planner/targets.go
+++ b/internal/sequencer/planner/targets.go
@@ -23,7 +23,12 @@ const (
 //
 // If `includeStackRoots` is true, the stack root branches (the immediate children of the trunk
 // branches) are included in the result.
-func GetTargetBranches(tx meta.ReadTx, repo *git.Repo, includeStackRoots bool, mode TargetBranchMode) ([]plumbing.ReferenceName, error) {
+func GetTargetBranches(
+	tx meta.ReadTx,
+	repo *git.Repo,
+	includeStackRoots bool,
+	mode TargetBranchMode,
+) ([]plumbing.ReferenceName, error) {
 	var ret []plumbing.ReferenceName
 	if mode == AllBranches {
 		for _, br := range tx.AllBranches() {

--- a/internal/sequencer/sequencer.go
+++ b/internal/sequencer/sequencer.go
@@ -87,7 +87,11 @@ func getBranchSnapshots(db meta.DB) map[plumbing.ReferenceName]*branchSnapshot {
 	return ret
 }
 
-func (seq *Sequencer) Run(repo *git.Repo, db meta.DB, seqAbort, seqContinue, seqSkip bool) (*git.RebaseResult, error) {
+func (seq *Sequencer) Run(
+	repo *git.Repo,
+	db meta.DB,
+	seqAbort, seqContinue, seqSkip bool,
+) (*git.RebaseResult, error) {
 	if seqAbort || seqContinue || seqSkip {
 		return seq.runFromInterruptedState(repo, db, seqAbort, seqContinue, seqSkip)
 	}
@@ -98,7 +102,11 @@ func (seq *Sequencer) Run(repo *git.Repo, db meta.DB, seqAbort, seqContinue, seq
 	return seq.rebaseBranch(repo, db)
 }
 
-func (seq *Sequencer) runFromInterruptedState(repo *git.Repo, db meta.DB, seqAbort, seqContinue, seqSkip bool) (*git.RebaseResult, error) {
+func (seq *Sequencer) runFromInterruptedState(
+	repo *git.Repo,
+	db meta.DB,
+	seqAbort, seqContinue, seqSkip bool,
+) (*git.RebaseResult, error) {
 	if seq.CurrentSyncRef == "" {
 		return nil, errors.New("no sync in progress")
 	}
@@ -197,7 +205,12 @@ func (seq *Sequencer) rebaseBranch(repo *git.Repo, db meta.DB) (*git.RebaseResul
 		return nil, err
 	}
 	if result.Status == git.RebaseConflict {
-		result.ErrorHeadline = fmt.Sprintf("Failed to rebase %q onto %q (merge base is %q)\n", op.Name, op.NewParent, previousParentHash.String()[:7]) + result.ErrorHeadline
+		result.ErrorHeadline = fmt.Sprintf(
+			"Failed to rebase %q onto %q (merge base is %q)\n",
+			op.Name,
+			op.NewParent,
+			previousParentHash.String()[:7],
+		) + result.ErrorHeadline
 		seq.SequenceInterruptedNewParentHash = newParentHash
 		return result, nil
 	}
@@ -260,30 +273,47 @@ func (seq *Sequencer) getCurrentOp() RestackOp {
 	panic(fmt.Sprintf("op not found for ref %q", seq.CurrentSyncRef))
 }
 
-func (seq *Sequencer) getRemoteTrackingBranchCommit(repo *git.Repo, ref plumbing.ReferenceName) (plumbing.Hash, error) {
+func (seq *Sequencer) getRemoteTrackingBranchCommit(
+	repo *git.Repo,
+	ref plumbing.ReferenceName,
+) (plumbing.Hash, error) {
 	remote, err := repo.GoGitRepo().Remote(seq.RemoteName)
 	if err != nil {
 		return plumbing.ZeroHash, errors.Errorf("failed to get remote %q: %v", seq.RemoteName, err)
 	}
 	rtb := mapToRemoteTrackingBranch(remote.Config(), ref)
 	if rtb == nil {
-		return plumbing.ZeroHash, errors.Errorf("failed to get remote tracking branch in %q for %q", seq.RemoteName, ref)
+		return plumbing.ZeroHash, errors.Errorf(
+			"failed to get remote tracking branch in %q for %q",
+			seq.RemoteName,
+			ref,
+		)
 	}
 	return seq.getBranchCommit(repo, *rtb)
 }
 
-func (seq *Sequencer) getBranchCommit(repo *git.Repo, ref plumbing.ReferenceName) (plumbing.Hash, error) {
+func (seq *Sequencer) getBranchCommit(
+	repo *git.Repo,
+	ref plumbing.ReferenceName,
+) (plumbing.Hash, error) {
 	refObj, err := repo.GoGitRepo().Reference(ref, false)
 	if err != nil {
 		return plumbing.ZeroHash, errors.Errorf("failed to get branch %q: %v", ref, err)
 	}
 	if refObj.Type() != plumbing.HashReference {
-		return plumbing.ZeroHash, errors.Errorf("unexpected reference type for branch %q: %v", ref, refObj.Type())
+		return plumbing.ZeroHash, errors.Errorf(
+			"unexpected reference type for branch %q: %v",
+			ref,
+			refObj.Type(),
+		)
 	}
 	return refObj.Hash(), nil
 }
 
-func mapToRemoteTrackingBranch(remoteConfig *config.RemoteConfig, refName plumbing.ReferenceName) *plumbing.ReferenceName {
+func mapToRemoteTrackingBranch(
+	remoteConfig *config.RemoteConfig,
+	refName plumbing.ReferenceName,
+) *plumbing.ReferenceName {
 	for _, fetch := range remoteConfig.Fetch {
 		if fetch.Match(refName) {
 			dst := fetch.Dst(refName)

--- a/internal/sequencer/sequencerui/ui.go
+++ b/internal/sequencer/sequencerui/ui.go
@@ -105,7 +105,11 @@ func (vm *RestackModel) View() string {
 	sb := strings.Builder{}
 	if vm.State != nil && vm.State.Seq != nil {
 		if vm.State.Seq.CurrentSyncRef != "" {
-			sb.WriteString(colors.ProgressStyle.Render(vm.spinner.View() + "Restacking " + vm.State.Seq.CurrentSyncRef.Short() + "..."))
+			sb.WriteString(
+				colors.ProgressStyle.Render(
+					vm.spinner.View() + "Restacking " + vm.State.Seq.CurrentSyncRef.Short() + "...",
+				),
+			)
 		} else if vm.abortedBranch != "" {
 			sb.WriteString(colors.FailureStyle.Render("✗ Restack is aborted"))
 		} else {
@@ -130,7 +134,11 @@ func (vm *RestackModel) View() string {
 		var nodes []*stackutils.StackTreeNode
 		var err error
 		if vm.State.RestackingAll {
-			nodes = stackutils.BuildStackTreeAllBranches(vm.db.ReadTx(), vm.State.InitialBranch, true)
+			nodes = stackutils.BuildStackTreeAllBranches(
+				vm.db.ReadTx(),
+				vm.State.InitialBranch,
+				true,
+			)
 		} else {
 			nodes, err = stackutils.BuildStackTreeRelatedBranchStacks(vm.db.ReadTx(), vm.State.InitialBranch, true, vm.State.RelatedBranches)
 		}
@@ -173,11 +181,20 @@ func (vm *RestackModel) View() string {
 	}
 	if vm.rebaseConflictErrorHeadline != "" {
 		sb.WriteString("\n")
-		sb.WriteString(colors.FailureStyle.Render("Rebase conflict while rebasing ", vm.State.Seq.CurrentSyncRef.Short()) + "\n")
+		sb.WriteString(
+			colors.FailureStyle.Render(
+				"Rebase conflict while rebasing ",
+				vm.State.Seq.CurrentSyncRef.Short(),
+			) + "\n",
+		)
 		sb.WriteString(vm.rebaseConflictErrorHeadline + "\n")
 		sb.WriteString(vm.rebaseConflictHint + "\n")
 		sb.WriteString("\n")
-		sb.WriteString("Resolve the conflicts and continue the restack with " + colors.CliCmd(vm.Command+" --continue"))
+		sb.WriteString(
+			"Resolve the conflicts and continue the restack with " + colors.CliCmd(
+				vm.Command+" --continue",
+			),
+		)
 	}
 	return sb.String()
 }

--- a/internal/treedetector/detector.go
+++ b/internal/treedetector/detector.go
@@ -24,7 +24,11 @@ type BranchPiece struct {
 	IncludedCommits []*object.Commit
 }
 
-func DetectBranchTree(repo *avgit.Repo, remoteName string, trunkBranches []plumbing.ReferenceName) (map[plumbing.ReferenceName]*BranchPiece, error) {
+func DetectBranchTree(
+	repo *avgit.Repo,
+	remoteName string,
+	trunkBranches []plumbing.ReferenceName,
+) (map[plumbing.ReferenceName]*BranchPiece, error) {
 	trunkCommits, err := getTrunkCommits(repo.GoGitRepo(), remoteName, trunkBranches)
 	if err != nil {
 		return nil, err
@@ -61,7 +65,11 @@ func DetectBranchTree(repo *avgit.Repo, remoteName string, trunkBranches []plumb
 	return ret, nil
 }
 
-func getTrunkCommits(repo *git.Repository, remoteName string, trunkBranches []plumbing.ReferenceName) (map[plumbing.ReferenceName][]*object.Commit, error) {
+func getTrunkCommits(
+	repo *git.Repository,
+	remoteName string,
+	trunkBranches []plumbing.ReferenceName,
+) (map[plumbing.ReferenceName][]*object.Commit, error) {
 	remote, err := repo.Remote(remoteName)
 	if err != nil {
 		return nil, errors.Errorf("failed to get remote %q: %v", remoteName, err)
@@ -194,7 +202,10 @@ func (d *detector) detectBranchTree(ref *plumbing.Reference) (*BranchPiece, erro
 	return ret, nil
 }
 
-func mapToRemoteTrackingBranch(remoteConfig *config.RemoteConfig, refName plumbing.ReferenceName) *plumbing.ReferenceName {
+func mapToRemoteTrackingBranch(
+	remoteConfig *config.RemoteConfig,
+	refName plumbing.ReferenceName,
+) *plumbing.ReferenceName {
 	for _, fetch := range remoteConfig.Fetch {
 		if fetch.Match(refName) {
 			dst := fetch.Dst(refName)

--- a/internal/treedetector/util.go
+++ b/internal/treedetector/util.go
@@ -8,7 +8,10 @@ import (
 
 // GetStackRoot returns the root of the stack of branches from the given branch. It returns an empty
 // string if the stack root cannot be detected.
-func GetStackRoot(pieces map[plumbing.ReferenceName]*BranchPiece, branch plumbing.ReferenceName) plumbing.ReferenceName {
+func GetStackRoot(
+	pieces map[plumbing.ReferenceName]*BranchPiece,
+	branch plumbing.ReferenceName,
+) plumbing.ReferenceName {
 	stackRoot := branch
 	for {
 		piece, ok := pieces[stackRoot]
@@ -25,7 +28,10 @@ func GetStackRoot(pieces map[plumbing.ReferenceName]*BranchPiece, branch plumbin
 }
 
 // GetChildren returns the children of the given branch.
-func GetChildren(pieces map[plumbing.ReferenceName]*BranchPiece, branch plumbing.ReferenceName) map[plumbing.ReferenceName]*BranchPiece {
+func GetChildren(
+	pieces map[plumbing.ReferenceName]*BranchPiece,
+	branch plumbing.ReferenceName,
+) map[plumbing.ReferenceName]*BranchPiece {
 	ret := map[plumbing.ReferenceName]*BranchPiece{}
 	var childFn func(plumbing.ReferenceName)
 	childFn = func(branch plumbing.ReferenceName) {
@@ -41,7 +47,10 @@ func GetChildren(pieces map[plumbing.ReferenceName]*BranchPiece, branch plumbing
 }
 
 // GetPossibleChildren returns the possible children of the given branch.
-func GetPossibleChildren(pieces map[plumbing.ReferenceName]*BranchPiece, branch plumbing.ReferenceName) []*BranchPiece {
+func GetPossibleChildren(
+	pieces map[plumbing.ReferenceName]*BranchPiece,
+	branch plumbing.ReferenceName,
+) []*BranchPiece {
 	var ret []*BranchPiece
 	var allChildFn func(plumbing.ReferenceName)
 	var mpChildFn func(plumbing.ReferenceName)
@@ -66,7 +75,11 @@ func GetPossibleChildren(pieces map[plumbing.ReferenceName]*BranchPiece, branch 
 }
 
 // ConvertToStackTree converts the branch pieces to a tree structure.
-func ConvertToStackTree(pieces map[plumbing.ReferenceName]*BranchPiece, currentBranch plumbing.ReferenceName, sortCurrent bool) []*stackutils.StackTreeNode {
+func ConvertToStackTree(
+	pieces map[plumbing.ReferenceName]*BranchPiece,
+	currentBranch plumbing.ReferenceName,
+	sortCurrent bool,
+) []*stackutils.StackTreeNode {
 	trunks := map[string]bool{}
 	var branches []*stackutils.StackTreeBranchInfo
 	for bn, piece := range pieces {

--- a/internal/utils/stackutils/render_tree.go
+++ b/internal/utils/stackutils/render_tree.go
@@ -6,11 +6,19 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func RenderTree(node *StackTreeNode, branchDataFn func(branchName string, isTrunk bool) string) string {
+func RenderTree(
+	node *StackTreeNode,
+	branchDataFn func(branchName string, isTrunk bool) string,
+) string {
 	return strings.TrimSuffix(renderTreeInternal(0, node, true, branchDataFn), "\n")
 }
 
-func renderTreeInternal(columns int, node *StackTreeNode, isTrunk bool, branchDataFn func(branchName string, isTrunk bool) string) string {
+func renderTreeInternal(
+	columns int,
+	node *StackTreeNode,
+	isTrunk bool,
+	branchDataFn func(branchName string, isTrunk bool) string,
+) string {
 	sb := strings.Builder{}
 	for i, child := range node.Children {
 		sb.WriteString(renderTreeInternal(columns+i, child, false, branchDataFn))

--- a/internal/utils/stackutils/stackutils.go
+++ b/internal/utils/stackutils/stackutils.go
@@ -17,12 +17,19 @@ type StackTreeNode struct {
 	Children []*StackTreeNode
 }
 
-func BuildTree(currentBranchName string, branches []*StackTreeBranchInfo, sortCurrent bool) []*StackTreeNode {
+func BuildTree(
+	currentBranchName string,
+	branches []*StackTreeBranchInfo,
+	sortCurrent bool,
+) []*StackTreeNode {
 	childBranches := make(map[string][]string)
 	branchMap := make(map[string]*StackTreeNode)
 	for _, branch := range branches {
 		branchMap[branch.BranchName] = &StackTreeNode{Branch: branch}
-		childBranches[branch.ParentBranchName] = append(childBranches[branch.ParentBranchName], branch.BranchName)
+		childBranches[branch.ParentBranchName] = append(
+			childBranches[branch.ParentBranchName],
+			branch.BranchName,
+		)
 	}
 	for _, branch := range branches {
 		node := branchMap[branch.BranchName]
@@ -84,12 +91,25 @@ func BuildTree(currentBranchName string, branches []*StackTreeBranchInfo, sortCu
 	return rootBranches
 }
 
-func BuildStackTreeAllBranches(tx meta.ReadTx, currentBranch string, sortCurrent bool) []*StackTreeNode {
+func BuildStackTreeAllBranches(
+	tx meta.ReadTx,
+	currentBranch string,
+	sortCurrent bool,
+) []*StackTreeNode {
 	return buildStackTree(currentBranch, tx.AllBranches(), sortCurrent)
 }
 
-func BuildStackTreeCurrentStack(tx meta.ReadTx, currentBranch string, sortCurrent bool) (*StackTreeNode, error) {
-	nodes, err := BuildStackTreeRelatedBranchStacks(tx, currentBranch, sortCurrent, []string{currentBranch})
+func BuildStackTreeCurrentStack(
+	tx meta.ReadTx,
+	currentBranch string,
+	sortCurrent bool,
+) (*StackTreeNode, error) {
+	nodes, err := BuildStackTreeRelatedBranchStacks(
+		tx,
+		currentBranch,
+		sortCurrent,
+		[]string{currentBranch},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +119,12 @@ func BuildStackTreeCurrentStack(tx meta.ReadTx, currentBranch string, sortCurren
 	return nodes[0], nil
 }
 
-func BuildStackTreeRelatedBranchStacks(tx meta.ReadTx, currentBranch string, sortCurrent bool, relatedBranches []string) ([]*StackTreeNode, error) {
+func BuildStackTreeRelatedBranchStacks(
+	tx meta.ReadTx,
+	currentBranch string,
+	sortCurrent bool,
+	relatedBranches []string,
+) ([]*StackTreeNode, error) {
 	branches := map[string]bool{}
 	for _, branch := range relatedBranches {
 		stack, err := meta.StackBranches(tx, branch)
@@ -123,7 +148,11 @@ func BuildStackTreeRelatedBranchStacks(tx meta.ReadTx, currentBranch string, sor
 	return buildStackTree(currentBranch, branchesToInclude, sortCurrent), nil
 }
 
-func buildStackTree(currentBranch string, branchesToInclude map[string]meta.Branch, sortCurrent bool) []*StackTreeNode {
+func buildStackTree(
+	currentBranch string,
+	branchesToInclude map[string]meta.Branch,
+	sortCurrent bool,
+) []*StackTreeNode {
 	trunks := map[string]bool{}
 	var branches []*StackTreeBranchInfo
 	for _, branch := range branchesToInclude {


### PR DESCRIPTION
It seems I forgot to install pre-commit, and the styles are not applied
properly. Run for all existing files.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
