### PR TITLE
Handle a special case in reparenting when the new parent is in the middle of the branch's history

### DIFF
--- a/internal/git/mergebase.go
+++ b/internal/git/mergebase.go
@@ -1,0 +1,16 @@
+package git
+
+import "context"
+
+func (r *Repo) IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error) {
+	out, err := r.Run(ctx, &RunOpts{
+		Args: []string{"merge-base", "--is-ancestor", ancestor, descendant},
+	})
+	if err != nil {
+		return false, err
+	}
+	if out.ExitCode != 0 && out.ExitCode != 1 {
+		return false, err
+	}
+	return out.ExitCode == 0, nil
+}


### PR DESCRIPTION
This is a special case that can happen when the user has two branches
that share some history. A scenario is:

1. A user creates a new branch from `main`. Add commits. Create a PR.
2. The user creates another branch off from the first branch, but with
   normal `git checkout -b` rather than `av branch`. Add commits. Create
   a PR. This new branch now contains all commits from the first branch.
   However, the parent of this new branch is still `main`.
3. The user tries to correct the parent-child relationship by
   reparenting the new branch onto the first branch. i.e. `av reparent
   --parent <first-branch>` on the new branch.

When this happens, and when there are multiple commits on the first
branch, Git tries to replay those commits when rebasing the second
branch onto the first branch, which can lead to conflicts.

There can be another way to create this situation, but after all, the
point here is that we don't need to change the Git history when the new
parent is already an ancestor of the current branch, and the new parent
also contains the previous parent as an ancestor. Detect this case in
sequencer and skip the rebase entirely. We still need to update the DB
in order to track the new parent-child relationship, so we do that while
skipping the Git rebase.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
