### PR TITLE
Strip the remote name from the specified parent

### DIFF
--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -103,3 +103,16 @@ func allBranches() ([]string, error) {
 
 	return branches, nil
 }
+
+// stripRemoteRefPrefixes removes the "refs/heads/", "refs/remotes/<remote>/", "<remote>/" prefix
+// from a ref name if it exists.
+func stripRemoteRefPrefixes(repo *git.Repo, possibleRefName string) string {
+	ret := possibleRefName
+	if strings.HasPrefix(ret, "refs/heads/") {
+		ret = strings.TrimPrefix(ret, "refs/heads/")
+	} else {
+		ret = strings.TrimPrefix(ret, "refs/remotes/")
+		ret = strings.TrimPrefix(ret, repo.GetRemoteName()+"/")
+	}
+	return ret
+}

--- a/cmd/av/stack_adopt.go
+++ b/cmd/av/stack_adopt.go
@@ -75,7 +75,7 @@ func stackAdoptForceAdoption(repo *git.Repo, db meta.DB, currentBranch, parent s
 		return errors.New("branch is already adopted")
 	}
 
-	parent = strings.TrimPrefix(parent, "refs/heads/")
+	parent = stripRemoteRefPrefixes(repo, parent)
 	if currentBranch == parent {
 		return errors.New("cannot adopt the current branch as its parent")
 	}

--- a/cmd/av/stack_reparent.go
+++ b/cmd/av/stack_reparent.go
@@ -45,6 +45,7 @@ var stackReparentCmd = &cobra.Command{
 		if stackReparentFlags.Parent == "" {
 			return errors.New("missing parent branch name")
 		}
+		stackReparentFlags.Parent = stripRemoteRefPrefixes(repo, stackReparentFlags.Parent)
 
 		return uiutils.RunBubbleTea(&stackReparentViewModel{repo: repo, db: db})
 	},


### PR DESCRIPTION
Fixes https://github.com/aviator-co/av/issues/406


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
