### PR TITLE
Do not make --parent or --trunk obligatory

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -261,6 +261,7 @@ func CreatePullRequest(
 		"rev-list",
 		"--reverse",
 		fmt.Sprintf("%s..%s", prCompareRef, opts.BranchName),
+		"--",
 	)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to determine commits to include in PR")

--- a/internal/git/revlist.go
+++ b/internal/git/revlist.go
@@ -21,6 +21,8 @@ func (r *Repo) RevList(opts RevListOpts) ([]string, error) {
 		args = append(args, "--reverse")
 	}
 	args = append(args, opts.Specifiers...)
+	// Unambiguous the positional arguments
+	args = append(args, "--")
 	res, err := r.Run(&RunOpts{
 		Args:      args,
 		Env:       nil,

--- a/internal/reorder/stackbranch.go
+++ b/internal/reorder/stackbranch.go
@@ -84,6 +84,7 @@ func (b StackBranchCmd) Execute(ctx *Context) error {
 		colors.UserInput(git.ShortSha(headCommit)),
 		"\n",
 	)
+	ctx.State.Branch = b.Name
 
 	return tx.Commit()
 }


### PR DESCRIPTION
Fixes #423

Also fixes a case where `av` fails when there's a branch with the same name as a
file.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
