### PR TITLE
Address the nil dereference

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -354,11 +354,13 @@ func runPRHook(repo *git.Repo, hookType string) error {
 		ExitError:   true,
 	})
 	var messages []string
-	if len(output.Stdout) != 0 {
-		messages = append(messages, string(output.Stdout))
-	}
-	if len(output.Stderr) != 0 {
-		messages = append(messages, string(output.Stderr))
+	if output != nil {
+		if len(output.Stdout) != 0 {
+			messages = append(messages, string(output.Stdout))
+		}
+		if len(output.Stderr) != 0 {
+			messages = append(messages, string(output.Stderr))
+		}
 	}
 	if len(messages) != 0 {
 		fmt.Fprint(os.Stderr, strings.Join(messages, "\n"))

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -342,11 +342,13 @@ func (vm *syncViewModel) initSync() tea.Cmd {
 			ExitError:   true,
 		})
 		var messages []string
-		if len(output.Stdout) != 0 {
-			messages = append(messages, string(output.Stdout))
-		}
-		if len(output.Stderr) != 0 {
-			messages = append(messages, string(output.Stderr))
+		if output != nil {
+			if len(output.Stdout) != 0 {
+				messages = append(messages, string(output.Stdout))
+			}
+			if len(output.Stderr) != 0 {
+				messages = append(messages, string(output.Stderr))
+			}
 		}
 		if len(messages) != 0 {
 			vm.preAvSyncHookMessage = strings.Join(messages, "\n")


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
