### PR TITLE
Move from `av stack branch` to `av branch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Join our discord community: [https://discord.gg/TFgtZtN8](https://discord.gg/NFs
 Create a new branch and make some changes:
 
 ```sh
-$ av stack branch feature-1
+$ av branch feature-1
 $ echo "Hello, world!" > hello.txt
 $ git add hello.txt
 $ git commit -m "Add hello.txt"
@@ -54,7 +54,7 @@ Create a new branch and make some changes. Create another PR that depends on the
 previous PR:
 
 ```sh
-$ av stack branch feature-2
+$ av branch feature-2
 $ echo "Another feature" >> hello.txt
 $ git add hello.txt
 $ git commit -m "Update hello.txt"
@@ -224,19 +224,19 @@ Download the binary from the [releases page](https://github.com/aviator-co/av/re
 
 # Example commands
 
-| Command             | Description                                                |
-| ------------------- | ---------------------------------------------------------- |
-| `av stack branch`   | Create a new child branch from the current branch.         |
-| `av stack restack`  | Rebase the branches to their parents.                      |
-| `av pr create`      | Create or update a PR.                                     |
-| `av stack tree`     | Visualize the PRs.                                         |
-| `av sync --all`     | Fetch and rebase all branches.                             |
-| `av stack adopt`    | Adopt a branch that is not created from `av stack branch`. |
-| `av stack reparent` | Change the parent of the current branch.                   |
-| `av stack switch`   | Check out branches interactively.                          |
-| `av stack reorder`  | Reorder the branches.                                      |
-| `av commit amend`   | Amend the last commit and rebase the children.             |
-| `av commit split`   | Split the last commit.                                     |
+| Command             | Description                                          |
+| ------------------- | ---------------------------------------------------- |
+| `av branch`         | Create a new child branch from the current branch.   |
+| `av stack restack`  | Rebase the branches to their parents.                |
+| `av pr create`      | Create or update a PR.                               |
+| `av stack tree`     | Visualize the PRs.                                   |
+| `av sync --all`     | Fetch and rebase all branches.                       |
+| `av stack adopt`    | Adopt a branch that is not created from `av branch`. |
+| `av stack reparent` | Change the parent of the current branch.             |
+| `av stack switch`   | Check out branches interactively.                    |
+| `av stack reorder`  | Reorder the branches.                                |
+| `av commit amend`   | Amend the last commit and rebase the children.       |
+| `av commit split`   | Split the last commit.                               |
 
 # How it works
 

--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -92,6 +92,7 @@ func init() {
 	)
 	rootCmd.AddCommand(
 		branchMetaCmd,
+		branchCmd,
 		commitCmd,
 		fetchCmd,
 		initCmd,

--- a/cmd/av/stack.go
+++ b/cmd/av/stack.go
@@ -13,10 +13,13 @@ var stackCmd = &cobra.Command{
 func init() {
 	deprecatedStackSyncCmd := deprecateCommand(*syncCmd, "av sync", "sync")
 
+	deprecatedBranchCmd := deprecateCommand(*branchCmd, "av branch", "branch")
+	deprecatedBranchCmd.Aliases = []string{"b", "br"}
+
 	stackCmd.AddCommand(
+		deprecatedBranchCmd,
 		deprecatedStackSyncCmd,
 		stackAdoptCmd,
-		stackBranchCmd,
 		stackBranchCommitCmd,
 		stackDiffCmd,
 		stackForEachCmd,

--- a/demos/stack_adopt/stack_adopt_with_stack_root.tape
+++ b/demos/stack_adopt/stack_adopt_with_stack_root.tape
@@ -11,7 +11,7 @@ Hide
 Type '. ../test_utils.sh' Enter
 Type 'new_temp_repo' Enter
 
-Type 'av stack branch stack-1' Enter
+Type 'av branch stack-1' Enter
 Type 'create_commit "my-file" "1a" "Commit 1a"' Enter
 Type 'create_commit "my-file" "1b" "Commit 1b"' Enter
 

--- a/demos/stack_restack/stack_restack.tape
+++ b/demos/stack_restack/stack_restack.tape
@@ -11,13 +11,13 @@ Hide
 Type '. ../test_utils.sh' Enter
 Type 'new_temp_repo' Enter
 
-Type 'av stack branch stack-1' Enter
+Type 'av branch stack-1' Enter
 Type 'create_commit "my-file" "1a" "Commit 1a"' Enter
 
-Type 'av stack branch stack-2' Enter
+Type 'av branch stack-2' Enter
 Type 'create_commit "my-file" "2a" "Commit 2a"' Enter
 
-Type 'av stack branch stack-3' Enter
+Type 'av branch stack-3' Enter
 Type 'create_commit "my-file" "3a" "Commit 3a"' Enter
 
 Type 'git switch stack-1' Enter

--- a/demos/stack_switch/stack_switch.tape
+++ b/demos/stack_switch/stack_switch.tape
@@ -11,18 +11,18 @@ Hide
 Type '. ../test_utils.sh' Enter
 Type 'new_temp_repo' Enter
 
-Type 'av stack branch stack-1' Enter
+Type 'av branch stack-1' Enter
 Type 'create_commit "my-file" "1a" "Commit 1a"' Enter
 
-Type 'av stack branch stack-2' Enter
+Type 'av branch stack-2' Enter
 Type 'create_commit "my-file" "2a" "Commit 2a"' Enter
 
-Type 'av stack branch stack-3' Enter
+Type 'av branch stack-3' Enter
 Type 'create_commit "my-file" "3a" "Commit 3a"' Enter
 
 Type 'git switch stack-1' Enter
 
-Type 'av stack branch stack-4' Enter
+Type 'av branch stack-4' Enter
 Type 'create_commit "my-file" "4a" "Commit 4a"' Enter
 
 Type 'git switch stack-1' Enter

--- a/demos/stack_switch/stack_switch_detached.tape
+++ b/demos/stack_switch/stack_switch_detached.tape
@@ -11,18 +11,18 @@ Hide
 Type '. ../test_utils.sh' Enter
 Type 'new_temp_repo' Enter
 
-Type 'av stack branch stack-1' Enter
+Type 'av branch stack-1' Enter
 Type 'create_commit "my-file" "1a" "Commit 1a"' Enter
 
-Type 'av stack branch stack-2' Enter
+Type 'av branch stack-2' Enter
 Type 'create_commit "my-file" "2a" "Commit 2a"' Enter
 
-Type 'av stack branch stack-3' Enter
+Type 'av branch stack-3' Enter
 Type 'create_commit "my-file" "3a" "Commit 3a"' Enter
 
 Type 'git switch stack-1' Enter
 
-Type 'av stack branch stack-4' Enter
+Type 'av branch stack-4' Enter
 Type 'create_commit "my-file" "4a" "Commit 4a"' Enter
 
 Type 'git switch --detach stack-1' Enter

--- a/demos/stack_switch/stack_switch_non_managed_branch.tape
+++ b/demos/stack_switch/stack_switch_non_managed_branch.tape
@@ -11,18 +11,18 @@ Hide
 Type '. ../test_utils.sh' Enter
 Type 'new_temp_repo' Enter
 
-Type 'av stack branch stack-1' Enter
+Type 'av branch stack-1' Enter
 Type 'create_commit "my-file" "1a" "Commit 1a"' Enter
 
-Type 'av stack branch stack-2' Enter
+Type 'av branch stack-2' Enter
 Type 'create_commit "my-file" "2a" "Commit 2a"' Enter
 
-Type 'av stack branch stack-3' Enter
+Type 'av branch stack-3' Enter
 Type 'create_commit "my-file" "3a" "Commit 3a"' Enter
 
 Type 'git switch stack-1' Enter
 
-Type 'av stack branch stack-4' Enter
+Type 'av branch stack-4' Enter
 Type 'create_commit "my-file" "4a" "Commit 4a"' Enter
 
 Type 'git switch stack-1' Enter

--- a/demos/stack_switch/stack_switch_trunk.tape
+++ b/demos/stack_switch/stack_switch_trunk.tape
@@ -11,18 +11,18 @@ Hide
 Type '. ../test_utils.sh' Enter
 Type 'new_temp_repo' Enter
 
-Type 'av stack branch stack-1' Enter
+Type 'av branch stack-1' Enter
 Type 'create_commit "my-file" "1a" "Commit 1a"' Enter
 
-Type 'av stack branch stack-2' Enter
+Type 'av branch stack-2' Enter
 Type 'create_commit "my-file" "2a" "Commit 2a"' Enter
 
-Type 'av stack branch stack-3' Enter
+Type 'av branch stack-3' Enter
 Type 'create_commit "my-file" "3a" "Commit 3a"' Enter
 
 Type 'git switch stack-1' Enter
 
-Type 'av stack branch stack-4' Enter
+Type 'av branch stack-4' Enter
 Type 'create_commit "my-file" "4a" "Commit 4a"' Enter
 
 Type 'git switch main' Enter

--- a/demos/stack_tidy/stack_tidy_deleted.tape
+++ b/demos/stack_tidy/stack_tidy_deleted.tape
@@ -11,8 +11,8 @@ Hide
 Type '. ../test_utils.sh' Enter
 Type 'new_temp_repo' Enter
 
-Type 'av stack branch stack-1' Enter
-Type 'av stack branch stack-2' Enter
+Type 'av branch stack-1' Enter
+Type 'av branch stack-2' Enter
 Type 'git switch main' Enter
 Type 'git branch -D stack-2' Enter
 Type 'git branch -D stack-1' Enter

--- a/demos/stack_tidy/stack_tidy_orphaned.tape
+++ b/demos/stack_tidy/stack_tidy_orphaned.tape
@@ -11,8 +11,8 @@ Hide
 Type '. ../test_utils.sh' Enter
 Type 'new_temp_repo' Enter
 
-Type 'av stack branch stack-1' Enter
-Type 'av stack branch stack-2' Enter
+Type 'av branch stack-1' Enter
+Type 'av branch stack-2' Enter
 Type 'git switch main' Enter
 Type 'git branch -D stack-1' Enter
 Type 'clear' Enter

--- a/docs/av-branch.1.md
+++ b/docs/av-branch.1.md
@@ -1,12 +1,12 @@
-# av-stack-branch
+# av-branch
 
 ## NAME
 
-av-stack-branch - Create or rename a branch in the stack
+av-branch - Create or rename a branch in the stack
 
 ## SYNOPSIS
 
-`av stack branch [-m | --rename] [--force] [--parent <parent_branch>] <branch-name> [<parent_branch>]`
+`av branch [-m | --rename] [--force] [--parent <parent_branch>] <branch-name> [<parent_branch>]`
 
 ## DESCRIPTION
 
@@ -17,7 +17,7 @@ instead of creating a new branch. Branches should only be renamed with this
 command (not with `git branch -m ...`) because av needs to update internal
 tracking metadata that defines the order of branches within a stack. If you
 renamed a branch with `git branch -m`, you can retroactively update the internal
-metadata with `av stack branch --rename <old-branch-name>:<new-branch-name>`.
+metadata with `av branch --rename <old-branch-name>:<new-branch-name>`.
 
 ## OPTIONS
 

--- a/docs/av-git-interaction.7.md
+++ b/docs/av-git-interaction.7.md
@@ -8,14 +8,14 @@ av-git-interaction - av CLI Git Interaction
 
 Typically in Git, a branch is created with `git branch`, `git switch`, or `git
 checkout`. Since `av` needs to keep track of the extra information about
-branches such as the parent branch, we have `av-stack-branch`(1) to create a new
+branches such as the parent branch, we have `av-branch`(1) to create a new
 branch and track the necessary information. This metadata is stored in
 `.git/av/av.db`. We call the branches that `av` has metadata for as "managed
 branches", and the branches that av doesn't have metadata for as "unmanaged
 branches".
 
 There is a case where you created a branch without going through
-`av-stack-branch`(1). In this case, you can attach the branch metadata by using
+`av-branch`(1). In this case, you can attach the branch metadata by using
 `av-stack-adopt`(1). The opposite can be done with `av-stack-orphan`(1).
 
 ## BRANCH DELETION

--- a/docs/av.1.md
+++ b/docs/av.1.md
@@ -11,6 +11,7 @@ av - Aviator CLI
 ## SUBCOMMANDS
 
 - av-auth(1): Show info about the logged in user
+- av-branch(1): Create or rename a branch in the stack
 - av-commit-amend(1): Amend a commit
 - av-commit-create(1): Record changes to the repository with commits
 - av-commit-split(1): Split a commit into multiple commits
@@ -21,7 +22,6 @@ av - Aviator CLI
 - av-pr-status(1): Get the status of the associated pull request
 - av-stack-adopt(1): Adopt branches that are not managed by `av`
 - av-stack-branch-commit(1): Create a new branch in the stack with the staged changes
-- av-stack-branch(1): Create or rename a branch in the stack
 - av-stack-diff(1): Show the diff between working tree and parent branch
 - av-stack-next(1): Checkout the next branch in the stack
 - av-stack-orphan(1): Orphan branches that are managed by `av`

--- a/e2e_tests/commit_amend_test.go
+++ b/e2e_tests/commit_amend_test.go
@@ -18,13 +18,13 @@ func TestCommitAmendInStack(t *testing.T) {
 	// Create a branch and commit a file.
 	filepath := repo.CreateFile(t, "one.txt", "one")
 	repo.AddFile(t, filepath)
-	RequireAv(t, "stack", "branch", "one")
+	RequireAv(t, "branch", "one")
 	RequireAv(t, "commit", "create", "-m", "one")
 
 	// Create another branch and commit a file.
 	filepath = repo.CreateFile(t, "two.txt", "two")
 	repo.AddFile(t, filepath)
-	RequireAv(t, "stack", "branch", "two")
+	RequireAv(t, "branch", "two")
 	RequireAv(t, "commit", "create", "-m", "two")
 
 	// Go back to the first branch and amend the commit with another file.
@@ -53,7 +53,7 @@ func TestCommitAmendOnMergedBranch(t *testing.T) {
 	repo.Git(t, "fetch")
 
 	// Create a branch with a commit
-	RequireAv(t, "stack", "branch", "one")
+	RequireAv(t, "branch", "one")
 	filepath := repo.CreateFile(t, "one.txt", "one")
 	repo.AddFile(t, filepath)
 	RequireAv(t, "commit", "create", "-m", "one")

--- a/e2e_tests/commit_create_test.go
+++ b/e2e_tests/commit_create_test.go
@@ -18,13 +18,13 @@ func TestCommitCreateInStack(t *testing.T) {
 	// Create a branch and commit a file.
 	filepath := repo.CreateFile(t, "one.txt", "one")
 	repo.AddFile(t, filepath)
-	RequireAv(t, "stack", "branch", "one")
+	RequireAv(t, "branch", "one")
 	RequireAv(t, "commit", "create", "-m", "one")
 
 	// Create another branch and commit a file.
 	filepath = repo.CreateFile(t, "two.txt", "two")
 	repo.AddFile(t, filepath)
-	RequireAv(t, "stack", "branch", "two")
+	RequireAv(t, "branch", "two")
 	RequireAv(t, "commit", "create", "-m", "two")
 
 	// Go back to the first branch and commit another file.
@@ -53,7 +53,7 @@ func TestCommitCreateOnMergedBranch(t *testing.T) {
 	repo.Git(t, "fetch")
 
 	// Create a branch
-	RequireAv(t, "stack", "branch", "one")
+	RequireAv(t, "branch", "one")
 
 	// Update the branch meta with the PR data
 	db := repo.OpenDB(t)

--- a/e2e_tests/stack_adopt_test.go
+++ b/e2e_tests/stack_adopt_test.go
@@ -40,7 +40,7 @@ func TestStackAdopt_Success_WithStackRoot(t *testing.T) {
 
 	// main: root_commit
 	// stack-1: root_commit -> 1a -> 1b
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1b\n", gittest.WithMessage("Commit 1b"))
 

--- a/e2e_tests/stack_branch_test.go
+++ b/e2e_tests/stack_branch_test.go
@@ -13,16 +13,16 @@ func TestStackBranchMove(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create one -> two -> three stack
-	RequireAv(t, "stack", "branch", "one")
+	RequireAv(t, "branch", "one")
 	repo.CommitFile(t, "one.txt", "one")
-	RequireAv(t, "stack", "branch", "two")
+	RequireAv(t, "branch", "two")
 	repo.CommitFile(t, "two.txt", "two")
-	RequireAv(t, "stack", "branch", "three")
+	RequireAv(t, "branch", "three")
 	repo.CommitFile(t, "three.txt", "three")
 
 	// one -> un
 	repo.Git(t, "checkout", "one")
-	RequireAv(t, "stack", "branch", "-m", "un")
+	RequireAv(t, "branch", "-m", "un")
 	RequireCurrentBranchName(t, repo, "refs/heads/un")
 
 	// two -> deux
@@ -30,13 +30,13 @@ func TestStackBranchMove(t *testing.T) {
 	// correct
 	RequireAv(t, "stack", "next")
 	RequireCurrentBranchName(t, repo, "refs/heads/two")
-	RequireAv(t, "stack", "branch", "-m", "deux")
+	RequireAv(t, "branch", "-m", "deux")
 	RequireCurrentBranchName(t, repo, "refs/heads/deux")
 
 	// three -> trois
 	RequireAv(t, "stack", "next")
 	RequireCurrentBranchName(t, repo, "refs/heads/three")
-	RequireAv(t, "stack", "branch", "-m", "trois")
+	RequireAv(t, "branch", "-m", "trois")
 	RequireCurrentBranchName(t, repo, "refs/heads/trois")
 
 	// Make sure we've handled all the parent/child renames correctly
@@ -65,11 +65,11 @@ func TestStackBranchRetroactiveMove(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create one -> two -> three stack
-	RequireAv(t, "stack", "branch", "one")
+	RequireAv(t, "branch", "one")
 	repo.CommitFile(t, "one.txt", "one")
-	RequireAv(t, "stack", "branch", "two")
+	RequireAv(t, "branch", "two")
 	repo.CommitFile(t, "two.txt", "two")
-	RequireAv(t, "stack", "branch", "three")
+	RequireAv(t, "branch", "three")
 	repo.CommitFile(t, "three.txt", "three")
 
 	// one -> un without av
@@ -78,7 +78,7 @@ func TestStackBranchRetroactiveMove(t *testing.T) {
 	RequireCurrentBranchName(t, repo, "refs/heads/un")
 
 	// Retroactive rename with av
-	RequireAv(t, "stack", "branch", "--rename", "one:un")
+	RequireAv(t, "branch", "--rename", "one:un")
 
 	// Make sure we've handled all the parent/child renames correctly
 	db := repo.OpenDB(t)

--- a/e2e_tests/stack_foreach_test.go
+++ b/e2e_tests/stack_foreach_test.go
@@ -13,11 +13,11 @@ func TestStackForEach(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a stack of three branches
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "2a\n", gittest.WithMessage("Commit 2a"))
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(t, "my-file", "3a\n", gittest.WithMessage("Commit 3a"))
 
 	out := RequireAv(t,

--- a/e2e_tests/stack_orphan_test.go
+++ b/e2e_tests/stack_orphan_test.go
@@ -19,10 +19,10 @@ func TestStackOrphan(t *testing.T) {
 	// Then stack-2 (and child branch stack-3) will be orphaned
 
 	// Setup initial state
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n1b\n2a\n", gittest.WithMessage("Commit 2a"))
 	repo.CommitFile(
 		t,
@@ -30,7 +30,7 @@ func TestStackOrphan(t *testing.T) {
 		"1a\n1b\n2a\n2b\n",
 		gittest.WithMessage("Commit 2b"),
 	)
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(
 		t,
 		"my-file",

--- a/e2e_tests/stack_reparent_test.go
+++ b/e2e_tests/stack_reparent_test.go
@@ -15,16 +15,16 @@ func TestStackReparent(t *testing.T) {
 	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
-	RequireAv(t, "stack", "branch", "foo")
+	RequireAv(t, "branch", "foo")
 	repo.CommitFile(t, "foo.txt", "foo")
 	requireFileContent(t, "foo.txt", "foo")
 
-	RequireAv(t, "stack", "branch", "bar")
+	RequireAv(t, "branch", "bar")
 	repo.CommitFile(t, "bar.txt", "bar")
 	requireFileContent(t, "bar.txt", "bar")
 	requireFileContent(t, "foo.txt", "foo")
 
-	RequireAv(t, "stack", "branch", "spam")
+	RequireAv(t, "branch", "spam")
 	repo.CommitFile(t, "spam.txt", "spam")
 	requireFileContent(t, "spam.txt", "spam")
 
@@ -63,10 +63,10 @@ func TestStackReparentTrunk(t *testing.T) {
 	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
-	RequireAv(t, "stack", "branch", "foo")
+	RequireAv(t, "branch", "foo")
 	repo.CommitFile(t, "foo.txt", "foo")
 
-	RequireAv(t, "stack", "branch", "bar")
+	RequireAv(t, "branch", "bar")
 	repo.CommitFile(t, "bar.txt", "bar")
 
 	// Delete the local main. av should use the remote tracking branch.

--- a/e2e_tests/stack_restack_test.go
+++ b/e2e_tests/stack_restack_test.go
@@ -24,11 +24,11 @@ func TestStackRestack(t *testing.T) {
 	//     stack-4:           \ -> 4a
 	// Note: we create the first branch with a "vanilla" git checkout just to
 	// make sure that's working as intended.
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(
 		t,
 		"different-file",
@@ -36,7 +36,7 @@ func TestStackRestack(t *testing.T) {
 		gittest.WithMessage("Commit 3a"),
 	)
 	repo.Git(t, "checkout", "stack-1")
-	RequireAv(t, "stack", "branch", "stack-4")
+	RequireAv(t, "branch", "stack-4")
 	repo.CommitFile(t, "another-file", "1a\n4a\n", gittest.WithMessage("Commit 4a"))
 	repo.Git(t, "checkout", "stack-3")
 
@@ -167,9 +167,9 @@ func TestStackRestackAbort(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a two stack...
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
 
 	// Save the original parent HEAD for stack-2, which is the stack-1's commit.
@@ -224,11 +224,11 @@ func TestStackRestackWithLotsOfConflicts(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(t, "my-file", "1a\n2a\n3a\n", gittest.WithMessage("Commit 3a"))
 
 	// Go back to the first branch (to make sure that the sync constructs the
@@ -290,10 +290,10 @@ func TestStackRestackAfterAmendingCommit(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n1b\n2a\n", gittest.WithMessage("Commit 2a"))
 	repo.CommitFile(
 		t,
@@ -301,7 +301,7 @@ func TestStackRestackAfterAmendingCommit(t *testing.T) {
 		"1a\n1b\n2a\n2b\n",
 		gittest.WithMessage("Commit 2b"),
 	)
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(
 		t,
 		"my-file",
@@ -336,15 +336,15 @@ func TestStackRestackAll(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	repo.Git(t, "switch", "main")
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1\n", gittest.WithMessage("Commit 1"))
 
 	repo.Git(t, "switch", "stack-1")
-	RequireAv(t, "stack", "branch", "stack-1a")
+	RequireAv(t, "branch", "stack-1a")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 
 	repo.Git(t, "switch", "stack-1")
-	RequireAv(t, "stack", "branch", "stack-1b")
+	RequireAv(t, "branch", "stack-1b")
 	repo.CommitFile(t, "my-file", "1b\n", gittest.WithMessage("Commit 1b"))
 
 	repo.Git(t, "switch", "stack-1")

--- a/e2e_tests/stack_sync_all_test.go
+++ b/e2e_tests/stack_sync_all_test.go
@@ -13,11 +13,11 @@ func TestStackSyncAll(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	repo.Git(t, "switch", "main")
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 
 	repo.Git(t, "switch", "main")
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "2a\n", gittest.WithMessage("Commit 2a"))
 
 	repo.Git(t, "switch", "main")

--- a/e2e_tests/stack_sync_amend_test.go
+++ b/e2e_tests/stack_sync_amend_test.go
@@ -15,10 +15,10 @@ func TestSyncAfterAmendingCommit(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n1b\n2a\n", gittest.WithMessage("Commit 2a"))
 	repo.CommitFile(
 		t,
@@ -26,7 +26,7 @@ func TestSyncAfterAmendingCommit(t *testing.T) {
 		"1a\n1b\n2a\n2b\n",
 		gittest.WithMessage("Commit 2b"),
 	)
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(
 		t,
 		"my-file",

--- a/e2e_tests/stack_sync_delete_merged_test.go
+++ b/e2e_tests/stack_sync_delete_merged_test.go
@@ -20,10 +20,10 @@ func TestStackSyncDeleteMerged(t *testing.T) {
 	//     main:    X
 	//     stack-1:  \ -> 1a -> 1b
 	//     stack-2:              \ -> 2a -> 2b
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n1b\n2a\n", gittest.WithMessage("Commit 2a"))
 	repo.CommitFile(
 		t,
@@ -94,7 +94,7 @@ func TestStackSyncDeleteMerged_NoMain(t *testing.T) {
 	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
 	Chdir(t, repo.RepoDir)
 
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.Git(t, "push", "origin", "stack-1:refs/pull/42/head")
 

--- a/e2e_tests/stack_sync_merge_commit_test.go
+++ b/e2e_tests/stack_sync_merge_commit_test.go
@@ -21,10 +21,10 @@ func TestStackSyncMergeCommit(t *testing.T) {
 	//     stack-1: main -> 1a -> 2b
 	//     stack-2:                \ -> 2a -> 2b
 	//     stack-3:			                   \ -> 3a -> 3b
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n1b\n2a\n", gittest.WithMessage("Commit 2a"))
 	repo.CommitFile(
 		t,
@@ -32,7 +32,7 @@ func TestStackSyncMergeCommit(t *testing.T) {
 		"1a\n1b\n2a\n2b\n",
 		gittest.WithMessage("Commit 2b"),
 	)
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(
 		t,
 		"my-file",

--- a/e2e_tests/stack_sync_merged_parent_test.go
+++ b/e2e_tests/stack_sync_merged_parent_test.go
@@ -21,10 +21,10 @@ func TestStackSyncMergedParent(t *testing.T) {
 	//     stack-1: main -> 1a -> 2b
 	//     stack-2:                \ -> 2a -> 2b
 	//     stack-3:                             \ -> 3a -> 3b
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n1b\n2a\n", gittest.WithMessage("Commit 2a"))
 	repo.CommitFile(
 		t,
@@ -32,7 +32,7 @@ func TestStackSyncMergedParent(t *testing.T) {
 		"1a\n1b\n2a\n2b\n",
 		gittest.WithMessage("Commit 2b"),
 	)
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(
 		t,
 		"my-file",

--- a/e2e_tests/stack_sync_test.go
+++ b/e2e_tests/stack_sync_test.go
@@ -30,11 +30,11 @@ func TestStackSync(t *testing.T) {
 	//     stack-4:           \ -> 4a
 	// Note: we create the first branch with a "vanilla" git checkout just to
 	// make sure that's working as intended.
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(
 		t,
 		"different-file",
@@ -42,7 +42,7 @@ func TestStackSync(t *testing.T) {
 		gittest.WithMessage("Commit 3a"),
 	)
 	repo.Git(t, "checkout", "stack-1")
-	RequireAv(t, "stack", "branch", "stack-4")
+	RequireAv(t, "branch", "stack-4")
 	repo.CommitFile(t, "another-file", "1a\n4a\n", gittest.WithMessage("Commit 4a"))
 	repo.Git(t, "checkout", "stack-3")
 
@@ -175,9 +175,9 @@ func TestStackSyncAbort(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a two stack...
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
 
 	// Save the original parent HEAD for stack-2, which is the stack-1's commit.
@@ -234,11 +234,11 @@ func TestStackSyncWithLotsOfConflicts(t *testing.T) {
 	Chdir(t, repo.RepoDir)
 
 	// Create a three stack...
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n2a\n", gittest.WithMessage("Commit 2a"))
-	RequireAv(t, "stack", "branch", "stack-3")
+	RequireAv(t, "branch", "stack-3")
 	repo.CommitFile(t, "my-file", "1a\n2a\n3a\n", gittest.WithMessage("Commit 3a"))
 
 	// Go back to the first branch (to make sure that the sync constructs the

--- a/e2e_tests/stack_sync_trunk_test.go
+++ b/e2e_tests/stack_sync_trunk_test.go
@@ -19,10 +19,10 @@ func TestStackSyncTrunk(t *testing.T) {
 	//     main:    X
 	//     stack-1:  \ -> 1a -> 1b
 	//     stack-2:              \ -> 2a -> 2b
-	RequireAv(t, "stack", "branch", "stack-1")
+	RequireAv(t, "branch", "stack-1")
 	repo.CommitFile(t, "my-file", "1a\n", gittest.WithMessage("Commit 1a"))
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
-	RequireAv(t, "stack", "branch", "stack-2")
+	RequireAv(t, "branch", "stack-2")
 	repo.CommitFile(t, "my-file", "1a\n1b\n2a\n", gittest.WithMessage("Commit 2a"))
 	repo.CommitFile(
 		t,

--- a/e2e_tests/stack_tree_test.go
+++ b/e2e_tests/stack_tree_test.go
@@ -10,14 +10,14 @@ func TestStackTree(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
 	Chdir(t, repo.RepoDir)
 
-	RequireAv(t, "stack", "branch", "foo")
+	RequireAv(t, "branch", "foo")
 	repo.CommitFile(t, "foo", "foo")
 
-	RequireAv(t, "stack", "branch", "bar")
+	RequireAv(t, "branch", "bar")
 	repo.CommitFile(t, "bar", "bar")
 
 	repo.CheckoutBranch(t, "refs/heads/main")
-	RequireAv(t, "stack", "branch", "spam")
+	RequireAv(t, "branch", "spam")
 	repo.CommitFile(t, "spam", "spam")
 
 	RequireAv(t, "stack", "tree")


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"rename-commands","parentHead":"e42da5f2529031945331feed66a2b5cfed5813e5","parentPull":462,"trunk":"master"}
```
-->
