### PR TITLE
add homebrew fish autocompletions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,7 +71,7 @@ brews:
     install: |
       bin.install "av"
       man.install Dir["man/*"]
-      generate_completions_from_executable(bin/"av", "completion", shells: [:bash, :zsh])
+      generate_completions_from_executable(bin/"av", "completion", shells: [:bash, :zsh, :fish])
 
 aurs:
   - name: "av-cli-bin"


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
