### PR TITLE
Finish migrating the rest of the `av stack` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ av pr create
 Visualize the PR stack:
 
 ```sh
-$ av stack tree
+$ av tree
   * feature-2 (HEAD)
   │ https://github.com/octocat/Hello-World/pull/2
   │
@@ -224,19 +224,19 @@ Download the binary from the [releases page](https://github.com/aviator-co/av/re
 
 # Example commands
 
-| Command             | Description                                          |
-| ------------------- | ---------------------------------------------------- |
-| `av branch`         | Create a new child branch from the current branch.   |
-| `av stack restack`  | Rebase the branches to their parents.                |
-| `av pr create`      | Create or update a PR.                               |
-| `av stack tree`     | Visualize the PRs.                                   |
-| `av sync --all`     | Fetch and rebase all branches.                       |
-| `av stack adopt`    | Adopt a branch that is not created from `av branch`. |
-| `av stack reparent` | Change the parent of the current branch.             |
-| `av stack switch`   | Check out branches interactively.                    |
-| `av stack reorder`  | Reorder the branches.                                |
-| `av commit amend`   | Amend the last commit and rebase the children.       |
-| `av commit split`   | Split the last commit.                               |
+| Command            | Description                                          |
+| ------------------ | ---------------------------------------------------- |
+| `av branch`        | Create a new child branch from the current branch.   |
+| `av commit amend`  | Amend the last commit and rebase the children.       |
+| `av commit split`  | Split the last commit.                               |
+| `av pr create`     | Create or update a PR.                               |
+| `av reorder`       | Reorder the branches.                                |
+| `av reparent`      | Change the parent of the current branch.             |
+| `av stack adopt`   | Adopt a branch that is not created from `av branch`. |
+| `av stack restack` | Rebase the branches to their parents.                |
+| `av switch`        | Check out branches interactively.                    |
+| `av sync --all`    | Fetch and rebase all branches.                       |
+| `av tree`          | Visualize the PRs.                                   |
 
 # How it works
 

--- a/cmd/av/diff.go
+++ b/cmd/av/diff.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stackDiffCmd = &cobra.Command{
+var diffCmd = &cobra.Command{
 	Use:   "diff",
 	Short: "Show the diff between working tree and parent branch",
 	Long: strings.TrimSpace(`
