### PR TITLE
Fix golangci-lint

### DIFF
--- a/cmd/av/auth.go
+++ b/cmd/av/auth.go
@@ -19,23 +19,23 @@ var authCmd = &cobra.Command{
 	SilenceUsage: true,
 	Args:         cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
-		if err := checkAviatorAuthStatus(); err != nil {
+		if err := checkAviatorAuthStatus(cmd.Context()); err != nil {
 			fmt.Fprintln(os.Stderr, colors.Warning(err.Error()))
 		}
-		if err := checkGitHubAuthStatus(); err != nil {
+		if err := checkGitHubAuthStatus(cmd.Context()); err != nil {
 			fmt.Fprintln(os.Stderr, colors.Failure(err.Error()))
 		}
 	},
 }
 
-func checkAviatorAuthStatus() error {
-	avClient, err := avgql.NewClient()
+func checkAviatorAuthStatus(ctx context.Context) error {
+	avClient, err := avgql.NewClient(ctx)
 	if err != nil {
 		return err
 	}
 
 	var query struct{ avgql.ViewerSubquery }
-	if err := avClient.Query(context.Background(), &query, nil); err != nil {
+	if err := avClient.Query(ctx, &query, nil); err != nil {
 		if avgql.IsHTTPUnauthorized(err) {
 			return errors.New(
 				"You are not logged in to Aviator. Please verify that your API token is correct.",
@@ -51,13 +51,13 @@ func checkAviatorAuthStatus() error {
 	return nil
 }
 
-func checkGitHubAuthStatus() error {
-	ghClient, err := getGitHubClient()
+func checkGitHubAuthStatus(ctx context.Context) error {
+	ghClient, err := getGitHubClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	viewer, err := ghClient.Viewer(context.Background())
+	viewer, err := ghClient.Viewer(ctx)
 	if err != nil {
 		// GitHub API returns 401 Unauthorized if the token is invalid or
 		// expired.

--- a/cmd/av/branchmeta.go
+++ b/cmd/av/branchmeta.go
@@ -33,11 +33,12 @@ var branchMetaDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "delete a branch metadata",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		repo, err := getRepo()
+		ctx := cmd.Context()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
@@ -54,11 +55,12 @@ var branchMetaListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "list all branch metadata",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		repo, err := getRepo()
+		ctx := cmd.Context()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
@@ -77,19 +79,20 @@ var branchMetaSetCmd = &cobra.Command{
 	Use:   "set branch-name",
 	Short: "modify the branch metadata",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 		if len(args) != 1 {
 			_ = cmd.Usage()
 			return errors.New("exactly one branch name and --parent is required")
 		}
-		repo, err := getRepo()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
-		if _, err := repo.RevParse(&git.RevParse{Rev: args[0]}); err != nil {
+		if _, err := repo.RevParse(ctx, &git.RevParse{Rev: args[0]}); err != nil {
 			return errors.WrapIf(err, "cannot check if a branch exists")
 		}
 		tx := db.WriteTx()
@@ -99,7 +102,7 @@ var branchMetaSetCmd = &cobra.Command{
 			var parentHead string
 			if branchMetaFlags.trunk {
 				var err error
-				parentHead, err = repo.RevParse(&git.RevParse{Rev: branchMetaFlags.parent})
+				parentHead, err = repo.RevParse(ctx, &git.RevParse{Rev: branchMetaFlags.parent})
 				if err != nil {
 					return err
 				}

--- a/cmd/av/commit_amend.go
+++ b/cmd/av/commit_amend.go
@@ -16,6 +16,11 @@ var commitAmendCmd = &cobra.Command{
 	Short: "Amend a commit",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		return amendCmd(commitAmendFlags.Message, !commitAmendFlags.NoEdit, commitAmendFlags.All)
+		return amendCmd(
+			cmd.Context(),
+			commitAmendFlags.Message,
+			!commitAmendFlags.NoEdit,
+			commitAmendFlags.All,
+		)
 	},
 }

--- a/cmd/av/commit_common.go
+++ b/cmd/av/commit_common.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 
 	"emperror.dev/errors"
@@ -103,7 +104,7 @@ func (vm *postCommitRestackViewModel) writeState(state *sequencerui.RestackState
 }
 
 func (vm *postCommitRestackViewModel) createState() (*sequencerui.RestackState, error) {
-	currentBranch, err := vm.repo.CurrentBranchName()
+	currentBranch, err := vm.repo.CurrentBranchName(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/av/diff.go
+++ b/cmd/av/diff.go
@@ -23,16 +23,17 @@ Generates the diff between the working tree and the parent branch
 	SilenceUsage: true,
 	Args:         cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		repo, err := getRepo()
+		ctx := cmd.Context()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
 
-		currentBranchName, err := repo.CurrentBranchName()
+		currentBranchName, err := repo.CurrentBranchName(ctx)
 		if err != nil {
 			return err
 		}
@@ -40,7 +41,7 @@ Generates the diff between the working tree and the parent branch
 		tx := db.ReadTx()
 		branch, exists := tx.Branch(currentBranchName)
 		if !exists {
-			defaultBranch, err := repo.DefaultBranch()
+			defaultBranch, err := repo.DefaultBranch(ctx)
 			if err != nil {
 				return err
 			}
@@ -93,7 +94,7 @@ Generates the diff between the working tree and the parent branch
 
 			// Determine if the branch is up-to-date with the parent and warn if
 			// not.
-			currentParentHead, err := repo.RevParse(&git.RevParse{Rev: branch.Parent.Name})
+			currentParentHead, err := repo.RevParse(ctx, &git.RevParse{Rev: branch.Parent.Name})
 			if err != nil {
 				return err
 			}
@@ -104,7 +105,7 @@ Generates the diff between the working tree and the parent branch
 		// We don't use repo.Diff here since that sets the --exit-error flag
 		// which in turn disables the output pager. We want this command to
 		// behave similarly to default `git diff` for the user.
-		_, err = repo.Run(&git.RunOpts{
+		_, err = repo.Run(ctx, &git.RunOpts{
 			Args:        diffArgs,
 			Interactive: true,
 		})

--- a/cmd/av/fetch.go
+++ b/cmd/av/fetch.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -21,11 +20,13 @@ var fetchCmd = &cobra.Command{
 	Short: "Fetch latest repository state from GitHub",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) (reterr error) {
-		repo, err := getRepo()
+		ctx := cmd.Context()
+
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
@@ -41,12 +42,11 @@ var fetchCmd = &cobra.Command{
 		info := tx.Repository()
 		branches := tx.AllBranches()
 
-		client, err := getGitHubClient()
+		client, err := getGitHubClient(ctx)
 		if err != nil {
 			return err
 		}
 
-		ctx := context.Background()
 		var cursor string
 		updatedCount := 0
 		for {

--- a/cmd/av/init.go
+++ b/cmd/av/init.go
@@ -15,12 +15,13 @@ var initCmd = &cobra.Command{
 	Short: "Initialize the repository for Aviator CLI",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) (reterr error) {
-		repo, err := getRepo()
+		ctx := cmd.Context()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
 
-		db, _, err := getOrCreateDB(repo)
+		db, _, err := getOrCreateDB(ctx, repo)
 		if err != nil {
 			return err
 		}
@@ -31,12 +32,12 @@ var initCmd = &cobra.Command{
 		})
 		defer cu.Cleanup()
 
-		client, err := getGitHubClient()
+		client, err := getGitHubClient(ctx)
 		if err != nil {
 			return err
 		}
 
-		origin, err := repo.Origin()
+		origin, err := repo.Origin(ctx)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -42,20 +43,21 @@ var rootCmd = &cobra.Command{
 
 	// Run setup before invoking any child commands.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 		if rootFlags.Debug {
 			logrus.SetLevel(logrus.DebugLevel)
 			logrus.WithField("av_version", config.Version).Debug("enabled debug logging")
 		}
 
 		repoConfigDir := ""
-		repo, err := getRepo()
+		repo, err := getRepo(ctx)
 		// If we weren't able to load the Git repo, that probably just means the
 		// command isn't being run from inside a repo. That's fine, we just
 		// don't need to bother reading repo-local config.
 		if err != nil {
 			logrus.WithError(err).Debug("unable to load Git repo (probably not inside a repo)")
 		} else {
-			gitCommonDir, err := repo.Git("rev-parse", "--git-common-dir")
+			gitCommonDir, err := repo.Git(ctx, "rev-parse", "--git-common-dir")
 			if err != nil {
 				logrus.WithError(err).Warning("failed to determine $GIT_COMMON_DIR")
 			} else {
@@ -182,13 +184,13 @@ var (
 	lazyGithubClient *gh.Client
 )
 
-func discoverGitHubAPIToken() string {
+func discoverGitHubAPIToken(ctx context.Context) string {
 	if config.Av.GitHub.Token != "" {
 		return config.Av.GitHub.Token
 	}
 	if ghCli, err := exec.LookPath("gh"); err == nil {
 		var stdout bytes.Buffer
-		cmd := exec.Command(ghCli, "auth", "token")
+		cmd := exec.CommandContext(ctx, ghCli, "auth", "token")
 		cmd.Stdout = &stdout
 		cmd.Stderr = nil
 		if err := cmd.Run(); err == nil {
@@ -198,14 +200,14 @@ func discoverGitHubAPIToken() string {
 	return ""
 }
 
-func getGitHubClient() (*gh.Client, error) {
-	token := discoverGitHubAPIToken()
+func getGitHubClient(ctx context.Context) (*gh.Client, error) {
+	token := discoverGitHubAPIToken(ctx)
 	if token == "" {
 		return nil, errNoGitHubToken
 	}
 	var err error
 	once.Do(func() {
-		lazyGithubClient, err = gh.NewClient(token)
+		lazyGithubClient, err = gh.NewClient(ctx, token)
 	})
 	return lazyGithubClient, err
 }

--- a/cmd/av/orphan.go
+++ b/cmd/av/orphan.go
@@ -15,19 +15,20 @@ var orphanCmd = &cobra.Command{
 	Short: "Orphan branches that are managed by av",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		repo, err := getRepo()
+		ctx := cmd.Context()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
 
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
 		tx := db.WriteTx()
 		defer tx.Abort()
 
-		currentBranch, err := repo.CurrentBranchName()
+		currentBranch, err := repo.CurrentBranchName(ctx)
 		if err != nil {
 			return errors.WrapIf(err, "failed to determine current branch")
 		}

--- a/cmd/av/pr_queue.go
+++ b/cmd/av/pr_queue.go
@@ -12,6 +12,6 @@ var prQueueCmd = &cobra.Command{
 	Args:         cobra.NoArgs,
 	// error or reterr from emperror.dev/errors here?
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		return queue()
+		return queue(cmd.Context())
 	},
 }

--- a/cmd/av/pr_status.go
+++ b/cmd/av/pr_status.go
@@ -20,12 +20,13 @@ var prStatusCmd = &cobra.Command{
 	SilenceUsage: true,
 	Args:         cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		variables, err := getQueryVariables()
+		ctx := cmd.Context()
+		variables, err := getQueryVariables(ctx)
 		if err != nil {
 			return err
 		}
 
-		client, err := avgql.NewClient()
+		client, err := avgql.NewClient(ctx)
 		if err != nil {
 			return err
 		}
@@ -197,20 +198,20 @@ var prStatusCmd = &cobra.Command{
 	},
 }
 
-func getQueryVariables() (map[string]interface{}, error) {
-	repo, err := getRepo()
+func getQueryVariables(ctx context.Context) (map[string]interface{}, error) {
+	repo, err := getRepo(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	db, err := getDB(repo)
+	db, err := getDB(ctx, repo)
 	if err != nil {
 		return nil, err
 	}
 
 	tx := db.ReadTx()
 
-	currentBranchName, err := repo.CurrentBranchName()
+	currentBranchName, err := repo.CurrentBranchName(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/av/prev.go
+++ b/cmd/av/prev.go
@@ -23,20 +23,21 @@ var prevCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get the previous branches so we can checkout the nth one
-		repo, err := getRepo()
+		ctx := cmd.Context()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
 		tx := db.ReadTx()
-		currentBranch, err := repo.CurrentBranchName()
+		currentBranch, err := repo.CurrentBranchName(ctx)
 		if err != nil {
 			return err
 		}
-		isCurrentBranchTrunk, err := repo.IsTrunkBranch(currentBranch)
+		isCurrentBranchTrunk, err := repo.IsTrunkBranch(ctx, currentBranch)
 		if err != nil {
 			return err
 		} else if isCurrentBranchTrunk {
@@ -80,7 +81,7 @@ var prevCmd = &cobra.Command{
 			branchToCheckout = previousBranches[len(previousBranches)-n]
 		}
 
-		if _, err := repo.CheckoutBranch(&git.CheckoutBranch{
+		if _, err := repo.CheckoutBranch(ctx, &git.CheckoutBranch{
 			Name: branchToCheckout,
 		}); err != nil {
 			return err

--- a/cmd/av/restack.go
+++ b/cmd/av/restack.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"emperror.dev/errors"
@@ -32,11 +33,12 @@ var restackCmd = &cobra.Command{
 	Short: "Rebase the stacked branches",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		repo, err := getRepo()
+		ctx := cmd.Context()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
@@ -162,9 +164,10 @@ func (vm *restackViewModel) writeState(state *sequencerui.RestackState) error {
 }
 
 func (vm *restackViewModel) createState() (*sequencerui.RestackState, error) {
-	var state sequencerui.RestackState
+	ctx := context.Background()
 
-	status, err := vm.repo.Status()
+	var state sequencerui.RestackState
+	status, err := vm.repo.Status(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -186,6 +189,7 @@ func (vm *restackViewModel) createState() (*sequencerui.RestackState, error) {
 	}
 
 	ops, err := planner.PlanForRestack(
+		ctx,
 		vm.db.ReadTx(),
 		vm.repo,
 		currentBranchRef,

--- a/cmd/av/stack_branchcommit.go
+++ b/cmd/av/stack_branchcommit.go
@@ -26,10 +26,13 @@ var stackBranchCommitCmd = &cobra.Command{
 	SilenceUsage: true,
 	Args:         cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) (reterr error) {
-		return branchAndCommit(stackBranchCommitFlags.BranchName,
+		return branchAndCommit(
+			cmd.Context(),
+			stackBranchCommitFlags.BranchName,
 			stackBranchCommitFlags.Message,
 			stackBranchCommitFlags.All,
 			stackBranchCommitFlags.AllModified,
-			"")
+			"",
+		)
 	},
 }

--- a/cmd/av/stack_foreach.go
+++ b/cmd/av/stack_foreach.go
@@ -42,16 +42,17 @@ Examples:
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		repo, err := getRepo()
+		ctx := cmd.Context()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
 		tx := db.ReadTx()
-		currentBranch, err := repo.CurrentBranchName()
+		currentBranch, err := repo.CurrentBranchName(ctx)
 		if err != nil {
 			return err
 		}
@@ -81,7 +82,7 @@ Examples:
 			_, _ = fmt.Fprint(os.Stderr,
 				"  - switching to branch ", colors.UserInput(branch), "\n",
 			)
-			if _, err := repo.CheckoutBranch(&git.CheckoutBranch{Name: branch}); err != nil {
+			if _, err := repo.CheckoutBranch(ctx, &git.CheckoutBranch{Name: branch}); err != nil {
 				return errors.Wrapf(err, "failed to switch to branch %q", branch)
 			}
 			cmd := exec.Command(args[0], args[1:]...)
@@ -95,7 +96,7 @@ Examples:
 		// Switch back to the original branch.
 		// We only do this on success, because on failure, it's likely that the
 		// user will want to be on the branch that had issues.
-		if _, err := repo.CheckoutBranch(&git.CheckoutBranch{Name: currentBranch}); err != nil {
+		if _, err := repo.CheckoutBranch(ctx, &git.CheckoutBranch{Name: currentBranch}); err != nil {
 			return errors.Wrapf(err, "failed to switch back to branch %q", currentBranch)
 		}
 		return nil

--- a/cmd/av/stack_submit.go
+++ b/cmd/av/stack_submit.go
@@ -20,6 +20,6 @@ Create pull requests for every branch in the stack
 If the --current flag is given, this command will create pull requests up to the current branch.`),
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		return submitAll(stackSubmitFlags.Current, stackSubmitFlags.Draft)
+		return submitAll(cmd.Context(), stackSubmitFlags.Current, stackSubmitFlags.Draft)
 	},
 }

--- a/cmd/av/tidy.go
+++ b/cmd/av/tidy.go
@@ -23,17 +23,18 @@ does not delete Git branches.
 	SilenceUsage: true,
 	Args:         cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		repo, err := getRepo()
+		ctx := cmd.Context()
+		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
 		}
 
-		db, err := getDB(repo)
+		db, err := getDB(ctx, repo)
 		if err != nil {
 			return err
 		}
 
-		deleted, orphaned, err := actions.TidyDB(repo, db)
+		deleted, orphaned, err := actions.TidyDB(ctx, repo, db)
 		if err != nil {
 			return err
 		}

--- a/docs/convert-manpages.go
+++ b/docs/convert-manpages.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"log"
 	"os"
@@ -105,13 +106,13 @@ func previewMarkdown(fp string) error {
 
 	switch runtime.GOOS {
 	case "darwin", "freebsd":
-		cmd := exec.Command("mandoc", "-a")
+		cmd := exec.CommandContext(context.Background(), "mandoc", "-a")
 		cmd.Stdin = bytes.NewBuffer(roff)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
 	case "linux":
-		cmd := exec.Command("man", "-l", "-")
+		cmd := exec.CommandContext(context.Background(), "man", "-l", "-")
 		cmd.Stdin = bytes.NewBuffer(roff)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/e2e_tests/av.go
+++ b/e2e_tests/av.go
@@ -2,6 +2,7 @@ package e2e_tests
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,7 +23,7 @@ func init() {
 		panic(err)
 	}
 
-	cmd := exec.Command("go", "build", "../cmd/av")
+	cmd := exec.CommandContext(context.Background(), "go", "build", "../cmd/av")
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 
@@ -44,7 +45,7 @@ type AvOutput struct {
 
 func Cmd(t *testing.T, exe string, args ...string) AvOutput {
 	t.Helper()
-	cmd := exec.Command(exe, args...)
+	cmd := exec.CommandContext(t.Context(), exe, args...)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	cmd.Stdout = stdout

--- a/internal/actions/tidy.go
+++ b/internal/actions/tidy.go
@@ -1,20 +1,26 @@
 package actions
 
 import (
+	"context"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 )
 
 // TidyDB removes deleted branches from the metadata and returns number of branches removed from the
 // DB.
-func TidyDB(repo *git.Repo, db meta.DB) (map[string]bool, map[string]bool, error) {
+func TidyDB(
+	ctx context.Context,
+	repo *git.Repo,
+	db meta.DB,
+) (map[string]bool, map[string]bool, error) {
 	tx := db.WriteTx()
 	defer tx.Abort()
 	branches := tx.AllBranches()
 
 	deleted := make(map[string]bool)
 	for name := range branches {
-		if _, err := repo.Git("show-ref", "refs/heads/"+name); err != nil {
+		if _, err := repo.Git(ctx, "show-ref", "refs/heads/"+name); err != nil {
 			// Ref doesn't exist. Should be removed.
 			deleted[name] = true
 		} else {

--- a/internal/avgql/client.go
+++ b/internal/avgql/client.go
@@ -12,11 +12,11 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func NewClient() (*graphql.Client, error) {
+func NewClient(ctx context.Context) (*graphql.Client, error) {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: config.Av.Aviator.APIToken},
 	)
-	httpClient := oauth2.NewClient(context.Background(), src)
+	httpClient := oauth2.NewClient(ctx, src)
 	apiURL := os.Getenv("AV_GRAPHQL_URL")
 	if apiURL == "" {
 		baseURL, err := url.Parse(config.Av.Aviator.APIHost)

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -42,7 +42,7 @@ func TestEditor(t *testing.T) {
 			eolcomments: true,
 		},
 	} {
-		res, err := Launch(nil, Config{
+		res, err := Launch(t.Context(), nil, Config{
 			Text:              tt.in,
 			CommentPrefix:     "%%",
 			Command:           tt.command,

--- a/internal/gh/client.go
+++ b/internal/gh/client.go
@@ -20,14 +20,14 @@ type Client struct {
 
 // NewClient creates a new GitHub client.
 // It takes configuration from the global config.Av.GitHub variable.
-func NewClient(token string) (*Client, error) {
+func NewClient(ctx context.Context, token string) (*Client, error) {
 	if token == "" {
 		return nil, errors.Errorf("no GitHub token provided (do you need to configure one?)")
 	}
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
-	httpClient := oauth2.NewClient(context.Background(), src)
+	httpClient := oauth2.NewClient(ctx, src)
 	var gh *githubv4.Client
 	if config.Av.GitHub.BaseURL == "" {
 		gh = githubv4.NewClient(httpClient)

--- a/internal/gh/ghui/fetch.go
+++ b/internal/gh/ghui/fetch.go
@@ -174,7 +174,7 @@ func (vm *GitHubFetchModel) View() string {
 
 func (vm *GitHubFetchModel) runGitFetch() tea.Msg {
 	remote := vm.repo.GetRemoteName()
-	if _, err := vm.repo.Git("fetch", remote); err != nil {
+	if _, err := vm.repo.Git(context.Background(), "fetch", remote); err != nil {
 		return errors.Errorf("failed to fetch from %s: %v", remote, err)
 	}
 	return &GitHubFetchProgress{gitFetchIsDone: true}

--- a/internal/gh/ghui/push.go
+++ b/internal/gh/ghui/push.go
@@ -285,6 +285,7 @@ func (vm *GitHubPushModel) runUpdate() (ret tea.Msg) {
 }
 
 func (vm *GitHubPushModel) runGitPush() error {
+	ctx := context.Background()
 	pushArgs := []string{"push", vm.repo.GetRemoteName(), "--atomic"}
 	for _, branch := range vm.pushCandidates {
 		// Do a compare-and-swap to be strict on what we show as a difference.
@@ -303,7 +304,7 @@ func (vm *GitHubPushModel) runGitPush() error {
 			fmt.Sprintf("%s:%s", branch.localCommit.Hash.String(), branch.branch.String()),
 		)
 	}
-	res, err := vm.repo.Run(&git.RunOpts{
+	res, err := vm.repo.Run(ctx, &git.RunOpts{
 		Args: pushArgs,
 	})
 	if err != nil {
@@ -314,13 +315,13 @@ func (vm *GitHubPushModel) runGitPush() error {
 	}
 
 	for _, branch := range vm.pushCandidates {
-		if err := vm.repo.BranchSetConfig(branch.branch.Short(), "av-pushed-remote", vm.repo.GetRemoteName()); err != nil {
+		if err := vm.repo.BranchSetConfig(ctx, branch.branch.Short(), "av-pushed-remote", vm.repo.GetRemoteName()); err != nil {
 			return err
 		}
-		if err := vm.repo.BranchSetConfig(branch.branch.Short(), "av-pushed-ref", branch.branch.String()); err != nil {
+		if err := vm.repo.BranchSetConfig(ctx, branch.branch.Short(), "av-pushed-ref", branch.branch.String()); err != nil {
 			return err
 		}
-		if err := vm.repo.BranchSetConfig(branch.branch.Short(), "av-pushed-commit", branch.localCommit.Hash.String()); err != nil {
+		if err := vm.repo.BranchSetConfig(ctx, branch.branch.Short(), "av-pushed-commit", branch.localCommit.Hash.String()); err != nil {
 			return err
 		}
 	}

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -1,10 +1,13 @@
 package git
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // BranchDelete deletes the given branches (equivalent to `git branch -D`).
-func (r *Repo) BranchDelete(names ...string) error {
-	_, err := r.Run(&RunOpts{
+func (r *Repo) BranchDelete(ctx context.Context, names ...string) error {
+	_, err := r.Run(ctx, &RunOpts{
 		Args:      append([]string{"branch", "-D"}, names...),
 		ExitError: true,
 	})
@@ -13,8 +16,8 @@ func (r *Repo) BranchDelete(names ...string) error {
 
 // BranchSetConfig sets a config on the given branch (equivalent to `git config
 // branch.<branch>.<key> <value>`).
-func (r *Repo) BranchSetConfig(name, key, value string) error {
-	_, err := r.Run(&RunOpts{
+func (r *Repo) BranchSetConfig(ctx context.Context, name, key, value string) error {
+	_, err := r.Run(ctx, &RunOpts{
 		Args:      []string{"config", fmt.Sprintf("branch.%s.%s", name, key), value},
 		ExitError: true,
 	})

--- a/internal/git/catfile.go
+++ b/internal/git/catfile.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -30,14 +31,14 @@ type GetRefsItem struct {
 
 // GetRefs reads the contents of the specified objects from the repository.
 // This corresponds to the `git cat-file --batch` command.
-func (r *Repo) GetRefs(opts *GetRefs) ([]*GetRefsItem, error) {
+func (r *Repo) GetRefs(ctx context.Context, opts *GetRefs) ([]*GetRefsItem, error) {
 	input := new(bytes.Buffer)
 	for _, item := range opts.Revisions {
 		input.WriteString(item)
 		input.WriteString("\n")
 	}
 
-	res, err := r.Run(&RunOpts{
+	res, err := r.Run(ctx, &RunOpts{
 		Args:      []string{"cat-file", "--batch"},
 		Stdin:     input,
 		ExitError: true,

--- a/internal/git/cherrypick.go
+++ b/internal/git/cherrypick.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -48,7 +49,7 @@ func (e ErrCherryPickConflict) Error() string {
 
 // CherryPick applies the given commits on top of the current HEAD.
 // If there are conflicts, ErrCherryPickConflict is returned.
-func (r *Repo) CherryPick(opts CherryPick) error {
+func (r *Repo) CherryPick(ctx context.Context, opts CherryPick) error {
 	args := []string{"cherry-pick"}
 
 	if opts.Resume != "" {
@@ -63,7 +64,7 @@ func (r *Repo) CherryPick(opts CherryPick) error {
 		args = append(args, opts.Commits...)
 	}
 
-	run, err := r.Run(&RunOpts{
+	run, err := r.Run(ctx, &RunOpts{
 		Args: args,
 	})
 	if err != nil {

--- a/internal/git/cherrypick_test.go
+++ b/internal/git/cherrypick_test.go
@@ -22,7 +22,7 @@ func TestRepo_CherryPick(t *testing.T) {
 	repo.CheckoutCommit(t, c1)
 	require.NoError(
 		t,
-		repo.AsAvGitRepo().CherryPick(git.CherryPick{Commits: []string{c2.String()}}),
+		repo.AsAvGitRepo().CherryPick(t.Context(), git.CherryPick{Commits: []string{c2.String()}}),
 	)
 	contents, err := os.ReadFile(filepath.Join(repo.RepoDir, "file"))
 	require.NoError(t, err)
@@ -33,13 +33,13 @@ func TestRepo_CherryPick(t *testing.T) {
 	require.NoError(
 		t,
 		repo.AsAvGitRepo().
-			CherryPick(git.CherryPick{Commits: []string{c2.String()}, FastForward: true}),
+			CherryPick(t.Context(), git.CherryPick{Commits: []string{c2.String()}, FastForward: true}),
 	)
 	_, err = os.ReadFile(filepath.Join(repo.RepoDir, "file"))
 	require.NoError(t, err)
 
 	// We're back to c2, so trying to cherry-pick c1 should fail.
-	err = repo.AsAvGitRepo().CherryPick(git.CherryPick{Commits: []string{c1.String()}})
+	err = repo.AsAvGitRepo().CherryPick(t.Context(), git.CherryPick{Commits: []string{c1.String()}})
 	conflictErr, ok := errutils.As[git.ErrCherryPickConflict](err)
 	require.True(t, ok, "expected cherry-pick conflict")
 	assert.Equal(t, c1.String(), conflictErr.ConflictingCommit)

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"context"
+
 	"emperror.dev/errors"
 )
 
@@ -28,7 +30,7 @@ type Diff struct {
 	Contents string
 }
 
-func (r *Repo) Diff(d *DiffOpts) (*Diff, error) {
+func (r *Repo) Diff(ctx context.Context, d *DiffOpts) (*Diff, error) {
 	args := []string{"diff", "--exit-code"}
 	if d.Quiet {
 		args = append(args, "--quiet")
@@ -47,7 +49,7 @@ func (r *Repo) Diff(d *DiffOpts) (*Diff, error) {
 	args = append(args, "--")
 	args = append(args, d.Paths...)
 
-	output, err := r.Run(&RunOpts{
+	output, err := r.Run(ctx, &RunOpts{
 		Args: args,
 	})
 	if err != nil {

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -16,7 +16,7 @@ func TestRepoDiffAmbiguousPathName(t *testing.T) {
 	repo.CheckoutBranch(t, plumbing.NewBranchReferenceName("foo"))
 
 	repo.CommitFile(t, "foo", "foo")
-	diff, err := repo.AsAvGitRepo().Diff(&git.DiffOpts{
+	diff, err := repo.AsAvGitRepo().Diff(t.Context(), &git.DiffOpts{
 		Quiet:      true,
 		Specifiers: []string{"main", "foo"},
 	})

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -12,13 +12,13 @@ import (
 func TestOrigin(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
 	repo.Git(t, "remote", "set-url", "origin", "https://github.com/aviator-co/av.git")
-	origin, err := repo.AsAvGitRepo().Origin()
+	origin, err := repo.AsAvGitRepo().Origin(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "aviator-co/av", origin.RepoSlug)
 
 	repo.Git(t, "remote", "set-url", "origin", "git@github.com:aviator-co/av.git")
 	require.NoError(t, err)
-	origin, err = repo.AsAvGitRepo().Origin()
+	origin, err = repo.AsAvGitRepo().Origin(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "aviator-co/av", origin.RepoSlug)
 }
@@ -26,13 +26,13 @@ func TestOrigin(t *testing.T) {
 func TestTrunkBranches(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
 
-	branches, err := repo.AsAvGitRepo().TrunkBranches()
+	branches, err := repo.AsAvGitRepo().TrunkBranches(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, branches, []string{"main"})
 
 	// add some branches to AdditionalTrunkBranches
 	config.Av.AdditionalTrunkBranches = []string{"develop", "staging"}
-	branches, err = repo.AsAvGitRepo().TrunkBranches()
+	branches, err = repo.AsAvGitRepo().TrunkBranches(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, branches, []string{"main", "develop", "staging"})
 }

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -45,13 +45,13 @@ func NewTempRepoWithGitHubServer(t *testing.T, serverURL string) *GitTestRepo {
 		remoteDir = filepath.Join(t.TempDir(), "remote")
 		require.NoError(t, os.MkdirAll(remoteDir, 0o755))
 	}
-	init := exec.Command("git", "init", "--initial-branch=main")
+	init := exec.CommandContext(t.Context(), "git", "init", "--initial-branch=main")
 	init.Dir = dir
 
 	err := init.Run()
 	require.NoError(t, err, "failed to initialize git repository")
 
-	remoteInit := exec.Command("git", "init", "--bare")
+	remoteInit := exec.CommandContext(t.Context(), "git", "init", "--bare")
 	remoteInit.Dir = remoteDir
 
 	err = remoteInit.Run()
@@ -123,7 +123,7 @@ func (r *GitTestRepo) AsAvGitRepo() *avgit.Repo {
 
 func (r *GitTestRepo) Git(t *testing.T, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	cmd.Stdout = stdout

--- a/internal/git/listrefs.go
+++ b/internal/git/listrefs.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"strings"
 
 	"emperror.dev/errors"
@@ -22,7 +23,7 @@ type RefInfo struct {
 
 // ListRefs lists all refs in the repository (optionally matching a specific
 // pattern).
-func (r *Repo) ListRefs(showRef *ListRefs) ([]RefInfo, error) {
+func (r *Repo) ListRefs(ctx context.Context, showRef *ListRefs) ([]RefInfo, error) {
 	// We want a subset of information about each ref, so we can tell Git to
 	// print only specific fields. %00 is a null byte, which is the delimiter
 	// that we split on while parsing the output.
@@ -35,7 +36,7 @@ func (r *Repo) ListRefs(showRef *ListRefs) ([]RefInfo, error) {
 	if len(showRef.Patterns) > 0 {
 		args = append(args, showRef.Patterns...)
 	}
-	out, err := r.Git(args...)
+	out, err := r.Git(ctx, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/listrefs_test.go
+++ b/internal/git/listrefs_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRepo_ListRefs(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
-	refs, err := repo.AsAvGitRepo().ListRefs(&git.ListRefs{
+	refs, err := repo.AsAvGitRepo().ListRefs(t.Context(), &git.ListRefs{
 		Patterns: []string{"refs/heads/*"},
 	})
 	require.NoError(t, err)

--- a/internal/git/log.go
+++ b/internal/git/log.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"io"
 	"regexp"
 	"strconv"
@@ -22,11 +23,11 @@ type LogOpts struct {
 }
 
 // Log returns a list of commits specified by the range.
-func (r *Repo) Log(opts LogOpts) ([]*CommitInfo, error) {
+func (r *Repo) Log(ctx context.Context, opts LogOpts) ([]*CommitInfo, error) {
 	args := []string{"log", "--format=%H%x00%h%x00%s%x00%b%x00"}
 	args = append(args, opts.RevisionRange...)
 	args = append(args, "--")
-	res, err := r.Run(&RunOpts{
+	res, err := r.Run(ctx, &RunOpts{
 		Args:      args,
 		ExitError: true,
 	})

--- a/internal/git/log_test.go
+++ b/internal/git/log_test.go
@@ -24,7 +24,7 @@ func TestRepo_Log(t *testing.T) {
 	)
 
 	cis, err := repo.AsAvGitRepo().
-		Log(git.LogOpts{RevisionRange: []string{c2.String(), "^" + c1.String() + "^1"}})
+		Log(t.Context(), git.LogOpts{RevisionRange: []string{c2.String(), "^" + c1.String() + "^1"}})
 	assert.NoError(t, err)
 	assert.Equal(t, []*git.CommitInfo{
 		{

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"regexp"
 	"strings"
 
@@ -27,12 +28,12 @@ type RebaseOpts struct {
 	Branch string
 }
 
-func (r *Repo) Rebase(opts RebaseOpts) (*Output, error) {
+func (r *Repo) Rebase(ctx context.Context, opts RebaseOpts) (*Output, error) {
 	// TODO: probably move the parseRebaseOutput logic in sync to here
 
 	args := []string{"rebase"}
 	if opts.Continue {
-		return r.Run(&RunOpts{
+		return r.Run(ctx, &RunOpts{
 			Args: []string{"rebase", "--continue"},
 			// `git rebase --continue` will open an editor to allow the user
 			// to edit the commit message, which we don't want here. Instead, we
@@ -41,11 +42,11 @@ func (r *Repo) Rebase(opts RebaseOpts) (*Output, error) {
 			Env: []string{"GIT_EDITOR=true"},
 		})
 	} else if opts.Abort {
-		return r.Run(&RunOpts{
+		return r.Run(ctx, &RunOpts{
 			Args: []string{"rebase", "--abort"},
 		})
 	} else if opts.Skip {
-		return r.Run(&RunOpts{
+		return r.Run(ctx, &RunOpts{
 			Args: []string{"rebase", "--skip"},
 		})
 	}
@@ -57,12 +58,12 @@ func (r *Repo) Rebase(opts RebaseOpts) (*Output, error) {
 		args = append(args, opts.Branch)
 	}
 
-	return r.Run(&RunOpts{Args: args})
+	return r.Run(ctx, &RunOpts{Args: args})
 }
 
 // RebaseParse runs a `git rebase` and parses the output into a RebaseResult.
-func (r *Repo) RebaseParse(opts RebaseOpts) (*RebaseResult, error) {
-	out, err := r.Rebase(opts)
+func (r *Repo) RebaseParse(ctx context.Context, opts RebaseOpts) (*RebaseResult, error) {
+	out, err := r.Rebase(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/revlist.go
+++ b/internal/git/revlist.go
@@ -1,5 +1,7 @@
 package git
 
+import "context"
+
 type RevListOpts struct {
 	// A list of commit roots, or exclusions if the commit sha starts with a
 	// caret (^). As a special case, "foo..bar" is equivalent to "foo ^bar"
@@ -15,7 +17,7 @@ type RevListOpts struct {
 
 // RevList list commits that are reachable from the given commits (excluding
 // commits reachable from the given exclusions).
-func (r *Repo) RevList(opts RevListOpts) ([]string, error) {
+func (r *Repo) RevList(ctx context.Context, opts RevListOpts) ([]string, error) {
 	args := []string{"rev-list"}
 	if opts.Reverse {
 		args = append(args, "--reverse")
@@ -23,7 +25,7 @@ func (r *Repo) RevList(opts RevListOpts) ([]string, error) {
 	args = append(args, opts.Specifiers...)
 	// Unambiguous the positional arguments
 	args = append(args, "--")
-	res, err := r.Run(&RunOpts{
+	res, err := r.Run(ctx, &RunOpts{
 		Args:      args,
 		Env:       nil,
 		ExitError: true,

--- a/internal/git/show.go
+++ b/internal/git/show.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"strings"
 
 	"emperror.dev/errors"
@@ -27,10 +28,10 @@ func (c CommitInfo) BodyWithPrefix(prefix string) []string {
 	return lines
 }
 
-func (r *Repo) CommitInfo(opts CommitInfoOpts) (*CommitInfo, error) {
+func (r *Repo) CommitInfo(ctx context.Context, opts CommitInfoOpts) (*CommitInfo, error) {
 	// Need --quiet to suppress the diff that would otherwise be printed at the
 	// end
-	res, err := r.Run(&RunOpts{
+	res, err := r.Run(ctx, &RunOpts{
 		Args:      []string{"show", "--quiet", "--format=%H%n%s%n%b", opts.Rev},
 		ExitError: true,
 	})

--- a/internal/git/status.go
+++ b/internal/git/status.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"regexp"
 	"strings"
 )
@@ -57,8 +58,8 @@ var (
 	patternFileUntracked = regexp.MustCompile(`\? (.+)`)
 )
 
-func (r *Repo) Status() (GitStatus, error) {
-	body, err := r.Git("status", "--porcelain=v2", "--branch", "--untracked-files")
+func (r *Repo) Status(ctx context.Context) (GitStatus, error) {
+	body, err := r.Git(ctx, "status", "--porcelain=v2", "--branch", "--untracked-files")
 	if err != nil {
 		return GitStatus{}, err
 	}

--- a/internal/meta/refmeta/import.go
+++ b/internal/meta/refmeta/import.go
@@ -1,6 +1,8 @@
 package refmeta
 
 import (
+	"context"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/cleanup"
@@ -8,7 +10,7 @@ import (
 )
 
 // Import imports all ref metadata from the git repo into the database.
-func Import(repo *git.Repo, db meta.DB) error {
+func Import(ctx context.Context, repo *git.Repo, db meta.DB) error {
 	tx := db.WriteTx()
 	cu := cleanup.New(func() { tx.Abort() })
 	defer cu.Cleanup()
@@ -19,7 +21,7 @@ func Import(repo *git.Repo, db meta.DB) error {
 	}
 	tx.SetRepository(repoMeta)
 
-	allBranchMetas, err := ReadAllBranches(repo)
+	allBranchMetas, err := ReadAllBranches(ctx, repo)
 	if err != nil {
 		return err
 	}

--- a/internal/reorder/deletebranch.go
+++ b/internal/reorder/deletebranch.go
@@ -1,6 +1,7 @@
 package reorder
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -39,7 +40,7 @@ func (d DeleteBranchCmd) Execute(ctx *Context) error {
 		return nil
 	}
 
-	_, err := ctx.Repo.Run(&git.RunOpts{
+	_, err := ctx.Repo.Run(context.Background(), &git.RunOpts{
 		Args:      []string{"branch", "--delete", "--force", d.Name},
 		ExitError: true,
 	})

--- a/internal/reorder/editor.go
+++ b/internal/reorder/editor.go
@@ -1,6 +1,7 @@
 package reorder
 
 import (
+	"context"
 	"strings"
 
 	"github.com/aviator-co/av/internal/utils/sliceutils"
@@ -11,7 +12,7 @@ import (
 )
 
 // EditPlan opens the user's editor and allows them to edit the plan.
-func EditPlan(repo *git.Repo, plan []Cmd) ([]Cmd, error) {
+func EditPlan(ctx context.Context, repo *git.Repo, plan []Cmd) ([]Cmd, error) {
 	text := strings.Builder{}
 	for i, cmd := range plan {
 		if i > 0 && typeutils.Is[StackBranchCmd](cmd) {
@@ -25,7 +26,7 @@ func EditPlan(repo *git.Repo, plan []Cmd) ([]Cmd, error) {
 	}
 	text.WriteString(instructionsText)
 
-	res, err := editor.Launch(repo, editor.Config{
+	res, err := editor.Launch(ctx, repo, editor.Config{
 		Text:              text.String(),
 		CommentPrefix:     "#",
 		EndOfLineComments: true,

--- a/internal/reorder/pick.go
+++ b/internal/reorder/pick.go
@@ -1,6 +1,7 @@
 package reorder
 
 import (
+	"context"
 	"strings"
 
 	"github.com/aviator-co/av/internal/git"
@@ -17,7 +18,7 @@ type PickCmd struct {
 }
 
 func (p PickCmd) Execute(ctx *Context) error {
-	err := ctx.Repo.CherryPick(git.CherryPick{
+	err := ctx.Repo.CherryPick(context.Background(), git.CherryPick{
 		Commits: []string{p.Commit},
 		// Use FastForward to avoid always amending commits.
 		FastForward: true,
@@ -32,7 +33,7 @@ func (p PickCmd) Execute(ctx *Context) error {
 		return err
 	}
 
-	head, err := ctx.Repo.RevParse(&git.RevParse{Rev: "HEAD"})
+	head, err := ctx.Repo.RevParse(context.Background(), &git.RevParse{Rev: "HEAD"})
 	if err != nil {
 		return err
 	}

--- a/internal/reorder/plan_test.go
+++ b/internal/reorder/plan_test.go
@@ -45,7 +45,7 @@ func TestCreatePlan(t *testing.T) {
 	})
 	require.NoError(t, tx.Commit())
 
-	plan, err := CreatePlan(repo.AsAvGitRepo(), db.ReadTx(), "one")
+	plan, err := CreatePlan(t.Context(), repo.AsAvGitRepo(), db.ReadTx(), "one")
 	require.NoError(t, err)
 	for _, cmd := range plan {
 		t.Log(cmd.String())

--- a/internal/reorder/stackbranch.go
+++ b/internal/reorder/stackbranch.go
@@ -1,6 +1,7 @@
 package reorder
 
 import (
+	"context"
 	"strings"
 
 	"github.com/aviator-co/av/internal/utils/colors"
@@ -59,7 +60,7 @@ func (b StackBranchCmd) Execute(ctx *Context) error {
 		var err error
 
 		// We always start child branches at the HEAD of their parents.
-		headCommit, err = ctx.Repo.RevParse(&git.RevParse{Rev: b.Parent})
+		headCommit, err = ctx.Repo.RevParse(context.Background(), &git.RevParse{Rev: b.Parent})
 		if err != nil {
 			return err
 		}
@@ -71,10 +72,10 @@ func (b StackBranchCmd) Execute(ctx *Context) error {
 	if headCommit == "" {
 		headCommit = branch.Parent.Name
 	}
-	if _, err := ctx.Repo.Git("switch", "--force-create", b.Name); err != nil {
+	if _, err := ctx.Repo.Git(context.Background(), "switch", "--force-create", b.Name); err != nil {
 		return err
 	}
-	if _, err := ctx.Repo.Git("reset", "--hard", headCommit); err != nil {
+	if _, err := ctx.Repo.Git(context.Background(), "reset", "--hard", headCommit); err != nil {
 		return err
 	}
 	ctx.Print(

--- a/internal/sequencer/planner/planner.go
+++ b/internal/sequencer/planner/planner.go
@@ -1,6 +1,8 @@
 package planner
 
 import (
+	"context"
+
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
@@ -9,6 +11,7 @@ import (
 )
 
 func PlanForRestack(
+	ctx context.Context,
 	tx meta.ReadTx,
 	repo *git.Repo,
 	currentBranch plumbing.ReferenceName,
@@ -17,11 +20,11 @@ func PlanForRestack(
 	var targetBranches []plumbing.ReferenceName
 	var err error
 	if restackAll {
-		targetBranches, err = GetTargetBranches(tx, repo, false, AllBranches)
+		targetBranches, err = GetTargetBranches(ctx, tx, repo, false, AllBranches)
 	} else if restackCurrent {
-		targetBranches, err = GetTargetBranches(tx, repo, false, CurrentAndParents)
+		targetBranches, err = GetTargetBranches(ctx, tx, repo, false, CurrentAndParents)
 	} else {
-		targetBranches, err = GetTargetBranches(tx, repo, false, CurrentStack)
+		targetBranches, err = GetTargetBranches(ctx, tx, repo, false, CurrentStack)
 	}
 	if err != nil {
 		return nil, err
@@ -48,6 +51,7 @@ func PlanForRestack(
 }
 
 func PlanForSync(
+	ctx context.Context,
 	tx meta.ReadTx,
 	repo *git.Repo,
 	currentBranch plumbing.ReferenceName,
@@ -56,11 +60,11 @@ func PlanForSync(
 	var targetBranches []plumbing.ReferenceName
 	var err error
 	if restackAll {
-		targetBranches, err = GetTargetBranches(tx, repo, true, AllBranches)
+		targetBranches, err = GetTargetBranches(ctx, tx, repo, true, AllBranches)
 	} else if restackCurrent {
-		targetBranches, err = GetTargetBranches(tx, repo, true, CurrentAndParents)
+		targetBranches, err = GetTargetBranches(ctx, tx, repo, true, CurrentAndParents)
 	} else {
-		targetBranches, err = GetTargetBranches(tx, repo, true, CurrentStack)
+		targetBranches, err = GetTargetBranches(ctx, tx, repo, true, CurrentStack)
 	}
 	if err != nil {
 		return nil, err
@@ -103,6 +107,7 @@ func PlanForSync(
 }
 
 func PlanForReparent(
+	ctx context.Context,
 	tx meta.ReadTx,
 	repo *git.Repo,
 	currentBranch, newParentBranch plumbing.ReferenceName,
@@ -116,7 +121,7 @@ func PlanForReparent(
 			return nil, errors.New("cannot re-parent to a child branch")
 		}
 	}
-	isParentTrunk, err := repo.IsTrunkBranch(newParentBranch.Short())
+	isParentTrunk, err := repo.IsTrunkBranch(ctx, newParentBranch.Short())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sequencer/planner/targets.go
+++ b/internal/sequencer/planner/targets.go
@@ -1,6 +1,8 @@
 package planner
 
 import (
+	"context"
+
 	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -24,6 +26,7 @@ const (
 // If `includeStackRoots` is true, the stack root branches (the immediate children of the trunk
 // branches) are included in the result.
 func GetTargetBranches(
+	ctx context.Context,
 	tx meta.ReadTx,
 	repo *git.Repo,
 	includeStackRoots bool,
@@ -45,7 +48,7 @@ func GetTargetBranches(
 		return ret, nil
 	}
 	if mode == CurrentAndParents {
-		curr, err := repo.CurrentBranchName()
+		curr, err := repo.CurrentBranchName(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +69,7 @@ func GetTargetBranches(
 		return ret, nil
 	}
 	if mode == CurrentAndChildren {
-		curr, err := repo.CurrentBranchName()
+		curr, err := repo.CurrentBranchName(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -80,7 +83,7 @@ func GetTargetBranches(
 		}
 		return ret, nil
 	}
-	curr, err := repo.CurrentBranchName()
+	curr, err := repo.CurrentBranchName(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sequencer/sequencerui/ui.go
+++ b/internal/sequencer/sequencerui/ui.go
@@ -1,6 +1,7 @@
 package sequencerui
 
 import (
+	"context"
 	"strings"
 
 	"github.com/aviator-co/av/internal/git"
@@ -77,7 +78,7 @@ func (vm *RestackModel) Update(msg tea.Msg) (*RestackModel, tea.Cmd) {
 		if msg.err == nil && msg.result == nil {
 			// Finished the sequence.
 			if vm.State.InitialBranch != "" {
-				if _, err := vm.repo.CheckoutBranch(&git.CheckoutBranch{Name: vm.State.InitialBranch}); err != nil {
+				if _, err := vm.repo.CheckoutBranch(context.Background(), &git.CheckoutBranch{Name: vm.State.InitialBranch}); err != nil {
 					return vm, func() tea.Msg { return err }
 				}
 			}
@@ -202,11 +203,18 @@ func (vm *RestackModel) View() string {
 }
 
 func (vm *RestackModel) runSeqWithContinuationFlags() tea.Msg {
-	result, err := vm.State.Seq.Run(vm.repo, vm.db, vm.Abort, vm.Continue, vm.Skip)
+	result, err := vm.State.Seq.Run(
+		context.Background(),
+		vm.repo,
+		vm.db,
+		vm.Abort,
+		vm.Continue,
+		vm.Skip,
+	)
 	return &RestackProgress{result: result, err: err}
 }
 
 func (vm *RestackModel) runSeq() tea.Msg {
-	result, err := vm.State.Seq.Run(vm.repo, vm.db, false, false, false)
+	result, err := vm.State.Seq.Run(context.Background(), vm.repo, vm.db, false, false, false)
 	return &RestackProgress{result: result, err: err}
 }

--- a/internal/utils/browser/browser.go
+++ b/internal/utils/browser/browser.go
@@ -32,6 +32,7 @@
 package browser
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -39,7 +40,7 @@ import (
 )
 
 // Open tries to open url in a browser and reports whether it succeeded.
-func Open(url string) error {
+func Open(ctx context.Context, url string) error {
 	var args []string
 	if exe := os.Getenv("BROWSER"); exe != "" {
 		args = []string{exe}
@@ -59,7 +60,7 @@ func Open(url string) error {
 	if args == nil {
 		return errors.New("no open command found")
 	}
-	cmd := exec.Command(args[0], append(args[1:], url)...)
+	cmd := exec.CommandContext(ctx, args[0], append(args[1:], url)...)
 	if err := cmd.Start(); err != nil {
 		return err
 	}


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
