### PR TITLE
fix av squash command

### DIFF
--- a/cmd/av/squash.go
+++ b/cmd/av/squash.go
@@ -78,13 +78,14 @@ func runSquash(ctx context.Context, repo *git.Repo, db meta.DB) error {
 		return err
 	}
 
-	if len(commitIDs) <= 1 {
+	if len(commitIDs) < 2 {
 		return errors.New("no commits to squash")
 	}
 
-	firstCommitSha := commitIDs[0]
+	secondCommitHash := commitIDs[1]
 
-	if _, err := repo.Git(ctx, "reset", "--soft", firstCommitSha); err != nil {
+	// Reset to the second commit, so that we can squash into the first commit
+	if _, err := repo.Git(ctx, "reset", "--soft", secondCommitHash); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Realised when testing this that the CLI was squashing all the commits of a branch into the last commit of the parent. This was different to the behaviour of other stacked CLI tooling and not what I initially intended