### PR TITLE
failure to fetch latest release version should be debug only message

### DIFF
--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -158,7 +158,7 @@ func checkCliVersion() {
 	}
 	latest, err := config.FetchLatestVersion()
 	if err != nil {
-		logrus.WithError(err).Warning("failed to determine latest released version of av")
+		logrus.WithError(err).Debug("failed to determine latest released version of av")
 		return
 	}
 	logrus.WithField("latest", latest).Debug("fetched latest released version")


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
