### PR TITLE
Set IN_AV_CLI environment variable to 1 when invoking git commands

### DIFF
--- a/docs/internal/md2man/roff.go
+++ b/docs/internal/md2man/roff.go
@@ -343,6 +343,7 @@ func countColumns(node *blackfriday.Node) int {
 	var columns int
 
 	node.Walk(func(node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
+		//nolint: exhaustive
 		switch node.Type {
 		case blackfriday.TableRow:
 			if !entering {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -130,6 +130,9 @@ func (r *Repo) Git(args ...string) (string, error) {
 	startTime := time.Now()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = r.repoDir
+	// Set the IN_AV_CLI environment variable to 1 to let the hooks invoked by git know it's
+	// part of av-cli invocation.
+	cmd.Env = append(os.Environ(), "IN_AV_CLI=1")
 	out, err := cmd.Output()
 	log := r.log.WithField("duration", time.Since(startTime))
 	if err != nil {
@@ -191,7 +194,10 @@ func (r *Repo) Run(opts *RunOpts) (*Output, error) {
 	if opts.Stdin != nil {
 		cmd.Stdin = opts.Stdin
 	}
-	cmd.Env = append(os.Environ(), opts.Env...)
+	// Set the IN_AV_CLI environment variable to 1 to let the hooks invoked by git know it's
+	// part of av-cli invocation.
+	cmd.Env = append(os.Environ(), "IN_AV_CLI=1")
+	cmd.Env = append(cmd.Env, opts.Env...)
 	err := cmd.Run()
 	var exitError *exec.ExitError
 	if err != nil && !errors.As(err, &exitError) {


### PR DESCRIPTION
This is a follow up to https://github.com/aviator-co/av/pull/541. This
is used to indicate that the git command is being invoked by av-cli.
The git hooks can use this information to behave differently.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
