### PR TITLE
feat: add --all flag to av commit amend

### DIFF
--- a/cmd/av/commit_amend.go
+++ b/cmd/av/commit_amend.go
@@ -96,5 +96,5 @@ func init() {
 		BoolVar(&commitAmendFlags.NoEdit, "no-edit", false, "amend a commit without changing its commit message")
 	commitAmendCmd.MarkFlagsMutuallyExclusive("message", "no-edit")
 	commitAmendCmd.Flags().
-		BoolVarP(&commitCreateFlags.All, "all", "a", false, "automatically stage modified files (same as git commit --all)")
+		BoolVarP(&commitAmendFlags.All, "all", "a", false, "automatically stage modified files (same as git commit --all)")
 }

--- a/cmd/av/commit_amend.go
+++ b/cmd/av/commit_amend.go
@@ -59,7 +59,7 @@ func runAmend(repo *git.Repo, db meta.DB) error {
 	if commitAmendFlags.NoEdit {
 		commitArgs = append(commitArgs, "--no-edit")
 	}
-	if commitCreateFlags.All {
+	if commitAmendFlags.All {
 		commitArgs = append(commitArgs, "--all")
 	}
 	if commitAmendFlags.Message != "" {
@@ -95,6 +95,6 @@ func init() {
 	commitAmendCmd.Flags().
 		BoolVar(&commitAmendFlags.NoEdit, "no-edit", false, "amend a commit without changing its commit message")
 	commitAmendCmd.MarkFlagsMutuallyExclusive("message", "no-edit")
-	commitCreateCmd.Flags().
+	commitAmendCmd.Flags().
 		BoolVarP(&commitCreateFlags.All, "all", "a", false, "automatically stage modified files (same as git commit --all)")
 }

--- a/cmd/av/commit_amend.go
+++ b/cmd/av/commit_amend.go
@@ -19,6 +19,9 @@ var commitAmendFlags struct {
 
 	// Same as `git commit --amend --no-edit`. Amends a commit without changing its commit message.
 	NoEdit bool
+
+	// Same as `git commit --all`.
+	All bool
 }
 
 var commitAmendCmd = &cobra.Command{
@@ -56,6 +59,9 @@ func runAmend(repo *git.Repo, db meta.DB) error {
 	if commitAmendFlags.NoEdit {
 		commitArgs = append(commitArgs, "--no-edit")
 	}
+	if commitCreateFlags.All {
+		commitArgs = append(commitArgs, "--all")
+	}
 	if commitAmendFlags.Message != "" {
 		commitArgs = append(commitArgs, "--message", commitAmendFlags.Message)
 	}
@@ -89,4 +95,6 @@ func init() {
 	commitAmendCmd.Flags().
 		BoolVar(&commitAmendFlags.NoEdit, "no-edit", false, "amend a commit without changing its commit message")
 	commitAmendCmd.MarkFlagsMutuallyExclusive("message", "no-edit")
+	commitCreateCmd.Flags().
+		BoolVarP(&commitCreateFlags.All, "all", "a", false, "automatically stage modified files (same as git commit --all)")
 }


### PR DESCRIPTION
Adds the --flag to `av commit amend` to match `av commit create`