### PR TITLE
Branch off from the parent branch

### DIFF
--- a/cmd/av/branch.go
+++ b/cmd/av/branch.go
@@ -294,7 +294,7 @@ func createBranch(
 	var parentHead string
 	if isBranchFromTrunk {
 		// If the parent is trunk, start from the remote tracking branch.
-		checkoutStartingPoint = remoteName + "/" + defaultBranch
+		checkoutStartingPoint = remoteName + "/" + parentBranchName
 		// If the parent is the trunk, we don't log the parent branch's head
 		parentHead = ""
 	} else {


### PR DESCRIPTION
When creating a new branch from a trunk branch, it should branch from
the parent remote tracking branch. This hasn't been an issue if the
trunk branch is the default branch (such as main / master), but if this
is used with a additionalTrunkBranches, it branches off from main /
master always rather than the specified additional trunk branch.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
