### PR TITLE
fix #486, 'av tidy' not respecting branches not off trunk

### DIFF
--- a/cmd/av/tidy.go
+++ b/cmd/av/tidy.go
@@ -39,7 +39,16 @@ does not delete Git branches.
 		}
 
 		var ss []string
-		if len(deleted) > 0 {
+
+		hasDeleted := false
+		for _, d := range deleted {
+			if d {
+				hasDeleted = true
+				break
+			}
+		}
+
+		if hasDeleted {
 			ss = append(
 				ss,
 				colors.SuccessStyle.Render(
@@ -49,8 +58,10 @@ does not delete Git branches.
 			ss = append(ss, "")
 			ss = append(ss, "  Following branches no longer exist in the repository:")
 			ss = append(ss, "")
-			for name := range deleted {
-				ss = append(ss, "  * "+name)
+			for name, d := range deleted {
+				if d {
+					ss = append(ss, "  * "+name)
+				}
 			}
 			if len(orphaned) > 0 {
 				ss = append(ss, "")

--- a/internal/actions/tidy.go
+++ b/internal/actions/tidy.go
@@ -17,6 +17,8 @@ func TidyDB(repo *git.Repo, db meta.DB) (map[string]bool, map[string]bool, error
 		if _, err := repo.Git("show-ref", "refs/heads/"+name); err != nil {
 			// Ref doesn't exist. Should be removed.
 			deleted[name] = true
+		} else {
+			deleted[name] = false
 		}
 	}
 	orphaned := make(map[string]bool)
@@ -29,8 +31,10 @@ func TidyDB(repo *git.Repo, db meta.DB) (map[string]bool, map[string]bool, error
 		}
 	}
 
-	for name := range deleted {
-		tx.DeleteBranch(name)
+	for name, d := range deleted {
+		if d {
+			tx.DeleteBranch(name)
+		}
 	}
 	for name := range orphaned {
 		tx.DeleteBranch(name)


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
