### PR TITLE
Switch autocomplete for reparent to using valid branch names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,6 @@ repos:
       - id: check-github-workflows
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.7.0
+    rev: v1.9.0
     hooks:
       - id: zizmor

--- a/cmd/av/reparent.go
+++ b/cmd/av/reparent.go
@@ -21,8 +21,9 @@ var reparentFlags struct {
 }
 
 var reparentCmd = &cobra.Command{
-	Use:   "reparent",
-	Short: "Change the parent of the current branch",
+	Use:               "reparent",
+	Short:             "Change the parent of the current branch",
+	ValidArgsFunction: branchNameArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repo, err := getRepo()
 		if err != nil {


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
