### PR TITLE
Apply Go's official modernize tool

### DIFF
--- a/cmd/av/adopt.go
+++ b/cmd/av/adopt.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"strings"
 
 	"emperror.dev/errors"
@@ -384,9 +384,7 @@ func (vm *adoptViewModel) View() string {
 		for branch := range vm.chosenTargets {
 			branches = append(branches, branch)
 		}
-		sort.Slice(branches, func(i, j int) bool {
-			return branches[i] < branches[j]
-		})
+		slices.Sort(branches)
 		if len(branches) == 0 {
 			ss = append(ss, "No branch is adopted")
 		} else if vm.adoptionComplete {

--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -118,8 +118,8 @@ func allBranches(ctx context.Context) ([]string, error) {
 // from a ref name if it exists.
 func stripRemoteRefPrefixes(repo *git.Repo, possibleRefName string) string {
 	ret := possibleRefName
-	if strings.HasPrefix(ret, "refs/heads/") {
-		ret = strings.TrimPrefix(ret, "refs/heads/")
+	if after, ok := strings.CutPrefix(ret, "refs/heads/"); ok {
+		ret = after
 	} else {
 		ret = strings.TrimPrefix(ret, "refs/remotes/")
 		ret = strings.TrimPrefix(ret, repo.GetRemoteName()+"/")

--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -150,14 +151,12 @@ func checkCliVersion() {
 		logrus.Debug("Skipping CLI version check (development version)")
 		return
 	}
-	for _, arg := range os.Args {
-		if arg == "completion" {
-			// Skip the update check as it can slow down the shell initialization on a
-			// slow network connection. This can have a false positive, but this is
-			// anyway an optional check.
-			logrus.Debug("Skipping CLI version check (shell completion)")
-			return
-		}
+	if slices.Contains(os.Args, "completion") {
+		// Skip the update check as it can slow down the shell initialization on a
+		// slow network connection. This can have a false positive, but this is
+		// anyway an optional check.
+		logrus.Debug("Skipping CLI version check (shell completion)")
+		return
 	}
 	latest, err := config.FetchLatestVersion()
 	if err != nil {

--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -307,7 +307,7 @@ func queue(ctx context.Context) error {
 	prNumber := branch.PullRequest.Number
 	repository := tx.Repository()
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"repoOwner": graphql.String(repository.Owner),
 		"repoName":  graphql.String(repository.Name),
 		// prNumber is int64 graphql expects in32, we should not have more than 2^31-1 PRs

--- a/cmd/av/pr_status.go
+++ b/cmd/av/pr_status.go
@@ -198,7 +198,7 @@ var prStatusCmd = &cobra.Command{
 	},
 }
 
-func getQueryVariables(ctx context.Context) (map[string]interface{}, error) {
+func getQueryVariables(ctx context.Context) (map[string]any, error) {
 	repo, err := getRepo(ctx)
 	if err != nil {
 		return nil, err
@@ -226,7 +226,7 @@ func getQueryVariables(ctx context.Context) (map[string]interface{}, error) {
 
 	prNumber := branch.PullRequest.Number
 	repository := tx.Repository()
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"repoOwner": graphql.String(repository.Owner),
 		"repoName":  graphql.String(repository.Name),
 		"prNumber":  graphql.Int(prNumber), //nolint:gosec

--- a/docs/internal/md2man/roff.go
+++ b/docs/internal/md2man/roff.go
@@ -197,7 +197,7 @@ func (r *roffRenderer) RenderNode(
 			out(w, "\n.fi\n")
 		} else {
 			out(w, codeTag)
-			for _, line := range strings.Split(string(node.Literal), "\n") {
+			for line := range strings.SplitSeq(string(node.Literal), "\n") {
 				escapeSpecialChars(w, []byte("    "+line+"\n"))
 			}
 			out(w, codeCloseTag)

--- a/e2e_tests/mock_ghgql_server.go
+++ b/e2e_tests/mock_ghgql_server.go
@@ -43,12 +43,12 @@ type mockPR struct {
 }
 
 type graphqlRequest struct {
-	Query     string                 `json:"query"`
-	Variables map[string]interface{} `json:"variables"`
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
 }
 
 type graphqlResponse struct {
-	Data map[string]interface{} `json:"data"`
+	Data map[string]any `json:"data"`
 }
 
 func (s *mockGitHubServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -73,12 +73,12 @@ func (s *mockGitHubServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
 	headRefName := req.Variables["headRefName"].(string)
-	var prs []interface{}
+	var prs []any
 	for _, pr := range s.pulls {
 		if pr.HeadRefName != headRefName {
 			continue
 		}
-		gqlpr := map[string]interface{}{
+		gqlpr := map[string]any{
 			"id":          pr.ID,
 			"number":      pr.Number,
 			"headRefName": pr.HeadRefName,
@@ -93,11 +93,11 @@ func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
 			gqlpr["mergeCommit"] = map[string]string{"oid": pr.MergeCommitOID}
 		}
 		if pr.ClosedCommitOID != "" {
-			gqlpr["timelineItems"] = map[string]interface{}{
-				"nodes": []interface{}{
-					map[string]interface{}{
+			gqlpr["timelineItems"] = map[string]any{
+				"nodes": []any{
+					map[string]any{
 						"__typename": "ClosedEvent",
-						"closer": map[string]interface{}{
+						"closer": map[string]any{
 							"__typename": "Commit",
 							"oid":        pr.ClosedCommitOID,
 						},
@@ -108,9 +108,9 @@ func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
 		prs = append(prs, gqlpr)
 	}
 	return graphqlResponse{
-		Data: map[string]interface{}{
-			"repository": map[string]interface{}{
-				"pullRequests": map[string]interface{}{
+		Data: map[string]any{
+			"repository": map[string]any{
+				"pullRequests": map[string]any{
 					"nodes": prs,
 				},
 			},

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -83,7 +83,7 @@ func (c *Client) PullRequest(ctx context.Context, id string) (*PullRequest, erro
 			PullRequest PullRequest `graphql:"... on PullRequest"`
 		} `graphql:"node(id: $id)"`
 	}
-	if err := c.query(ctx, &query, map[string]interface{}{
+	if err := c.query(ctx, &query, map[string]any{
 		"id": githubv4.ID(id),
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to query pull request")
@@ -126,7 +126,7 @@ func (c *Client) GetPullRequests(
 			} `graphql:"pullRequests(states: $states, headRefName: $headRefName, baseRefName: $baseRefName, first: $first, after: $after)"`
 		} `graphql:"repository(owner: $owner, name: $repo)"`
 	}
-	if err := c.query(ctx, &query, map[string]interface{}{
+	if err := c.query(ctx, &query, map[string]any{
 		"owner":       githubv4.String(input.Owner),
 		"repo":        githubv4.String(input.Repo),
 		"headRefName": nullable(githubv4.String(input.HeadRefName)),

--- a/internal/gh/repository.go
+++ b/internal/gh/repository.go
@@ -28,7 +28,7 @@ func (c *Client) GetRepositoryBySlug(ctx context.Context, slug string) (*Reposit
 	var query struct {
 		Repository Repository `graphql:"repository(owner: $owner, name: $name)"`
 	}
-	err := c.query(ctx, &query, map[string]interface{}{
+	err := c.query(ctx, &query, map[string]any{
 		"owner": githubv4.String(owner),
 		"name":  githubv4.String(name),
 	})

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -92,10 +93,8 @@ func (r *Repo) IsTrunkBranch(ctx context.Context, name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	for _, branch := range branches {
-		if name == branch {
-			return true, nil
-		}
+	if slices.Contains(branches, name) {
+		return true, nil
 	}
 	return false, nil
 }
@@ -386,7 +385,7 @@ func (r *Repo) BranchesContainCommittish(
 		return nil, err
 	}
 	var ret []BranchAndCommit
-	for _, line := range strings.Split(strings.TrimSpace(lines), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(lines), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) != 2 {
 			continue

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -98,11 +98,11 @@ func NewTempRepoWithGitHubServer(t *testing.T, serverURL string) *GitTestRepo {
 
 	err = os.WriteFile(
 		filepath.Join(repo.GitDir, "av", "config.yml"),
-		[]byte(fmt.Sprintf(`
+		fmt.Appendf(nil, `
 github:
     token: "dummy_valid_token"
     baseUrl: %q
-`, serverURL)),
+`, serverURL),
 		0o644,
 	)
 	require.NoError(t, err, "failed to write .git/av/config.yml")

--- a/internal/git/show.go
+++ b/internal/git/show.go
@@ -22,7 +22,7 @@ type CommitInfo struct {
 
 func (c CommitInfo) BodyWithPrefix(prefix string) []string {
 	var lines []string
-	for _, line := range strings.Split(strings.TrimSpace(c.Body), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(c.Body), "\n") {
 		lines = append(lines, prefix+line)
 	}
 	return lines

--- a/internal/git/status.go
+++ b/internal/git/status.go
@@ -64,7 +64,7 @@ func (r *Repo) Status(ctx context.Context) (GitStatus, error) {
 		return GitStatus{}, err
 	}
 	st := GitStatus{}
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		parseGitStatusLine(line, &st)
 	}
 	return st, nil

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -16,7 +16,7 @@ type Branch struct {
 	Name string `json:"name"`
 
 	// Information about the parent branch.
-	Parent BranchState `json:"parent,omitempty"`
+	Parent BranchState `json:"parent"`
 
 	// The associated pull request information, if any.
 	PullRequest *PullRequest `json:"pullRequest,omitempty"`

--- a/internal/reorder/editor.go
+++ b/internal/reorder/editor.go
@@ -36,8 +36,8 @@ func EditPlan(ctx context.Context, repo *git.Repo, plan []Cmd) ([]Cmd, error) {
 	}
 
 	var newPlan []Cmd
-	lines := strings.Split(res, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(res, "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/internal/sequencer/planner/planner.go
+++ b/internal/sequencer/planner/planner.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"context"
+	"slices"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
@@ -116,10 +117,8 @@ func PlanForReparent(
 		return nil, errors.New("cannot re-parent to self")
 	}
 	children := meta.SubsequentBranches(tx, currentBranch.Short())
-	for _, child := range children {
-		if child == newParentBranch.Short() {
-			return nil, errors.New("cannot re-parent to a child branch")
-		}
+	if slices.Contains(children, newParentBranch.Short()) {
+		return nil, errors.New("cannot re-parent to a child branch")
 	}
 	isParentTrunk, err := repo.IsTrunkBranch(ctx, newParentBranch.Short())
 	if err != nil {

--- a/internal/utils/logutils/logutils.go
+++ b/internal/utils/logutils/logutils.go
@@ -8,13 +8,13 @@ import (
 // printing an arbitrary object with a given format specifier/verb.
 type FormatPrinter struct {
 	verb string
-	item interface{}
+	item any
 }
 
 func (v FormatPrinter) String() string {
 	return fmt.Sprintf(v.verb, v.item)
 }
 
-func Format(verb string, item interface{}) FormatPrinter {
+func Format(verb string, item any) FormatPrinter {
 	return FormatPrinter{verb, item}
 }

--- a/internal/utils/maputils/copy.go
+++ b/internal/utils/maputils/copy.go
@@ -1,10 +1,10 @@
 package maputils
 
+import "maps"
+
 // Copy returns a (shallow) copy of the given map.
 func Copy[K comparable, T any](m map[K]T) map[K]T {
 	c := make(map[K]T, len(m))
-	for k, v := range m {
-		c[k] = v
-	}
+	maps.Copy(c, m)
 	return c
 }

--- a/internal/utils/sliceutils/contains.go
+++ b/internal/utils/sliceutils/contains.go
@@ -1,10 +1,7 @@
 package sliceutils
 
+import "slices"
+
 func Contains[T comparable](s []T, v T) bool {
-	for _, e := range s {
-		if e == v {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s, v)
 }

--- a/internal/utils/stackutils/stackutils.go
+++ b/internal/utils/stackutils/stackutils.go
@@ -2,6 +2,7 @@ package stackutils
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/aviator-co/av/internal/meta"
@@ -54,11 +55,9 @@ func BuildTree(
 			currentBranchPath[node.Branch.BranchName] = true
 			return true
 		}
-		for _, child := range node.Children {
-			if currentBranchVisitFn(child) {
-				currentBranchPath[node.Branch.BranchName] = true
-				return true
-			}
+		if slices.ContainsFunc(node.Children, currentBranchVisitFn) {
+			currentBranchPath[node.Branch.BranchName] = true
+			return true
 		}
 		return false
 	}

--- a/internal/utils/templateutils/templateutils.go
+++ b/internal/utils/templateutils/templateutils.go
@@ -6,7 +6,7 @@ import (
 )
 
 // String executes a template and returns the result as a string.
-func String(t *template.Template, data interface{}) (string, error) {
+func String(t *template.Template, data any) (string, error) {
 	buf := new(bytes.Buffer)
 	err := t.Execute(buf, data)
 	if err != nil {
@@ -15,7 +15,7 @@ func String(t *template.Template, data interface{}) (string, error) {
 	return buf.String(), nil
 }
 
-func MustString(t *template.Template, data interface{}) string {
+func MustString(t *template.Template, data any) string {
 	s, err := String(t, data)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Go has a tool that simplifies and modernizes Go code by using newer
language features and standard library functions. This commit applies
the tool to the codebase to improve readability and maintainability.
This modernize tool is part of the Go tools and can be found at:

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
