### PR TITLE
Wrong deprecation warning on 'av pr create'

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -374,7 +374,7 @@ func init() {
 		"create pull requests up to the current branch")
 	_ = prCmd.Flags().MarkHidden("current")
 
-	deprecatedCreateCmd := deprecateCommand(*prCmd, "av create", "create")
+	deprecatedCreateCmd := deprecateCommand(*prCmd, "av pr", "create")
 	deprecatedCreateCmd.Hidden = true
 
 	prCmd.AddCommand(


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
