### PR TITLE
add av branch --split to manpages

### DIFF
--- a/cmd/av/branch.go
+++ b/cmd/av/branch.go
@@ -155,7 +155,11 @@ func branchSplit(repo *git.Repo, db meta.DB, currentBranchName string, newBranch
 	currentBranchRef, err := repo.GoGitRepo().Reference(currentBranchRefName, true)
 
 	if err != nil {
-		return fmt.Errorf("failed to get reference for current branch %s: %w", currentBranchName, err)
+		return fmt.Errorf(
+			"failed to get reference for current branch %s: %w",
+			currentBranchName,
+			err,
+		)
 	}
 
 	lastCommitHash := currentBranchRef.Hash()
@@ -215,7 +219,12 @@ func branchSplit(repo *git.Repo, db meta.DB, currentBranchName string, newBranch
 
 	fmt.Fprint(
 		os.Stdout,
-		colors.Success(fmt.Sprintf("Successfully split the last commit into a new branch %s.\n", newBranchName)),
+		colors.Success(
+			fmt.Sprintf(
+				"Successfully split the last commit into a new branch %s.\n",
+				newBranchName,
+			),
+		),
 	)
 
 	// Adopt new branch to av database
@@ -265,7 +274,7 @@ func init() {
 	branchCmd.Flags().
 		BoolVar(&branchFlags.Force, "force", false, "force rename the current branch, even if a pull request exists")
 	branchCmd.Flags().
-		BoolVar(&branchFlags.Split, "split", false, "split the last commit into a new branch")
+		BoolVar(&branchFlags.Split, "split", false, "split the last commit into a new branch, if no branch name is given, one will be auto-generated")
 
 	_ = branchCmd.RegisterFlagCompletionFunc(
 		"parent",

--- a/docs/av-branch.1.md
+++ b/docs/av-branch.1.md
@@ -31,3 +31,7 @@ metadata with `av branch --rename <old-branch-name>:<new-branch-name>`.
 
 `--force`
 : Force rename the branch, even if a pull request exists.
+
+`--split`
+: Splits the last commit into a new branch, if no branch name is given
+  create one based on commit message.


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
