### PR TITLE
Use a checkmark instead of an x to indicate that a branch is selected

### DIFF
--- a/cmd/av/stack_adopt.go
+++ b/cmd/av/stack_adopt.go
@@ -419,7 +419,7 @@ func (vm stackAdoptViewModel) renderBranch(branch plumbing.ReferenceName, isTrun
 	if adopted && !vm.chosenTargets[branch] {
 		sb.WriteString(branch.Short())
 	} else if vm.chosenTargets[branch] {
-		sb.WriteString("[x] " + branch.Short())
+		sb.WriteString("[✓] " + branch.Short())
 	} else {
 		sb.WriteString("[ ] " + branch.Short())
 	}


### PR DESCRIPTION
Fixes https://github.com/aviator-co/av/issues/413


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
