### PR TITLE
Make 0 arg state for stack branch more user friendly

### DIFF
--- a/cmd/av/stack_branch.go
+++ b/cmd/av/stack_branch.go
@@ -39,9 +39,14 @@ If the --rename/-m flag is given, the current branch is renamed to the name
 given as the first argument to the command. Branches should only be renamed
 with this command (not with git branch -m ...) because av needs to update
 internal tracking metadata that defines the order of branches within a stack.`,
-	SilenceUsage: true,
-	Args:         cobra.RangeArgs(1, 2),
+	Args: cobra.RangeArgs(0, 2),
 	RunE: func(cmd *cobra.Command, args []string) (reterr error) {
+		if len(args) == 0 {
+			// The only time we don't want to suppress the usage message is when
+			// a user runs `av branch` with no arguments.
+			return cmd.Usage()
+		}
+
 		repo, err := getRepo()
 		if err != nil {
 			return err


### PR DESCRIPTION
We suppress cobra usage output across the board, but in the 0 arg case for stack branch we should show the user the usage rather than a generic "error: accepts between 1 and 2 arg(s), received 0"


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
