### PR TITLE
Add a workaround for the rendering stuck issue

### DIFF
--- a/internal/utils/colors/bgcolor.go
+++ b/internal/utils/colors/bgcolor.go
@@ -23,4 +23,15 @@ func SetupBackgroundColorTypeFromEnv() {
 	default:
 		// Otherwise, let lipgloss determine the background color based on the terminal.
 	}
+	// Workaround for lipgloss / MacOS Terminal.app issue.
+	//
+	// Inside HasDarkBackground() function, it'll eventually use termStatusReport(11) to get the
+	// current terminal background color.
+	//
+	// https://github.com/muesli/termenv/blob/98d742f6907a4622ef2e2f190123c86b6ec19b7b/termenv_unix.go#L95
+	//
+	// There are multiple locks in place until this call, but somehow if this is called in the
+	// Bubbletea loop, it'll deadlock / hang the program. So, we call it here before the loop
+	// starts, and once this is called, it'll be cached, so it'll never be called again.
+	lipgloss.HasDarkBackground()
 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
