### PR TITLE
Fix spelling errors

### DIFF
--- a/e2e_tests/stack_restack_test.go
+++ b/e2e_tests/stack_restack_test.go
@@ -127,7 +127,7 @@ func TestStackRestack(t *testing.T) {
 	stack1Head := repo.GetCommitAtRef(t, plumbing.NewBranchReferenceName("stack-1"))
 	require.Equal(t, mergeBases[0], stack1Head, "stack-2 should be up-to-date with stack-1")
 
-	// Further sync attemps should yield no-ops
+	// Further sync attempts should yield no-ops
 	syncNoop := RequireAv(t, "stack", "restack")
 	require.Contains(t, syncNoop.Stdout, "Restack is done")
 

--- a/e2e_tests/stack_sync_test.go
+++ b/e2e_tests/stack_sync_test.go
@@ -133,7 +133,7 @@ func TestStackSync(t *testing.T) {
 	stack1Head := repo.GetCommitAtRef(t, plumbing.NewBranchReferenceName("stack-1"))
 	require.Equal(t, mergeBases[0], stack1Head, "stack-2 should be up-to-date with stack-1")
 
-	// Further sync attemps should yield no-ops
+	// Further sync attempts should yield no-ops
 	syncNoop := RequireAv(t, "stack", "sync")
 	require.Contains(t, syncNoop.Stdout, "Restack is done")
 

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -368,7 +368,7 @@ func CreatePullRequest(
 			}
 
 			// Otherwise, save what the user entered to a file so that it's not
-			// lost forever (and we can re-use it if they try again).
+			// lost forever (and we can reuse it if they try again).
 			savePRDescriptionToTemporaryFile(saveFile, res)
 		}()
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -348,9 +348,9 @@ func (r *Repo) RevParse(rp *RevParse) (string, error) {
 	return r.Git(args...)
 }
 
-func (r *Repo) MergeBase(commitishes ...string) (string, error) {
+func (r *Repo) MergeBase(committishes ...string) (string, error) {
 	args := []string{"merge-base"}
-	args = append(args, commitishes...)
+	args = append(args, committishes...)
 	str, err := r.Git(args...)
 	if err != nil {
 		return "", err
@@ -363,11 +363,11 @@ type BranchAndCommit struct {
 	Branch string
 }
 
-func (r *Repo) BranchesContainCommitish(commitish string) ([]BranchAndCommit, error) {
+func (r *Repo) BranchesContainCommittish(committish string) ([]BranchAndCommit, error) {
 	lines, err := r.Git(
 		"for-each-ref",
 		"--contains",
-		commitish,
+		committish,
 		"--format=%(objectname) %(refname:short)",
 		"refs/heads",
 	)

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -63,7 +63,7 @@ func NewTempRepoWithGitHubServer(t *testing.T, serverURL string) *GitTestRepo {
 
 	settings := map[string]string{
 		"user.name":  "av-test",
-		"user.email": "av-test@nonexistant",
+		"user.email": "av-test@nonexistent",
 	}
 	for k, v := range settings {
 		repo.Git(t, "config", k, v)


### PR DESCRIPTION
Fixed with https://github.com/codespell-project/codespell


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
