### PR TITLE
Fix the infinite loop in av stack tidy

### DIFF
--- a/cmd/av/stack_next.go
+++ b/cmd/av/stack_next.go
@@ -194,22 +194,24 @@ func (m stackNextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.selection.Init()
 
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "enter":
-			currentBranch, err := m.selection.Value()
-			if err != nil {
-				m.err = err
-				return m, tea.Quit
-			}
-			m.currentBranch = currentBranch
-			m.nInStack--
+		if m.selection != nil {
+			switch msg.String() {
+			case "enter":
+				currentBranch, err := m.selection.Value()
+				if err != nil {
+					m.err = err
+					return m, tea.Quit
+				}
+				m.currentBranch = currentBranch
+				m.nInStack--
 
-			return m, m.nextBranch
-		case "ctrl+c":
-			return m, tea.Quit
-		default:
-			_, cmd := m.selection.Update(msg)
-			return m, cmd
+				return m, m.nextBranch
+			case "ctrl+c":
+				return m, tea.Quit
+			default:
+				_, cmd := m.selection.Update(msg)
+				return m, cmd
+			}
 		}
 	}
 	return m, nil

--- a/internal/actions/tidy.go
+++ b/internal/actions/tidy.go
@@ -45,7 +45,7 @@ func TidyDB(repo *git.Repo, db meta.DB) (map[string]bool, map[string]bool, error
 func isParentDeleted(branches map[string]meta.Branch, deleted map[string]bool, branch string) bool {
 	state := branches[branch].Parent
 	for !state.Trunk {
-		if deleted[state.Name] {
+		if deleted, exist := deleted[state.Name]; deleted || !exist {
 			return true
 		}
 		state = branches[state.Name].Parent


### PR DESCRIPTION
When the parent branch is deleted from the DB, it can go infinite loop.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"stack_next_nil_check","parentHead":"fda85f5e0855c2266a5cecc25fc794a6e05957d3","parentPull":433,"trunk":"master"}
```
-->
