### PR TITLE
Move av stack restack to av restack 

### DIFF
--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -109,6 +109,7 @@ func init() {
 		stackCmd,
 		switchCmd,
 		syncCmd,
+		restackCmd,
 		tidyCmd,
 		treeCmd,
 		versionCmd,

--- a/cmd/av/stack.go
+++ b/cmd/av/stack.go
@@ -31,6 +31,8 @@ func init() {
 
 	deprecatedReparentCmd := deprecateCommand(*reparentCmd, "av reparent", "reparent")
 
+	deprecatedRestackCmd := deprecateCommand(*restackCmd, "av restack", "restack")
+
 	deprecatedStackBranchCommitCmd := deprecateCommand(
 		*stackBranchCommitCmd,
 		"av commit -b",
@@ -120,6 +122,6 @@ func init() {
 		deprecatedTidyCmd,
 		deprecatedTreeCmd,
 		stackForEachCmd,
-		stackRestackCmd,
+		deprecatedRestackCmd,
 	)
 }

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -368,7 +368,7 @@ func (vm *syncViewModel) viewChangeNotice() string {
 		"  * " + commandStyle.Render("av reparent") + " to change the parent branch.\n",
 	)
 	sb.WriteString(
-		"  * " + commandStyle.Render("av stack restack") + " to rebase the stack locally.\n",
+		"  * " + commandStyle.Render("av restack") + " to rebase the stack locally.\n",
 	)
 	sb.WriteString(
 		"  * " + commandStyle.Render(
@@ -393,7 +393,7 @@ func (vm *syncViewModel) viewChangeNotice() string {
 	)
 	sb.WriteString(
 		"master). If you do not want to rebase onto the remote trunk branch, please use " + commandStyle.Render(
-			"av stack restack",
+			"av restack",
 		) + ".\n",
 	)
 	sb.WriteString("\n")
@@ -666,10 +666,10 @@ func init() {
 
 	// Deprecated flags
 	syncCmd.Flags().Bool("no-fetch", false,
-		"(deprecated; use av stack restack for offline restacking) do not fetch the latest status from GitHub",
+		"(deprecated; use av restack for offline restacking) do not fetch the latest status from GitHub",
 	)
 	_ = syncCmd.Flags().
-		MarkDeprecated("no-fetch", "please use av stack restack for offline restacking")
+		MarkDeprecated("no-fetch", "please use av restack for offline restacking")
 
 	syncCmd.Flags().Bool("trunk", false,
 		"(deprecated; use --rebase-to-trunk to rebase all branches to trunk) rebase the stack on the trunk branch",

--- a/demos/stack_restack/stack_restack.tape
+++ b/demos/stack_restack/stack_restack.tape
@@ -33,7 +33,7 @@ Sleep 2
 Type 'git --no-pager log --graph --all' Enter
 Sleep 2
 
-Type 'av stack restack' Enter
+Type 'av restack' Enter
 Sleep 3
 
 Type 'git --no-pager log --graph --all' Enter

--- a/docs/av-commit.1.md
+++ b/docs/av-commit.1.md
@@ -14,7 +14,7 @@ av commit [-m <msg>| --message=<msg>] [-a | --all] [--amend] [--edit]
 ## DESCRIPTION
 
 Create a new commit containing the current contents of the index and the given
-log message describing the changes, then run **av stack restack** on all
+log message describing the changes, then run **av restack** on all
 subsequent child branches with the new commit.
 
 Previous to running **av commit**, add changes to the index via

--- a/docs/av-restack.1.md
+++ b/docs/av-restack.1.md
@@ -1,18 +1,18 @@
-# av-stack-restack
+# av-restack
 
 ## NAME
 
-av-stack-restack - Rebase the stacked branches
+av-restack - Rebase the stacked branches
 
 ## SYNOPSIS
 
 ```synopsis
-av stack restack [--dry-run] [--continue | --abort | --skip]
+av restack [--dry-run] [--continue | --abort | --skip]
 ```
 
 ## DESCRIPTION
 
-`av stack restack` is a command to re-align the stacked branches. When a parent
+`av restack` is a command to re-align the stacked branches. When a parent
 branch is amended or has a new commit, the children branches need to be rebased
 on the new parent. This command does the rebase operation for all the branches
 in the current stack. This command does not push the changes to the remote.
@@ -20,7 +20,7 @@ in the current stack. This command does not push the changes to the remote.
 ## REBASE CONFLICT
 
 Rebasing can cause a conflict. When a conflict happens, it prompts you to
-resolve the conflict, and continue with `av stack restack --continue`. This is
+resolve the conflict, and continue with `av restack --continue`. This is
 similar to `git rebase --continue`, but it continues with syncing the rest of
 the branches.
 

--- a/e2e_tests/restack_test.go
+++ b/e2e_tests/restack_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStackRestack(t *testing.T) {
+func TestRestack(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
 	Chdir(t, repo.RepoDir)
 
@@ -41,7 +41,7 @@ func TestStackRestack(t *testing.T) {
 	repo.Git(t, "checkout", "stack-3")
 
 	// Everything up to date now, so this should be a no-op.
-	RequireAv(t, "stack", "restack")
+	RequireAv(t, "restack")
 
 	// We're going to add a commit to the first branch in the stack.
 	// Our stack looks like:
@@ -82,33 +82,33 @@ func TestStackRestack(t *testing.T) {
 
 	// Since both commits updated my-file in ways that conflict, we should get
 	// a merge/rebase conflict here.
-	syncConflict := Av(t, "stack", "restack")
+	syncConflict := Av(t, "restack")
 	require.NotEqual(
 		t, 0, syncConflict.ExitCode,
-		"stack restack should return non-zero exit code if conflicts",
+		"restack should return non-zero exit code if conflicts",
 	)
 	require.Contains(
 		t, syncConflict.Stdout,
-		"error: could not apply", "stack restack should include error message on rebase",
+		"error: could not apply", "restack should include error message on rebase",
 	)
 	require.Contains(
-		t, syncConflict.Stdout, "av stack restack --continue",
-		"stack restack should print a message with instructions to continue",
+		t, syncConflict.Stdout, "av restack --continue",
+		"restack should print a message with instructions to continue",
 	)
-	syncContinueWithoutResolving := Av(t, "stack", "restack", "--continue")
+	syncContinueWithoutResolving := Av(t, "restack", "--continue")
 	require.NotEqual(
 		t,
 		0,
 		syncContinueWithoutResolving.ExitCode,
-		"stack restack --continue should return non-zero exit code if conflicts have not been resolved",
+		"restack --continue should return non-zero exit code if conflicts have not been resolved",
 	)
 	// resolve the conflict
 	err := os.WriteFile(filepath.Join(repo.RepoDir, "my-file"), []byte("1a\n1b\n2a\n"), 0644)
 	require.NoError(t, err)
 	repo.Git(t, "add", "my-file")
 	require.NoError(t, err, "failed to stage file")
-	// stack restack --continue should return zero exit code after resolving conflicts
-	RequireAv(t, "stack", "restack", "--continue")
+	// restack --continue should return zero exit code after resolving conflicts
+	RequireAv(t, "restack", "--continue")
 
 	// Make sure we've handled the rebase of stack-3 correctly (see the long
 	// comment above).
@@ -128,7 +128,7 @@ func TestStackRestack(t *testing.T) {
 	require.Equal(t, mergeBases[0], stack1Head, "stack-2 should be up-to-date with stack-1")
 
 	// Further sync attempts should yield no-ops
-	syncNoop := RequireAv(t, "stack", "restack")
+	syncNoop := RequireAv(t, "restack")
 	require.Contains(t, syncNoop.Stdout, "Restack is done")
 
 	// Make sure we've not introduced any extra commits
@@ -180,12 +180,12 @@ func TestStackRestackAbort(t *testing.T) {
 	repo.CommitFile(t, "my-file", "1a\n1b\n", gittest.WithMessage("Commit 1b"))
 
 	// ... and make sure we get a conflict on sync...
-	syncConflict := Av(t, "stack", "restack")
+	syncConflict := Av(t, "restack")
 	require.NotEqual(
 		t,
 		0,
 		syncConflict.ExitCode,
-		"stack restack should return non-zero exit code if conflicts",
+		"restack should return non-zero exit code if conflicts",
 	)
 	require.FileExists(
 		t,
@@ -194,7 +194,7 @@ func TestStackRestackAbort(t *testing.T) {
 	)
 
 	// ... and then abort the sync...
-	RequireAv(t, "stack", "restack", "--abort")
+	RequireAv(t, "restack", "--abort")
 	require.NoFileExists(
 		t,
 		filepath.Join(repo.GitDir, "REBASE_HEAD"),
@@ -256,12 +256,12 @@ func TestStackRestackWithLotsOfConflicts(t *testing.T) {
 		)
 	})
 
-	sync := Av(t, "stack", "restack")
+	sync := Av(t, "restack")
 	require.NotEqual(
 		t,
 		0,
 		sync.ExitCode,
-		"stack restack should return non-zero exit code if conflicts",
+		"restack should return non-zero exit code if conflicts",
 	)
 	require.Regexp(t, regexp.MustCompile("could not apply .+ Commit 2a"), sync.Stdout)
 	require.NoError(t, os.WriteFile("my-file", []byte("1a\n1b\n2a\n"), 0644))
@@ -269,12 +269,12 @@ func TestStackRestackWithLotsOfConflicts(t *testing.T) {
 
 	// Commit 2b should be able to be applied normally, then we should have a
 	// conflict with 3a
-	sync = Av(t, "stack", "restack", "--continue")
+	sync = Av(t, "restack", "--continue")
 	require.NotEqual(
 		t,
 		0,
 		sync.ExitCode,
-		"stack restack should return non-zero exit code if conflicts",
+		"restack should return non-zero exit code if conflicts",
 	)
 	require.Regexp(t, regexp.MustCompile("could not apply .+ Commit 3a"), sync.Stdout)
 	require.NoError(t, os.WriteFile("my-file", []byte("1a\n1b\n2a\n2b\n3a\n"), 0644))
@@ -282,7 +282,7 @@ func TestStackRestackWithLotsOfConflicts(t *testing.T) {
 
 	// And finally, 3b should be able to be applied without conflict and our stack
 	// sync should be over.
-	RequireAv(t, "stack", "restack", "--continue")
+	RequireAv(t, "restack", "--continue")
 }
 
 func TestStackRestackAfterAmendingCommit(t *testing.T) {
@@ -318,7 +318,7 @@ func TestStackRestackAfterAmendingCommit(t *testing.T) {
 	// Now we amend commit 1b and make sure the sync after succeeds
 	repo.CheckoutBranch(t, "refs/heads/stack-1")
 	repo.CommitFile(t, "my-file", "1a\n1c\n1b\n", gittest.WithAmend())
-	RequireAv(t, "stack", "restack")
+	RequireAv(t, "restack")
 
 	repo.CheckoutBranch(t, "refs/heads/stack-3")
 	contents, err := os.ReadFile("my-file")
@@ -356,7 +356,7 @@ func TestStackRestackAll(t *testing.T) {
 	//     stack-1b:      \ -> 1b
 
 	repo.Git(t, "switch", "stack-1a")
-	RequireAv(t, "stack", "restack", "--all")
+	RequireAv(t, "restack", "--all")
 
 	//     main:    X
 	//     stack-1:  \ -> 1 -> 2

--- a/internal/sequencer/sequencerui/ui.go
+++ b/internal/sequencer/sequencerui/ui.go
@@ -18,7 +18,7 @@ func NewRestackModel(repo *git.Repo, db meta.DB) *RestackModel {
 		repo:    repo,
 		db:      db,
 		spinner: spinner.New(spinner.WithSpinner(spinner.Dot)),
-		Command: "av stack restack",
+		Command: "av restack",
 	}
 }
 


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
