### PR TITLE
Abstract parts as tea.Model where possible in av sync

### DIFF
--- a/cmd/av/adopt.go
+++ b/cmd/av/adopt.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"strings"
 
 	"emperror.dev/errors"
@@ -384,9 +384,7 @@ func (vm *adoptViewModel) View() string {
 		for branch := range vm.chosenTargets {
 			branches = append(branches, branch)
 		}
-		sort.Slice(branches, func(i, j int) bool {
-			return branches[i] < branches[j]
-		})
+		slices.Sort(branches)
 		if len(branches) == 0 {
 			ss = append(ss, "No branch is adopted")
 		} else if vm.adoptionComplete {

--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -118,8 +118,8 @@ func allBranches(ctx context.Context) ([]string, error) {
 // from a ref name if it exists.
 func stripRemoteRefPrefixes(repo *git.Repo, possibleRefName string) string {
 	ret := possibleRefName
-	if strings.HasPrefix(ret, "refs/heads/") {
-		ret = strings.TrimPrefix(ret, "refs/heads/")
+	if after, ok := strings.CutPrefix(ret, "refs/heads/"); ok {
+		ret = after
 	} else {
 		ret = strings.TrimPrefix(ret, "refs/remotes/")
 		ret = strings.TrimPrefix(ret, repo.GetRemoteName()+"/")

--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -150,14 +151,12 @@ func checkCliVersion() {
 		logrus.Debug("Skipping CLI version check (development version)")
 		return
 	}
-	for _, arg := range os.Args {
-		if arg == "completion" {
-			// Skip the update check as it can slow down the shell initialization on a
-			// slow network connection. This can have a false positive, but this is
-			// anyway an optional check.
-			logrus.Debug("Skipping CLI version check (shell completion)")
-			return
-		}
+	if slices.Contains(os.Args, "completion") {
+		// Skip the update check as it can slow down the shell initialization on a
+		// slow network connection. This can have a false positive, but this is
+		// anyway an optional check.
+		logrus.Debug("Skipping CLI version check (shell completion)")
+		return
 	}
 	latest, err := config.FetchLatestVersion()
 	if err != nil {

--- a/cmd/av/next.go
+++ b/cmd/av/next.go
@@ -190,7 +190,7 @@ func (m stackNextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.nextBranch
 
 	case showSelectionMsg:
-		m.selection = uiutils.NewPromptModel(
+		m.selection = uiutils.NewLegacyPromptModel(
 			fmt.Sprintf("There are multiple children of branch %s. Which branch would you like to follow?", colors.UserInput(m.currentBranch)),
 			m.currentBranchChildren(),
 		)

--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -307,7 +307,7 @@ func queue(ctx context.Context) error {
 	prNumber := branch.PullRequest.Number
 	repository := tx.Repository()
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"repoOwner": graphql.String(repository.Owner),
 		"repoName":  graphql.String(repository.Name),
 		// prNumber is int64 graphql expects in32, we should not have more than 2^31-1 PRs

--- a/cmd/av/pr_status.go
+++ b/cmd/av/pr_status.go
@@ -198,7 +198,7 @@ var prStatusCmd = &cobra.Command{
 	},
 }
 
-func getQueryVariables(ctx context.Context) (map[string]interface{}, error) {
+func getQueryVariables(ctx context.Context) (map[string]any, error) {
 	repo, err := getRepo(ctx)
 	if err != nil {
 		return nil, err
@@ -226,7 +226,7 @@ func getQueryVariables(ctx context.Context) (map[string]interface{}, error) {
 
 	prNumber := branch.PullRequest.Number
 	repository := tx.Repository()
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"repoOwner": graphql.String(repository.Owner),
 		"repoName":  graphql.String(repository.Name),
 		"prNumber":  graphql.Int(prNumber), //nolint:gosec

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -21,7 +21,6 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/erikgeiser/promptkit/selection"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 )
@@ -120,11 +119,10 @@ type syncViewModel struct {
 	db     meta.DB
 	client *gh.Client
 	help   help.Model
-
-	preAvSyncHookMessage string
+	views  []tea.Model
 
 	state            *syncState
-	syncAllPrompt    *selection.Model[string]
+	syncAllPrompt    tea.Model
 	githubFetchModel *ghui.GitHubFetchModel
 	restackModel     *sequencerui.RestackModel
 	githubPushModel  *ghui.GitHubPushModel
@@ -219,54 +217,19 @@ func (vm *syncViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		vm.pruningBranches = false
 		return vm, tea.Quit
 
-	case promptUserShouldSyncAllMsg:
-		vm.syncAllPrompt = uiutils.NewPromptModel("You are on the trunk, do you want to sync all stacks?", []string{"Yes", "No"})
-		return vm, vm.syncAllPrompt.Init()
-
 	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			return vm, tea.Quit
+		}
 		if vm.syncAllPrompt != nil {
-			switch msg.String() {
-			case " ", "enter":
-				c, err := vm.syncAllPrompt.Value()
-				if err != nil {
-					vm.err = err
-					return vm, tea.Quit
-				}
-				vm.syncAllPrompt = nil
-				if c == "Yes" {
-					syncFlags.All = true
-				}
-				if c == "No" {
-					return vm, tea.Quit
-				}
-				return vm, vm.initSync()
-			case "ctrl+c":
-				return vm, tea.Quit
-			default:
-				_, cmd := vm.syncAllPrompt.Update(msg)
-				return vm, cmd
-			}
+			_, cmd := vm.syncAllPrompt.Update(msg)
+			return vm, cmd
 		} else if vm.pushingToGitHub {
-			switch msg.String() {
-			case "ctrl+c":
-				return vm, tea.Quit
-			default:
-				_, cmd := vm.githubPushModel.Update(msg)
-				return vm, cmd
-			}
+			_, cmd := vm.githubPushModel.Update(msg)
+			return vm, cmd
 		} else if vm.pruningBranches {
-			switch msg.String() {
-			case "ctrl+c":
-				return vm, tea.Quit
-			default:
-				_, cmd := vm.pruneBranchModel.Update(msg)
-				return vm, cmd
-			}
-		} else {
-			switch msg.String() {
-			case "ctrl+c":
-				return vm, tea.Quit
-			}
+			_, cmd := vm.pruneBranchModel.Update(msg)
+			return vm, cmd
 		}
 	case error:
 		vm.err = msg
@@ -277,12 +240,8 @@ func (vm *syncViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (vm *syncViewModel) View() string {
 	var ss []string
-	if vm.preAvSyncHookMessage != "" {
-		ss = append(ss, vm.preAvSyncHookMessage)
-	}
-	if vm.syncAllPrompt != nil {
-		ss = append(ss, vm.syncAllPrompt.View())
-		ss = append(ss, vm.help.ShortHelpView(uiutils.PromptKeys))
+	for _, v := range vm.views {
+		ss = append(ss, v.View())
 	}
 	if vm.githubFetchModel != nil {
 		ss = append(ss, vm.githubFetchModel.View())
@@ -314,8 +273,6 @@ func (vm *syncViewModel) View() string {
 
 type preAvSyncHookDoneMsg struct{}
 
-type promptUserShouldSyncAllMsg struct{}
-
 func (vm *syncViewModel) initSync() tea.Cmd {
 	state, err := vm.readState()
 	if err != nil {
@@ -332,12 +289,7 @@ func (vm *syncViewModel) initSync() tea.Cmd {
 	if err != nil {
 		return uiutils.ErrCmd(err)
 	}
-	if isTrunkBranch && !syncFlags.All {
-		return func() tea.Msg {
-			return promptUserShouldSyncAllMsg{}
-		}
-	}
-	return func() tea.Msg {
+	continuation := func() tea.Msg {
 		output, err := vm.repo.Run(
 			context.Background(),
 			&git.RunOpts{
@@ -356,13 +308,31 @@ func (vm *syncViewModel) initSync() tea.Cmd {
 			}
 		}
 		if len(messages) != 0 {
-			vm.preAvSyncHookMessage = strings.Join(messages, "\n")
+			vm.views = append(vm.views, uiutils.SimpleMessageView{Message: strings.Join(messages, "\n")})
 		}
 		if err != nil {
 			return errors.Errorf("pre-av-sync hook failed: %v", err)
 		}
 		return preAvSyncHookDoneMsg{}
 	}
+	if isTrunkBranch && !syncFlags.All {
+		vm.syncAllPrompt = &uiutils.NewlineModel{Model: uiutils.NewPromptModel(
+			"You are on the trunk, do you want to sync all stacks?",
+			[]string{"Yes", "No"},
+			func(choice string) tea.Cmd {
+				if choice == "Yes" {
+					syncFlags.All = true
+				}
+				if choice == "No" {
+					return tea.Quit
+				}
+				return continuation
+			},
+		)}
+		vm.views = append(vm.views, vm.syncAllPrompt)
+		return vm.syncAllPrompt.Init()
+	}
+	return continuation
 }
 
 func (vm *syncViewModel) initSequencerState() tea.Cmd {

--- a/docs/internal/md2man/roff.go
+++ b/docs/internal/md2man/roff.go
@@ -197,7 +197,7 @@ func (r *roffRenderer) RenderNode(
 			out(w, "\n.fi\n")
 		} else {
 			out(w, codeTag)
-			for _, line := range strings.Split(string(node.Literal), "\n") {
+			for line := range strings.SplitSeq(string(node.Literal), "\n") {
 				escapeSpecialChars(w, []byte("    "+line+"\n"))
 			}
 			out(w, codeCloseTag)

--- a/e2e_tests/mock_ghgql_server.go
+++ b/e2e_tests/mock_ghgql_server.go
@@ -43,12 +43,12 @@ type mockPR struct {
 }
 
 type graphqlRequest struct {
-	Query     string                 `json:"query"`
-	Variables map[string]interface{} `json:"variables"`
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
 }
 
 type graphqlResponse struct {
-	Data map[string]interface{} `json:"data"`
+	Data map[string]any `json:"data"`
 }
 
 func (s *mockGitHubServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -73,12 +73,12 @@ func (s *mockGitHubServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
 	headRefName := req.Variables["headRefName"].(string)
-	var prs []interface{}
+	var prs []any
 	for _, pr := range s.pulls {
 		if pr.HeadRefName != headRefName {
 			continue
 		}
-		gqlpr := map[string]interface{}{
+		gqlpr := map[string]any{
 			"id":          pr.ID,
 			"number":      pr.Number,
 			"headRefName": pr.HeadRefName,
@@ -93,11 +93,11 @@ func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
 			gqlpr["mergeCommit"] = map[string]string{"oid": pr.MergeCommitOID}
 		}
 		if pr.ClosedCommitOID != "" {
-			gqlpr["timelineItems"] = map[string]interface{}{
-				"nodes": []interface{}{
-					map[string]interface{}{
+			gqlpr["timelineItems"] = map[string]any{
+				"nodes": []any{
+					map[string]any{
 						"__typename": "ClosedEvent",
-						"closer": map[string]interface{}{
+						"closer": map[string]any{
 							"__typename": "Commit",
 							"oid":        pr.ClosedCommitOID,
 						},
@@ -108,9 +108,9 @@ func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
 		prs = append(prs, gqlpr)
 	}
 	return graphqlResponse{
-		Data: map[string]interface{}{
-			"repository": map[string]interface{}{
-				"pullRequests": map[string]interface{}{
+		Data: map[string]any{
+			"repository": map[string]any{
+				"pullRequests": map[string]any{
 					"nodes": prs,
 				},
 			},

--- a/internal/gh/ghui/push.go
+++ b/internal/gh/ghui/push.go
@@ -128,7 +128,7 @@ func (vm *GitHubPushModel) Update(msg tea.Msg) (*GitHubPushModel, tea.Cmd) {
 				return vm, vm.runUpdate
 			}
 			vm.askingForConfirmation = true
-			vm.pushPrompt = uiutils.NewPromptModel("Are you OK with pushing these branches to remote?", []string{continuePush, abortPush})
+			vm.pushPrompt = uiutils.NewLegacyPromptModel("Are you OK with pushing these branches to remote?", []string{continuePush, abortPush})
 			return vm, vm.pushPrompt.Init()
 		}
 		if msg.gitPushDone {

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -83,7 +83,7 @@ func (c *Client) PullRequest(ctx context.Context, id string) (*PullRequest, erro
 			PullRequest PullRequest `graphql:"... on PullRequest"`
 		} `graphql:"node(id: $id)"`
 	}
-	if err := c.query(ctx, &query, map[string]interface{}{
+	if err := c.query(ctx, &query, map[string]any{
 		"id": githubv4.ID(id),
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to query pull request")
@@ -126,7 +126,7 @@ func (c *Client) GetPullRequests(
 			} `graphql:"pullRequests(states: $states, headRefName: $headRefName, baseRefName: $baseRefName, first: $first, after: $after)"`
 		} `graphql:"repository(owner: $owner, name: $repo)"`
 	}
-	if err := c.query(ctx, &query, map[string]interface{}{
+	if err := c.query(ctx, &query, map[string]any{
 		"owner":       githubv4.String(input.Owner),
 		"repo":        githubv4.String(input.Repo),
 		"headRefName": nullable(githubv4.String(input.HeadRefName)),

--- a/internal/gh/repository.go
+++ b/internal/gh/repository.go
@@ -28,7 +28,7 @@ func (c *Client) GetRepositoryBySlug(ctx context.Context, slug string) (*Reposit
 	var query struct {
 		Repository Repository `graphql:"repository(owner: $owner, name: $name)"`
 	}
-	err := c.query(ctx, &query, map[string]interface{}{
+	err := c.query(ctx, &query, map[string]any{
 		"owner": githubv4.String(owner),
 		"name":  githubv4.String(name),
 	})

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -92,10 +93,8 @@ func (r *Repo) IsTrunkBranch(ctx context.Context, name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	for _, branch := range branches {
-		if name == branch {
-			return true, nil
-		}
+	if slices.Contains(branches, name) {
+		return true, nil
 	}
 	return false, nil
 }
@@ -386,7 +385,7 @@ func (r *Repo) BranchesContainCommittish(
 		return nil, err
 	}
 	var ret []BranchAndCommit
-	for _, line := range strings.Split(strings.TrimSpace(lines), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(lines), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) != 2 {
 			continue

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -98,11 +98,11 @@ func NewTempRepoWithGitHubServer(t *testing.T, serverURL string) *GitTestRepo {
 
 	err = os.WriteFile(
 		filepath.Join(repo.GitDir, "av", "config.yml"),
-		[]byte(fmt.Sprintf(`
+		fmt.Appendf(nil, `
 github:
     token: "dummy_valid_token"
     baseUrl: %q
-`, serverURL)),
+`, serverURL),
 		0o644,
 	)
 	require.NoError(t, err, "failed to write .git/av/config.yml")

--- a/internal/git/gitui/prune.go
+++ b/internal/git/gitui/prune.go
@@ -104,7 +104,7 @@ func (vm *PruneBranchModel) Update(msg tea.Msg) (*PruneBranchModel, tea.Cmd) {
 				return vm, vm.runDelete
 			}
 			vm.askingForConfirmation = true
-			vm.deletePrompt = uiutils.NewPromptModel("Are you OK with deleting these merged branches?", []string{continueDeletion, abortDeletion})
+			vm.deletePrompt = uiutils.NewLegacyPromptModel("Are you OK with deleting these merged branches?", []string{continueDeletion, abortDeletion})
 			return vm, vm.deletePrompt.Init()
 		}
 		if msg.deletionDone {

--- a/internal/git/show.go
+++ b/internal/git/show.go
@@ -22,7 +22,7 @@ type CommitInfo struct {
 
 func (c CommitInfo) BodyWithPrefix(prefix string) []string {
 	var lines []string
-	for _, line := range strings.Split(strings.TrimSpace(c.Body), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(c.Body), "\n") {
 		lines = append(lines, prefix+line)
 	}
 	return lines

--- a/internal/git/status.go
+++ b/internal/git/status.go
@@ -64,7 +64,7 @@ func (r *Repo) Status(ctx context.Context) (GitStatus, error) {
 		return GitStatus{}, err
 	}
 	st := GitStatus{}
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		parseGitStatusLine(line, &st)
 	}
 	return st, nil

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -16,7 +16,7 @@ type Branch struct {
 	Name string `json:"name"`
 
 	// Information about the parent branch.
-	Parent BranchState `json:"parent,omitempty"`
+	Parent BranchState `json:"parent"`
 
 	// The associated pull request information, if any.
 	PullRequest *PullRequest `json:"pullRequest,omitempty"`

--- a/internal/reorder/editor.go
+++ b/internal/reorder/editor.go
@@ -36,8 +36,8 @@ func EditPlan(ctx context.Context, repo *git.Repo, plan []Cmd) ([]Cmd, error) {
 	}
 
 	var newPlan []Cmd
-	lines := strings.Split(res, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(res, "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/internal/sequencer/planner/planner.go
+++ b/internal/sequencer/planner/planner.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"context"
+	"slices"
 
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/git"
@@ -116,10 +117,8 @@ func PlanForReparent(
 		return nil, errors.New("cannot re-parent to self")
 	}
 	children := meta.SubsequentBranches(tx, currentBranch.Short())
-	for _, child := range children {
-		if child == newParentBranch.Short() {
-			return nil, errors.New("cannot re-parent to a child branch")
-		}
+	if slices.Contains(children, newParentBranch.Short()) {
+		return nil, errors.New("cannot re-parent to a child branch")
 	}
 	isParentTrunk, err := repo.IsTrunkBranch(ctx, newParentBranch.Short())
 	if err != nil {

--- a/internal/utils/logutils/logutils.go
+++ b/internal/utils/logutils/logutils.go
@@ -8,13 +8,13 @@ import (
 // printing an arbitrary object with a given format specifier/verb.
 type FormatPrinter struct {
 	verb string
-	item interface{}
+	item any
 }
 
 func (v FormatPrinter) String() string {
 	return fmt.Sprintf(v.verb, v.item)
 }
 
-func Format(verb string, item interface{}) FormatPrinter {
+func Format(verb string, item any) FormatPrinter {
 	return FormatPrinter{verb, item}
 }

--- a/internal/utils/maputils/copy.go
+++ b/internal/utils/maputils/copy.go
@@ -1,10 +1,10 @@
 package maputils
 
+import "maps"
+
 // Copy returns a (shallow) copy of the given map.
 func Copy[K comparable, T any](m map[K]T) map[K]T {
 	c := make(map[K]T, len(m))
-	for k, v := range m {
-		c[k] = v
-	}
+	maps.Copy(c, m)
 	return c
 }

--- a/internal/utils/sliceutils/contains.go
+++ b/internal/utils/sliceutils/contains.go
@@ -1,10 +1,7 @@
 package sliceutils
 
+import "slices"
+
 func Contains[T comparable](s []T, v T) bool {
-	for _, e := range s {
-		if e == v {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s, v)
 }

--- a/internal/utils/stackutils/stackutils.go
+++ b/internal/utils/stackutils/stackutils.go
@@ -2,6 +2,7 @@ package stackutils
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/aviator-co/av/internal/meta"
@@ -54,11 +55,9 @@ func BuildTree(
 			currentBranchPath[node.Branch.BranchName] = true
 			return true
 		}
-		for _, child := range node.Children {
-			if currentBranchVisitFn(child) {
-				currentBranchPath[node.Branch.BranchName] = true
-				return true
-			}
+		if slices.ContainsFunc(node.Children, currentBranchVisitFn) {
+			currentBranchPath[node.Branch.BranchName] = true
+			return true
 		}
 		return false
 	}

--- a/internal/utils/templateutils/templateutils.go
+++ b/internal/utils/templateutils/templateutils.go
@@ -6,7 +6,7 @@ import (
 )
 
 // String executes a template and returns the result as a string.
-func String(t *template.Template, data interface{}) (string, error) {
+func String(t *template.Template, data any) (string, error) {
 	buf := new(bytes.Buffer)
 	err := t.Execute(buf, data)
 	if err != nil {
@@ -15,7 +15,7 @@ func String(t *template.Template, data interface{}) (string, error) {
 	return buf.String(), nil
 }
 
-func MustString(t *template.Template, data interface{}) string {
+func MustString(t *template.Template, data any) string {
 	s, err := String(t, data)
 	if err != nil {
 		panic(err)

--- a/internal/utils/uiutils/add_newline.go
+++ b/internal/utils/uiutils/add_newline.go
@@ -1,0 +1,21 @@
+package uiutils
+
+import tea "github.com/charmbracelet/bubbletea"
+
+type NewlineModel struct {
+	Model tea.Model
+}
+
+func (m *NewlineModel) Init() tea.Cmd {
+	return m.Model.Init()
+}
+
+func (m *NewlineModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	newModel, cmd := m.Model.Update(msg)
+	m.Model = newModel
+	return m, cmd
+}
+
+func (m *NewlineModel) View() string {
+	return m.Model.View() + "\n"
+}

--- a/internal/utils/uiutils/prompt.go
+++ b/internal/utils/uiutils/prompt.go
@@ -1,11 +1,16 @@
 package uiutils
 
 import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/erikgeiser/promptkit/selection"
 )
 
-func NewPromptModel(title string, items []string) *selection.Model[string] {
+func NewLegacyPromptModel(title string, items []string) *selection.Model[string] {
 	ret := selection.NewModel(selection.New(title, items))
 	ret.Filter = nil
 	ret.KeyMap.Up = append(ret.KeyMap.Up, "k", "ctrl+p")
@@ -30,4 +35,56 @@ var PromptKeys = []key.Binding{
 		key.WithKeys("ctrl+c"),
 		key.WithHelp("ctrl+c", "cancel"),
 	),
+}
+
+type PromptModel struct {
+	prompt   *selection.Model[string]
+	help     help.Model
+	callback func(string) tea.Cmd
+	quitting bool
+}
+
+func NewPromptModel(title string, items []string, callback func(string) tea.Cmd) *PromptModel {
+	return &PromptModel{
+		prompt:   NewLegacyPromptModel(title, items),
+		help:     help.New(),
+		callback: callback,
+	}
+}
+
+func (m *PromptModel) Init() tea.Cmd {
+	return m.prompt.Init()
+}
+
+func (m *PromptModel) View() string {
+	// The base prompt has a new line. Leave the caller to decide whether to add a new line
+	// after.
+	ret := strings.TrimSpace(m.prompt.View())
+	if !m.quitting {
+		// Do not show help after finishing the selection.
+		ret = lipgloss.JoinVertical(lipgloss.Top, ret, m.help.ShortHelpView(PromptKeys))
+	}
+	return ret
+}
+
+func (m *PromptModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case " ", "enter":
+			m.prompt.Update(msg)
+			m.quitting = true
+			c, err := m.prompt.Value()
+			if err != nil {
+				return m, ErrCmd(err)
+			}
+			return m, m.callback(c)
+		case "ctrl+c":
+			return m, tea.Quit
+		default:
+			_, cmd := m.prompt.Update(msg)
+			return m, cmd
+		}
+	}
+	return m, nil
 }

--- a/internal/utils/uiutils/simple_message.go
+++ b/internal/utils/uiutils/simple_message.go
@@ -1,0 +1,19 @@
+package uiutils
+
+import tea "github.com/charmbracelet/bubbletea"
+
+type SimpleMessageView struct {
+	Message string
+}
+
+func (s SimpleMessageView) View() string {
+	return s.Message
+}
+
+func (s SimpleMessageView) Init() tea.Cmd {
+	return nil
+}
+
+func (s SimpleMessageView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return s, nil
+}


### PR DESCRIPTION
This is to extract / reuse UI components as tea.Model, so that they can
be composed in other tea.Models. No substantial behavior changes. The
"sync all" prompt is now persisted after the user answers it, ctrl+c now
works at any timing.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"go_modernize","parentHead":"1165d4b149995539463b237ffa4d5b3916b6b01a","parentPull":599,"trunk":"master"}
```
-->
