### PR TITLE
Add autocomplete for 'av switch'

### DIFF
--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -149,3 +149,12 @@ func deprecateCommand(
 
 	return &deprecatedCommand
 }
+
+func branchNameArgs(
+	_ *cobra.Command,
+	_ []string,
+	toComplete string,
+) ([]string, cobra.ShellCompDirective) {
+	branches, _ := allBranches()
+	return branches, cobra.ShellCompDirectiveNoSpace
+}

--- a/cmd/av/restack.go
+++ b/cmd/av/restack.go
@@ -31,7 +31,7 @@ var restackCmd = &cobra.Command{
 	Use:   "restack",
 	Short: "Rebase the stacked branches",
 	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		repo, err := getRepo()
 		if err != nil {
 			return err

--- a/cmd/av/switch.go
+++ b/cmd/av/switch.go
@@ -24,9 +24,10 @@ import (
 )
 
 var switchCmd = &cobra.Command{
-	Use:   "switch [<branch> | <url>]",
-	Short: "Interactively switch to a different branch",
-	Args:  cobra.MaximumNArgs(1),
+	Use:               "switch [<branch> | <url>]",
+	Short:             "Interactively switch to a different branch",
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: branchNameArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repo, err := getRepo()
 		if err != nil {


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