@@ -113,7 +113,7 @@ Generates the diff between the working tree and the parent branch
 		// We need to display this **after** the diff to ensure that the diff
 		// output pager doesn't eat this message.
 		if notUpToDate {
-			_, _ = fmt.Fprint(os.Stderr,
+			fmt.Fprint(os.Stderr,
 				colors.Warning("\nWARNING: Branch "), colors.UserInput(currentBranchName),
 				colors.Warning(" is not up to date with parent branch "),
 				colors.UserInput(branch.Parent.Name), colors.Warning(". Run "),

--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -95,14 +95,20 @@ func init() {
 		branchCmd,
 		branchMetaCmd,
 		commitCmd,
+		diffCmd,
 		fetchCmd,
 		initCmd,
 		nextCmd,
 		prCmd,
 		prevCmd,
+		reorderCmd,
+		reparentCmd,
 		stackCmd,
 		syncCmd,
+		treeCmd,
 		versionCmd,
+		switchCmd,
+		tidyCmd,
 	)
 }
 

--- a/cmd/av/stack.go
+++ b/cmd/av/stack.go
@@ -13,31 +13,35 @@ var stackCmd = &cobra.Command{
 func init() {
 	deprecatedBranchCmd := deprecateCommand(*branchCmd, "av branch", "branch")
 	deprecatedBranchCmd.Aliases = []string{"b", "br"}
-
+	deprecatedDiffCmd := deprecateCommand(*diffCmd, "av diff", "diff")
 	deprecatedNextCmd := deprecateCommand(*nextCmd, "av next", "next")
 	deprecatedNextCmd.Aliases = []string{"n"}
-
 	deprecatedPrevCmd := deprecateCommand(*prevCmd, "av prev", "prev")
 	deprecatedPrevCmd.Aliases = []string{"p"}
-
+	deprecatedReorderCmd := deprecateCommand(*reorderCmd, "av reorder", "reorder")
+	deprecatedReparentCmd := deprecateCommand(*reparentCmd, "av reparent", "reparent")
 	deprecatedStackSyncCmd := deprecateCommand(*syncCmd, "av sync", "sync")
+	deprecatedSwitchCmd := deprecateCommand(*switchCmd, "av switch", "switch")
+	deprecatedTidyCmd := deprecateCommand(*tidyCmd, "av tidy", "tidy")
+	deprecatedTreeCmd := deprecateCommand(*treeCmd, "av tree", "tree")
+	deprecatedTreeCmd.Aliases = []string{"t"}
 
 	stackCmd.AddCommand(
 		deprecatedBranchCmd,
+		deprecatedDiffCmd,
 		deprecatedNextCmd,
 		deprecatedPrevCmd,
+		deprecatedReorderCmd,
+		deprecatedReparentCmd,
 		deprecatedStackSyncCmd,
+		deprecatedSwitchCmd,
+		deprecatedTidyCmd,
+		deprecatedTreeCmd,
 		stackAdoptCmd,
 		stackBranchCommitCmd,
-		stackDiffCmd,
 		stackForEachCmd,
 		stackOrphanCmd,
-		stackReorderCmd,
-		stackReparentCmd,
 		stackRestackCmd,
 		stackSubmitCmd,
-		stackSwitchCmd,
-		stackTidyCmd,
-		stackTreeCmd,
 	)
 }

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -365,7 +365,7 @@ func (vm *syncViewModel) viewChangeNotice() string {
 		"  * " + commandStyle.Render("av stack adopt") + " to adopt a new branch into the stack.\n",
 	)
 	sb.WriteString(
-		"  * " + commandStyle.Render("av stack reparent") + " to change the parent branch.\n",
+		"  * " + commandStyle.Render("av reparent") + " to change the parent branch.\n",
 	)
 	sb.WriteString(
 		"  * " + commandStyle.Render("av stack restack") + " to rebase the stack locally.\n",
@@ -678,8 +678,8 @@ func init() {
 		MarkDeprecated("trunk", "please use --rebase-to-trunk to rebase all branches to trunk")
 
 	syncCmd.Flags().String("parent", "",
-		"(deprecated; use av stack adopt or av stack reparent) parent branch to rebase onto",
+		"(deprecated; use av stack adopt or av reparent) parent branch to rebase onto",
 	)
 	_ = syncCmd.Flags().
-		MarkDeprecated("parent", "please use av stack adopt or av stack reparent")
+		MarkDeprecated("parent", "please use av stack adopt or av reparent")
 }

--- a/cmd/av/tidy.go
+++ b/cmd/av/tidy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stackTidyCmd = &cobra.Command{
+var tidyCmd = &cobra.Command{
 	Use:   "tidy",
 	Short: "Tidy stacked branches",
 	Long: strings.TrimSpace(`

--- a/cmd/av/tree.go
+++ b/cmd/av/tree.go
@@ -12,10 +12,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stackTreeCmd = &cobra.Command{
-	Use:     "tree",
-	Aliases: []string{"t"},
-	Short:   "Show the tree of stacked branches",
+var treeCmd = &cobra.Command{
+	Use:   "tree",
+	Short: "Show the tree of stacked branches",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repo, err := getRepo()
 		if err != nil {

--- a/demos/stack_restack/stack_restack.tape
+++ b/demos/stack_restack/stack_restack.tape
@@ -24,7 +24,7 @@ Type 'git switch stack-1' Enter
 Type 'clear' Enter
 Show
 
-Type 'av stack tree' Enter
+Type 'av tree' Enter
 Sleep 2
 
 Type 'git commit --amend -m "Commit 1a (amended)"' Enter

--- a/demos/stack_switch/stack_switch.tape
+++ b/demos/stack_switch/stack_switch.tape
@@ -29,7 +29,7 @@ Type 'git switch stack-1' Enter
 Type 'clear' Enter
 Show
 
-Type 'av stack switch' Enter
+Type 'av switch' Enter
 Sleep 2
 
 Up

--- a/demos/stack_switch/stack_switch_detached.tape
+++ b/demos/stack_switch/stack_switch_detached.tape
@@ -29,7 +29,7 @@ Type 'git switch --detach stack-1' Enter
 Type 'clear' Enter
 Show
 
-Type 'av stack switch' Enter
+Type 'av switch' Enter
 Sleep 2
 
 Down

--- a/demos/stack_switch/stack_switch_no_branch.tape
+++ b/demos/stack_switch/stack_switch_no_branch.tape
@@ -13,5 +13,5 @@ Type 'new_temp_repo' Enter
 Type 'clear' Enter
 Show
 
-Type 'av stack switch' Enter
+Type 'av switch' Enter
 Sleep 2

--- a/demos/stack_switch/stack_switch_non_managed_branch.tape
+++ b/demos/stack_switch/stack_switch_non_managed_branch.tape
@@ -30,7 +30,7 @@ Type 'git checkout -b non_managed' Enter
 Type 'clear' Enter
 Show
 
-Type 'av stack switch' Enter
+Type 'av switch' Enter
 Sleep 2
 
 Down

--- a/demos/stack_switch/stack_switch_trunk.tape
+++ b/demos/stack_switch/stack_switch_trunk.tape
@@ -29,7 +29,7 @@ Type 'git switch main' Enter
 Type 'clear' Enter
 Show
 
-Type 'av stack switch' Enter
+Type 'av switch' Enter
 Sleep 2
 
 Up

--- a/demos/stack_tidy/stack_tidy_deleted.tape
+++ b/demos/stack_tidy/stack_tidy_deleted.tape
@@ -19,5 +19,5 @@ Type 'git branch -D stack-1' Enter
 Type 'clear' Enter
 Show
 
-Type 'av stack tidy' Enter
+Type 'av tidy' Enter
 Sleep 3

--- a/demos/stack_tidy/stack_tidy_orphaned.tape
+++ b/demos/stack_tidy/stack_tidy_orphaned.tape
@@ -18,5 +18,5 @@ Type 'git branch -D stack-1' Enter
 Type 'clear' Enter
 Show
 
-Type 'av stack tidy' Enter
+Type 'av tidy' Enter
 Sleep 3

--- a/docs/av-diff.1.md
+++ b/docs/av-diff.1.md
@@ -1,13 +1,13 @@
-# av-stack-diff
+# av-diff
 
 ## NAME
 
-av-stack-diff - Show the diff between working tree and parent branch
+av-diff - Show the diff between working tree and parent branch
 
 ## SYNOPSIS
 
 ```synopsis
-av stack diff
+av diff
 ```
 
 ## DESCRIPTION

--- a/docs/av-reorder.1.md
+++ b/docs/av-reorder.1.md
@@ -1,13 +1,13 @@
-# av-stack-reorder
+# av-reorder
 
 ## NAME
 
-av-stack-reorder - Interactively reorder the stack
+av-reorder - Interactively reorder the stack
 
 ## SYNOPSIS
 
 ```synopsis
-av stack reorder [--continue | --abort]
+av reorder [--continue | --abort]
 ```
 
 ## DESCRIPTION

--- a/docs/av-reparent.1.md
+++ b/docs/av-reparent.1.md
@@ -1,13 +1,13 @@
-# av-stack-reparent
+# av-reparent
 
 ## NAME
 
-av-stack-reparent - Change the parent of the current branch
+av-reparent - Change the parent of the current branch
 
 ## SYNOPSIS
 
 ```synopsis
-av stack reparent [--parent=<parent>]
+av reparent [--parent=<parent>]
 ```
 
 ## DESCRIPTION

--- a/docs/av-switch.1.md
+++ b/docs/av-switch.1.md
@@ -1,13 +1,13 @@
-# av-stack-switch
+# av-switch
 
 ## NAME
 
-av-stack-switch - Interactively switch to a different branch
+av-switch - Interactively switch to a different branch
 
 ## SYNOPSIS
 
 ```synopsis
-av stack switch [<branch> | <url>]
+av switch [<branch> | <url>]
 ```
 
 ## DESCRIPTION

--- a/docs/av-sync.1.md
+++ b/docs/av-sync.1.md
@@ -81,4 +81,4 @@ branch to delete. Default is `ask`.
 
 `av-stack-restack`(1) for rebasing the branches locally.
 `av-stack-adopt`(1) for adopting a new branch.
-`av-stack-reparent`(1) for changing the parent of a branch.
+`av-reparent`(1) for changing the parent of a branch.

--- a/docs/av-tidy.1.md
+++ b/docs/av-tidy.1.md
@@ -1,13 +1,13 @@
-# av-stack-tidy
+# av-tidy
 
 ## NAME
 
-av-stack-tidy - Tidy stacked branches
+av-tidy - Tidy stacked branches
 
 ## SYNOPSIS
 
 ```synopsis
-av stack tidy
+av tidy
 ```
 
 ## DESCRIPTION

--- a/docs/av-tree.1.md
+++ b/docs/av-tree.1.md
@@ -1,13 +1,13 @@
-# av-stack-tree
+# av-tree
 
 ## NAME
 
-av-stack-tree - Show the tree of stacked branches
+av-tree - Show the tree of stacked branches
 
 ## SYNOPSIS
 
 ```synopsis
-av stack tree
+av tree
 ```
 
 ## DESCRIPTION

--- a/docs/av.1.md
+++ b/docs/av.1.md
@@ -15,6 +15,7 @@ av - Aviator CLI
 - av-commit-amend(1): Amend a commit
 - av-commit-create(1): Record changes to the repository with commits
 - av-commit-split(1): Split a commit into multiple commits
+- av-diff(1): Show the diff between working tree and parent branch
 - av-fetch(1): Fetch latest repository state from GitHub
 - av-init(1): Initialize the repository for `av`
 - av-next(1): Checkout the next branch in the stack
@@ -22,18 +23,17 @@ av - Aviator CLI
 - av-pr-queue(1): Queue an existing pull request for the current branch
 - av-pr-status(1): Get the status of the associated pull request
 - av-prev(1): Checkout the previous branch in the stack
+- av-reorder(1): Interactively reorder the stack
+- av-reparent(1): Change the parent of the current branch
 - av-stack-adopt(1): Adopt branches that are not managed by `av`
 - av-stack-branch-commit(1): Create a new branch in the stack with the staged changes
-- av-stack-diff(1): Show the diff between working tree and parent branch
 - av-stack-orphan(1): Orphan branches that are managed by `av`
-- av-stack-reorder(1): Interactively reorder the stack
-- av-stack-reparent(1): Change the parent of the current branch
 - av-stack-restack(1): Rebase the stacked branches
 - av-stack-submit(1): Create pull requests for every branch in the stack
-- av-stack-switch(1): Interactively switch to a different branch
-- av-stack-tidy(1): Tidy stacked branches
-- av-stack-tree(1): Show the tree of stacked branches
+- av-switch(1): Interactively switch to a different branch
 - av-sync(1): Synchronize stacked branches with GitHub
+- av-tidy(1): Tidy stacked branches
+- av-tree(1): Show the tree of stacked branches
 
 ## FURTHER DOCUMENTATION
 

--- a/e2e_tests/stack_orphan_test.go
+++ b/e2e_tests/stack_orphan_test.go
@@ -45,13 +45,13 @@ func TestStackOrphan(t *testing.T) {
 	)
 
 	RequireAv(t, "prev")
-	tree := RequireAv(t, "stack", "tree")
+	tree := RequireAv(t, "tree")
 	require.Contains(t, tree.Stdout, "stack-2")
 	require.Contains(t, tree.Stdout, "stack-3")
 
 	RequireAv(t, "stack", "orphan")
 
-	tree = RequireAv(t, "stack", "tree")
+	tree = RequireAv(t, "tree")
 	require.NotContains(t, tree.Stdout, "stack-2")
 	require.NotContains(t, tree.Stdout, "stack-3")
 }

--- a/e2e_tests/stack_reparent_test.go
+++ b/e2e_tests/stack_reparent_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStackReparent(t *testing.T) {
+func TestReparent(t *testing.T) {
 	server := RunMockGitHubServer(t)
 	defer server.Close()
 	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
@@ -29,7 +29,7 @@ func TestStackReparent(t *testing.T) {
 	requireFileContent(t, "spam.txt", "spam")
 
 	// Now, re-parent spam on top of bar (should be relatively a no-op)
-	RequireAv(t, "stack", "reparent", "--parent", "bar")
+	RequireAv(t, "reparent", "--parent", "bar")
 	requireFileContent(t, "spam.txt", "spam")
 	requireFileContent(
 		t,
@@ -39,7 +39,7 @@ func TestStackReparent(t *testing.T) {
 	)
 
 	// Now, re-parent spam on top of foo
-	RequireAv(t, "stack", "reparent", "--parent", "foo")
+	RequireAv(t, "reparent", "--parent", "foo")
 	currentBranch := repo.CurrentBranch(t)
 	require.Equal(
 		t,
@@ -57,7 +57,7 @@ func TestStackReparent(t *testing.T) {
 	require.NoFileExists(t, "bar.txt", "bar.txt should not exist after reparenting onto foo branch")
 }
 
-func TestStackReparentTrunk(t *testing.T) {
+func TestReparentTrunk(t *testing.T) {
 	server := RunMockGitHubServer(t)
 	defer server.Close()
 	repo := gittest.NewTempRepoWithGitHubServer(t, server.URL)
@@ -72,7 +72,7 @@ func TestStackReparentTrunk(t *testing.T) {
 	// Delete the local main. av should use the remote tracking branch.
 	repo.Git(t, "branch", "-D", "main")
 
-	RequireAv(t, "stack", "reparent", "--parent", "main")
+	RequireAv(t, "reparent", "--parent", "main")
 }
 
 func requireFileContent(t *testing.T, file string, expected string, args ...any) {

--- a/e2e_tests/stack_tree_test.go
+++ b/e2e_tests/stack_tree_test.go
@@ -20,5 +20,5 @@ func TestStackTree(t *testing.T) {
 	RequireAv(t, "branch", "spam")
 	repo.CommitFile(t, "spam", "spam")
 
-	RequireAv(t, "stack", "tree")
+	RequireAv(t, "tree")
 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"rename-prev-next","parentHead":"f629819be221a5d5dbd2ce99b33576f9ecdc4622","parentPull":467,"trunk":"master"}
```
-->
