### PR TITLE
Automate completions for homebrew installs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,6 +70,7 @@ brews:
     install: |
       bin.install "av"
       man.install Dir["man/*"]
+      generate_completions_from_executable(bin/"av", "completion", shells: [:bash, :zsh])
 
 aurs:
   - name: "av-cli-bin"


### PR DESCRIPTION
Make it slightly simpler for people who use homebrew to get autocompletions for the cli


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
