### PR TITLE
Do not route the key press events to the selection model when the selection is nil

### DIFF
--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -194,22 +194,24 @@ func (m stackNextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.selection.Init()
 
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "enter":
-			currentBranch, err := m.selection.Value()
-			if err != nil {
-				m.err = err
-				return m, tea.Quit
-			}
-			m.currentBranch = currentBranch
-			m.nInStack--
+		if m.selection != nil {
+			switch msg.String() {
+			case "enter":
+				currentBranch, err := m.selection.Value()
+				if err != nil {
+					m.err = err
+					return m, tea.Quit
+				}
+				m.currentBranch = currentBranch
+				m.nInStack--
 
-			return m, m.nextBranch
-		case "ctrl+c":
-			return m, tea.Quit
-		default:
-			_, cmd := m.selection.Update(msg)
-			return m, cmd
+				return m, m.nextBranch
+			case "ctrl+c":
+				return m, tea.Quit
+			default:
+				_, cmd := m.selection.Update(msg)
+				return m, cmd
+			}
 		}
 	}
 	return m, nil


### PR DESCRIPTION
Fixes https://github.com/aviator-co/av/issues/432


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
