### PR TITLE
Move `av stack prev/next` to `av prev/next`

### DIFF
--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -91,16 +91,18 @@ func init() {
 		"directory to use for git repository",
 	)
 	rootCmd.AddCommand(
-		branchMetaCmd,
+		authCmd,
 		branchCmd,
+		branchMetaCmd,
 		commitCmd,
 		fetchCmd,
 		initCmd,
+		nextCmd,
 		prCmd,
+		prevCmd,
 		stackCmd,
-		versionCmd,
-		authCmd,
 		syncCmd,
+		versionCmd,
 	)
 }
 

--- a/cmd/av/next.go
+++ b/cmd/av/next.go
@@ -17,15 +17,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stackNextFlags struct {
+var nextFlags struct {
 	// should we go to the last
 	Last bool
 }
 
-var stackNextCmd = &cobra.Command{
-	Use:     "next [<n>|--last]",
-	Aliases: []string{"n"},
-	Short:   "Checkout the next branch in the stack",
+var nextCmd = &cobra.Command{
+	Use:   "next [<n>|--last]",
+	Short: "Checkout the next branch in the stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var n int = 1
 		if len(args) == 1 {
@@ -42,7 +41,7 @@ var stackNextCmd = &cobra.Command{
 			return errors.New("invalid number (must be >= 1)")
 		}
 
-		stackNext, err := newStackNextModel(stackNextFlags.Last, n)
+		stackNext, err := newNextModel(nextFlags.Last, n)
 		if err != nil {
 			return err
 		}
@@ -51,8 +50,8 @@ var stackNextCmd = &cobra.Command{
 }
 
 func init() {
-	stackNextCmd.Flags().BoolVar(
-		&stackNextFlags.Last, "last", false,
+	nextCmd.Flags().BoolVar(
+		&nextFlags.Last, "last", false,
 		"checkout the last branch in the stack",
 	)
 }
@@ -69,7 +68,7 @@ type stackNextModel struct {
 	err         error
 }
 
-func newStackNextModel(lastInStack bool, nInStack int) (stackNextModel, error) {
+func newNextModel(lastInStack bool, nInStack int) (stackNextModel, error) {
 	repo, err := getRepo()
 	if err != nil {
 		return stackNextModel{}, err

--- a/cmd/av/prev.go
+++ b/cmd/av/prev.go
@@ -12,15 +12,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stackPrevFlags struct {
+var prevFlags struct {
 	// should we go to the first
 	First bool
 }
 
-var stackPrevCmd = &cobra.Command{
-	Use:     "prev [<n>|--first]",
-	Aliases: []string{"p"},
-	Short:   "Checkout the previous branch in the stack",
+var prevCmd = &cobra.Command{
+	Use:   "prev [<n>|--first]",
+	Short: "Checkout the previous branch in the stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get the previous branches so we can checkout the nth one
 		repo, err := getRepo()
@@ -42,7 +41,7 @@ var stackPrevCmd = &cobra.Command{
 		}
 
 		var branchToCheckout string
-		if stackPrevFlags.First {
+		if prevFlags.First {
 			if len(previousBranches) == 0 {
 				_, _ = fmt.Fprint(os.Stderr, "already on first branch in stack\n")
 				return nil
@@ -92,8 +91,8 @@ var stackPrevCmd = &cobra.Command{
 }
 
 func init() {
-	stackPrevCmd.Flags().BoolVar(
-		&stackPrevFlags.First, "first", false,
+	prevCmd.Flags().BoolVar(
+		&prevFlags.First, "first", false,
 		"checkout the first branch in the stack",
 	)
 }

--- a/cmd/av/stack.go
+++ b/cmd/av/stack.go
@@ -11,21 +11,27 @@ var stackCmd = &cobra.Command{
 }
 
 func init() {
-	deprecatedStackSyncCmd := deprecateCommand(*syncCmd, "av sync", "sync")
-
 	deprecatedBranchCmd := deprecateCommand(*branchCmd, "av branch", "branch")
 	deprecatedBranchCmd.Aliases = []string{"b", "br"}
 
+	deprecatedNextCmd := deprecateCommand(*nextCmd, "av next", "next")
+	deprecatedNextCmd.Aliases = []string{"n"}
+
+	deprecatedPrevCmd := deprecateCommand(*prevCmd, "av prev", "prev")
+	deprecatedPrevCmd.Aliases = []string{"p"}
+
+	deprecatedStackSyncCmd := deprecateCommand(*syncCmd, "av sync", "sync")
+
 	stackCmd.AddCommand(
 		deprecatedBranchCmd,
+		deprecatedNextCmd,
+		deprecatedPrevCmd,
 		deprecatedStackSyncCmd,
 		stackAdoptCmd,
 		stackBranchCommitCmd,
 		stackDiffCmd,
 		stackForEachCmd,
-		stackNextCmd,
 		stackOrphanCmd,
-		stackPrevCmd,
 		stackReorderCmd,
 		stackReparentCmd,
 		stackRestackCmd,

--- a/docs/av-next.1.md
+++ b/docs/av-next.1.md
@@ -1,13 +1,13 @@
-# av-stack-next
+# av-next
 
 ## NAME
 
-av-stack-next - Checkout the next branch in the stack
+av-next - Checkout the next branch in the stack
 
 ## SYNOPSIS
 
 ```synopsis
-av stack next [<n> | --last]
+av next [<n> | --last]
 ```
 
 ## DESCRIPTION
@@ -26,4 +26,4 @@ checking out the next branch in the stack.
 
 ## SEE ALSO
 
-`av-pr-prev`(1)
+`av-prev`(1)

--- a/docs/av-prev.1.md
+++ b/docs/av-prev.1.md
@@ -1,13 +1,13 @@
-# av-stack-prev
+# av-prev
 
 ## NAME
 
-av-stack-prev - Checkout the previous branch in the stack
+av-prev - Checkout the previous branch in the stack
 
 ## SYNOPSIS
 
 ```synopsis
-av stack prev [<n> | --first]
+av prev [<n> | --first]
 ```
 
 ## DESCRIPTION
@@ -26,4 +26,4 @@ to checking out the previous branch in the stack.
 
 ## SEE ALSO
 
-`av-pr-next`(1)
+`av-next`(1)

--- a/docs/av.1.md
+++ b/docs/av.1.md
@@ -17,15 +17,15 @@ av - Aviator CLI
 - av-commit-split(1): Split a commit into multiple commits
 - av-fetch(1): Fetch latest repository state from GitHub
 - av-init(1): Initialize the repository for `av`
+- av-next(1): Checkout the next branch in the stack
 - av-pr-create(1): Create a pull request for the current branch
 - av-pr-queue(1): Queue an existing pull request for the current branch
 - av-pr-status(1): Get the status of the associated pull request
+- av-prev(1): Checkout the previous branch in the stack
 - av-stack-adopt(1): Adopt branches that are not managed by `av`
 - av-stack-branch-commit(1): Create a new branch in the stack with the staged changes
 - av-stack-diff(1): Show the diff between working tree and parent branch
-- av-stack-next(1): Checkout the next branch in the stack
 - av-stack-orphan(1): Orphan branches that are managed by `av`
-- av-stack-prev(1): Checkout the previous branch in the stack
 - av-stack-reorder(1): Interactively reorder the stack
 - av-stack-reparent(1): Change the parent of the current branch
 - av-stack-restack(1): Rebase the stacked branches

--- a/e2e_tests/stack_branch_test.go
+++ b/e2e_tests/stack_branch_test.go
@@ -26,15 +26,15 @@ func TestStackBranchMove(t *testing.T) {
 	RequireCurrentBranchName(t, repo, "refs/heads/un")
 
 	// two -> deux
-	// use "av stack next" here to make sure the parent child relationship is
+	// use "av next" here to make sure the parent child relationship is
 	// correct
-	RequireAv(t, "stack", "next")
+	RequireAv(t, "next")
 	RequireCurrentBranchName(t, repo, "refs/heads/two")
 	RequireAv(t, "branch", "-m", "deux")
 	RequireCurrentBranchName(t, repo, "refs/heads/deux")
 
 	// three -> trois
-	RequireAv(t, "stack", "next")
+	RequireAv(t, "next")
 	RequireCurrentBranchName(t, repo, "refs/heads/three")
 	RequireAv(t, "branch", "-m", "trois")
 	RequireCurrentBranchName(t, repo, "refs/heads/trois")

--- a/e2e_tests/stack_orphan_test.go
+++ b/e2e_tests/stack_orphan_test.go
@@ -44,7 +44,7 @@ func TestStackOrphan(t *testing.T) {
 		gittest.WithMessage("Commit 3b"),
 	)
 
-	RequireAv(t, "stack", "prev")
+	RequireAv(t, "prev")
 	tree := RequireAv(t, "stack", "tree")
 	require.Contains(t, tree.Stdout, "stack-2")
 	require.Contains(t, tree.Stdout, "stack-3")


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"stack-branch","parentHead":"a60c2501a7d0724622e094c9ce2e214a17e10e80","parentPull":465,"trunk":"master"}
```
-->
