### PR TITLE
Strip the PR metadata from the PR body

### DIFF
--- a/cmd/av/commit_common.go
+++ b/cmd/av/commit_common.go
@@ -36,7 +36,7 @@ type postCommitRestackViewModel struct {
 func (vm *postCommitRestackViewModel) Init() tea.Cmd {
 	state, err := vm.createState()
 	if err != nil {
-		return func() tea.Msg { return err }
+		return uiutils.ErrCmd(err)
 	}
 	vm.restackModel = sequencerui.NewRestackModel(vm.repo, vm.db)
 	vm.restackModel.State = state
@@ -51,13 +51,13 @@ func (vm *postCommitRestackViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return vm, cmd
 	case *sequencerui.RestackConflict:
 		if err := vm.writeState(vm.restackModel.State); err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		vm.quitWithConflict = true
 		return vm, tea.Quit
 	case *sequencerui.RestackAbort, *sequencerui.RestackDone:
 		if err := vm.writeState(nil); err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		return vm, tea.Quit
 	case tea.KeyMsg:

--- a/cmd/av/reparent.go
+++ b/cmd/av/reparent.go
@@ -68,7 +68,7 @@ type reparentViewModel struct {
 func (vm *reparentViewModel) Init() tea.Cmd {
 	state, err := vm.createState()
 	if err != nil {
-		return func() tea.Msg { return err }
+		return uiutils.ErrCmd(err)
 	}
 	vm.restackModel = sequencerui.NewRestackModel(vm.repo, vm.db)
 	vm.restackModel.State = state
@@ -83,13 +83,13 @@ func (vm *reparentViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return vm, cmd
 	case *sequencerui.RestackConflict:
 		if err := vm.writeState(vm.restackModel.State); err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		vm.quitWithConflict = true
 		return vm, tea.Quit
 	case *sequencerui.RestackAbort, *sequencerui.RestackDone:
 		if err := vm.writeState(nil); err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		return vm, tea.Quit
 	case tea.KeyMsg:

--- a/cmd/av/restack.go
+++ b/cmd/av/restack.go
@@ -59,19 +59,19 @@ type restackViewModel struct {
 func (vm *restackViewModel) Init() tea.Cmd {
 	state, err := vm.readState()
 	if err != nil {
-		return func() tea.Msg { return err }
+		return uiutils.ErrCmd(err)
 	}
 	if state == nil {
 		if restackFlags.Abort || restackFlags.Continue || restackFlags.Skip {
-			return func() tea.Msg { return errors.New("no restack in progress") }
+			return uiutils.ErrCmd(errors.New("no restack in progress"))
 		}
 		state, err = vm.createState()
 		if err != nil {
-			return func() tea.Msg { return err }
+			return uiutils.ErrCmd(err)
 		}
 	}
 	if state == nil {
-		return func() tea.Msg { return nothingToRestackError }
+		return uiutils.ErrCmd(nothingToRestackError)
 	}
 	vm.restackModel = sequencerui.NewRestackModel(vm.repo, vm.db)
 	vm.restackModel.State = state
@@ -90,13 +90,13 @@ func (vm *restackViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return vm, cmd
 	case *sequencerui.RestackConflict:
 		if err := vm.writeState(vm.restackModel.State); err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		vm.quitWithConflict = true
 		return vm, tea.Quit
 	case *sequencerui.RestackAbort, *sequencerui.RestackDone:
 		if err := vm.writeState(nil); err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		return vm, tea.Quit
 	case tea.KeyMsg:

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -171,7 +171,7 @@ func (vm *syncViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var err error
 		vm.githubFetchModel, err = vm.createGitHubFetchModel()
 		if err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		return vm, vm.githubFetchModel.Init()
 
@@ -188,18 +188,18 @@ func (vm *syncViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return vm, cmd
 	case *sequencerui.RestackConflict:
 		if err := vm.writeState(vm.restackModel.State); err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		vm.quitWithConflict = true
 		return vm, tea.Quit
 	case *sequencerui.RestackAbort:
 		if err := vm.writeState(nil); err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		return vm, tea.Quit
 	case *sequencerui.RestackDone:
 		if err := vm.writeState(nil); err != nil {
-			return vm, func() tea.Msg { return err }
+			return vm, uiutils.ErrCmd(err)
 		}
 		return vm, vm.initPushBranches()
 
@@ -319,18 +319,18 @@ type promptUserShouldSyncAllMsg struct{}
 func (vm *syncViewModel) initSync() tea.Cmd {
 	state, err := vm.readState()
 	if err != nil {
-		return func() tea.Msg { return err }
+		return uiutils.ErrCmd(err)
 	}
 	if state != nil {
 		return vm.continueWithState(state)
 	}
 	if syncFlags.Abort || syncFlags.Continue || syncFlags.Skip {
-		return func() tea.Msg { return errors.New("no restack in progress") }
+		return uiutils.ErrCmd(errors.New("no restack in progress"))
 	}
 
 	isTrunkBranch, err := vm.repo.IsCurrentBranchTrunk(context.Background())
 	if err != nil {
-		return func() tea.Msg { return err }
+		return uiutils.ErrCmd(err)
 	}
 	if isTrunkBranch && !syncFlags.All {
 		return func() tea.Msg {
@@ -368,10 +368,10 @@ func (vm *syncViewModel) initSync() tea.Cmd {
 func (vm *syncViewModel) initSequencerState() tea.Cmd {
 	state, err := vm.createState()
 	if err != nil {
-		return func() tea.Msg { return err }
+		return uiutils.ErrCmd(err)
 	}
 	if state == nil {
-		return func() tea.Msg { return nothingToRestackError }
+		return uiutils.ErrCmd(nothingToRestackError)
 	}
 	return vm.continueWithState(state)
 }

--- a/internal/gh/ghui/push.go
+++ b/internal/gh/ghui/push.go
@@ -142,7 +142,7 @@ func (vm *GitHubPushModel) Update(msg tea.Msg) (*GitHubPushModel, tea.Cmd) {
 			case "enter":
 				c, err := vm.pushPrompt.Value()
 				if err != nil {
-					return vm, func() tea.Msg { return err }
+					return vm, uiutils.ErrCmd(err)
 				}
 				vm.askingForConfirmation = false
 				vm.pushPrompt = nil

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -72,7 +72,8 @@ func (r *Repo) AvTmpDir() string {
 }
 
 func (r *Repo) DefaultBranch(ctx context.Context) (string, error) {
-	ref, err := r.Git(ctx, "symbolic-ref", "refs/remotes/origin/HEAD")
+	remoteName := r.GetRemoteName()
+	ref, err := r.Git(ctx, "symbolic-ref", fmt.Sprintf("refs/remotes/%s/HEAD", remoteName))
 	if err != nil {
 		logrus.WithError(err).Debug("failed to determine remote HEAD")
 		// this communicates with the remote, so we probably don't want to run
@@ -83,7 +84,7 @@ func (r *Repo) DefaultBranch(ctx context.Context) (string, error) {
 		)
 		return "", errors.New("failed to determine remote HEAD")
 	}
-	return strings.TrimPrefix(ref, "refs/remotes/origin/"), nil
+	return strings.TrimPrefix(ref, fmt.Sprintf("refs/remotes/%s/", remoteName)), nil
 }
 
 func (r *Repo) IsTrunkBranch(ctx context.Context, name string) (bool, error) {

--- a/internal/git/gitui/prune.go
+++ b/internal/git/gitui/prune.go
@@ -118,7 +118,7 @@ func (vm *PruneBranchModel) Update(msg tea.Msg) (*PruneBranchModel, tea.Cmd) {
 			case "enter":
 				c, err := vm.deletePrompt.Value()
 				if err != nil {
-					return vm, func() tea.Msg { return err }
+					return vm, uiutils.ErrCmd(err)
 				}
 				vm.askingForConfirmation = false
 				vm.deletePrompt = nil

--- a/internal/sequencer/sequencerui/ui.go
+++ b/internal/sequencer/sequencerui/ui.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aviator-co/av/internal/sequencer"
 	"github.com/aviator-co/av/internal/utils/colors"
 	"github.com/aviator-co/av/internal/utils/stackutils"
+	"github.com/aviator-co/av/internal/utils/uiutils"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -79,7 +80,7 @@ func (vm *RestackModel) Update(msg tea.Msg) (*RestackModel, tea.Cmd) {
 			// Finished the sequence.
 			if vm.State.InitialBranch != "" {
 				if _, err := vm.repo.CheckoutBranch(context.Background(), &git.CheckoutBranch{Name: vm.State.InitialBranch}); err != nil {
-					return vm, func() tea.Msg { return err }
+					return vm, uiutils.ErrCmd(err)
 				}
 			}
 			if vm.abortedBranch != "" {

--- a/internal/treedetector/detector.go
+++ b/internal/treedetector/detector.go
@@ -2,6 +2,7 @@ package treedetector
 
 import (
 	"context"
+	"fmt"
 
 	"emperror.dev/errors"
 	avgit "github.com/aviator-co/av/internal/git"
@@ -119,9 +120,9 @@ func getNearestTrunkCommit(
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
-	// TODO(draftcode): Check if the branch exists. Use the rtb as well.
+	rtb := fmt.Sprintf("refs/remotes/%s/%s", repo.GetRemoteName(), trunk)
 
-	mbArgs := []string{ref.String(), trunk}
+	mbArgs := []string{rtb, ref.String()}
 	// Per git-merge-base(1), this should return the nearest commits from HEAD among
 	// the trunk branches since we don't specify --octopus.
 	mb, err := repo.MergeBase(ctx, mbArgs...)

--- a/internal/utils/uiutils/err_cmd.go
+++ b/internal/utils/uiutils/err_cmd.go
@@ -1,0 +1,13 @@
+package uiutils
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// ErrCmd wraps an error into a tea.Cmd that returns the error as a message.
+//
+// Throughout the application, we capture error as a message and use it as a mean to halt the
+// application. This is a convenience function to trigger that behavior.
+func ErrCmd(err error) tea.Cmd {
+	return func() tea.Msg {
+		return err
+	}
+}


### PR DESCRIPTION
When editing an existing PR with `av pr --edit`, we fetch the existing
PR body from GitHub and launch an editor to edit it. However, the PR
body on GitHub might already has a PR metadata section / PR stack info
appended to it, which we don't want to show in the editor. Strip them
from the body.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"better_commit_detection","parentHead":"db8d2e7be9cecb79107e73c5dfdaae9e0059ebbe","parentPull":597,"trunk":"master"}
```
-->
