### PR TITLE
Make pre-av hooks interactive and exit on error.

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -348,8 +348,10 @@ func queue() error {
 
 func runPRHook(repo *git.Repo, hookType string) error {
 	output, err := repo.Run(&git.RunOpts{
-		Args: []string{"hook", "run", "--ignore-missing", "pre-av-pr"},
-		Env:  []string{"AV_PR_HOOK_TYPE=" + hookType},
+		Args:        []string{"hook", "run", "--ignore-missing", "pre-av-pr"},
+		Env:         []string{"AV_PR_HOOK_TYPE=" + hookType},
+		Interactive: true,
+		ExitError:   true,
 	})
 	var messages []string
 	if len(output.Stdout) != 0 {

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -337,7 +337,9 @@ func (vm *syncViewModel) initSync() tea.Cmd {
 	}
 	return func() tea.Msg {
 		output, err := vm.repo.Run(&git.RunOpts{
-			Args: []string{"hook", "run", "--ignore-missing", "pre-av-sync"},
+			Args:        []string{"hook", "run", "--ignore-missing", "pre-av-sync"},
+			Interactive: true,
+			ExitError:   true,
 		})
 		var messages []string
 		if len(output.Stdout) != 0 {


### PR DESCRIPTION
Interactive for better user experience (show progress of the hook as it is running) and exit on error so that checks that fail actually stop the command.