### PR TITLE
Add support for '--parent' on 'av commit -b'

### DIFF
--- a/cmd/av/adopt.go
+++ b/cmd/av/adopt.go
@@ -465,7 +465,7 @@ func init() {
 		"parent",
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			branches, _ := allBranches()
-			return branches, cobra.ShellCompDirectiveDefault
+			return branches, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
 }

--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -97,9 +97,14 @@ func allBranches() ([]string, error) {
 		return nil, err
 	}
 
+	defaultBranch, err := repo.DefaultBranch()
+	if err != nil {
+		return nil, err
+	}
+
 	tx := db.ReadTx()
 
-	var branches []string
+	var branches = []string{defaultBranch}
 	for b := range tx.AllBranches() {
 		branches = append(branches, b)
 	}

--- a/cmd/av/reparent.go
+++ b/cmd/av/reparent.go
@@ -192,7 +192,7 @@ func init() {
 		"parent",
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			branches, _ := allBranches()
-			return branches, cobra.ShellCompDirectiveDefault
+			return branches, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
 }

--- a/cmd/av/stack_branchcommit.go
+++ b/cmd/av/stack_branchcommit.go
@@ -29,6 +29,7 @@ var stackBranchCommitCmd = &cobra.Command{
 		return branchAndCommit(stackBranchCommitFlags.BranchName,
 			stackBranchCommitFlags.Message,
 			stackBranchCommitFlags.All,
-			stackBranchCommitFlags.AllModified)
+			stackBranchCommitFlags.AllModified,
+			"")
 	},
 }

--- a/docs/av-commit.1.md
+++ b/docs/av-commit.1.md
@@ -9,6 +9,7 @@ av-commit - Record changes to the repository with commits
 ```synopsis
 av commit [-m <msg>| --message=<msg>] [-a | --all] [--amend] [--edit]
     [-b | --branch] [-A | --all-changes] [--branch-name <name>]
+    [--parent <parent_branch>]
 ```
 
 ## DESCRIPTION
@@ -44,3 +45,7 @@ git-add(1) to incrementally "add" changes to the index.
 
 `--branch-name <name>`
 : Create a new branch with the given name and commit to it
+
+`--parent <parent_branch>`
+: Instead of creating a new branch from current branch, create it from
+  specified `<parent_branch>`


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
