### PR TITLE
Use remote tracking branch for better commit detection in adopt

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -72,7 +72,8 @@ func (r *Repo) AvTmpDir() string {
 }
 
 func (r *Repo) DefaultBranch(ctx context.Context) (string, error) {
-	ref, err := r.Git(ctx, "symbolic-ref", "refs/remotes/origin/HEAD")
+	remoteName := r.GetRemoteName()
+	ref, err := r.Git(ctx, "symbolic-ref", fmt.Sprintf("refs/remotes/%s/HEAD", remoteName))
 	if err != nil {
 		logrus.WithError(err).Debug("failed to determine remote HEAD")
 		// this communicates with the remote, so we probably don't want to run
@@ -83,7 +84,7 @@ func (r *Repo) DefaultBranch(ctx context.Context) (string, error) {
 		)
 		return "", errors.New("failed to determine remote HEAD")
 	}
-	return strings.TrimPrefix(ref, "refs/remotes/origin/"), nil
+	return strings.TrimPrefix(ref, fmt.Sprintf("refs/remotes/%s/", remoteName)), nil
 }
 
 func (r *Repo) IsTrunkBranch(ctx context.Context, name string) (bool, error) {

--- a/internal/treedetector/detector.go
+++ b/internal/treedetector/detector.go
@@ -2,6 +2,7 @@ package treedetector
 
 import (
 	"context"
+	"fmt"
 
 	"emperror.dev/errors"
 	avgit "github.com/aviator-co/av/internal/git"
@@ -119,9 +120,9 @@ func getNearestTrunkCommit(
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
-	// TODO(draftcode): Check if the branch exists. Use the rtb as well.
+	rtb := fmt.Sprintf("refs/remotes/%s/%s", repo.GetRemoteName(), trunk)
 
-	mbArgs := []string{ref.String(), trunk}
+	mbArgs := []string{rtb, ref.String()}
 	// Per git-merge-base(1), this should return the nearest commits from HEAD among
 	// the trunk branches since we don't specify --octopus.
 	mb, err := repo.MergeBase(ctx, mbArgs...)


### PR DESCRIPTION
This improves the accuracy of detecting the nearest trunk commit by
using the remote tracking branch. Normally, we don't directly commit
anything on local trunk branches, so its remote tracking branch is
always ahead of the local trunk branch (if it exists). This change uses
that for better commit detection when checking which commit is a part of
the topic branches.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"error_handling","parentHead":"5b8f33a6229260bb0a516dbdb7f7479ee6f4cfb1","parentPull":595,"trunk":"master"}
```
-->
