### PR TITLE
Spilt the adopt branch selection UI into separate components

### DIFF
--- a/cmd/av/adopt.go
+++ b/cmd/av/adopt.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"slices"
 	"strings"
 
 	"emperror.dev/errors"
@@ -11,12 +10,8 @@ import (
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/treedetector"
 	"github.com/aviator-co/av/internal/utils/colors"
-	"github.com/aviator-co/av/internal/utils/sliceutils"
 	"github.com/aviator-co/av/internal/utils/stackutils"
 	"github.com/aviator-co/av/internal/utils/uiutils"
-	"github.com/charmbracelet/bubbles/help"
-	"github.com/charmbracelet/bubbles/key"
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -67,10 +62,6 @@ the parent.`),
 			repo:              repo,
 			db:                db,
 			currentHEADBranch: plumbing.NewBranchReferenceName(currentBranch),
-			currentCursor:     plumbing.NewBranchReferenceName(currentBranch),
-			chosenTargets:     make(map[plumbing.ReferenceName]bool),
-			help:              help.New(),
-			spinner:           spinner.New(spinner.WithSpinner(spinner.Dot)),
 		})
 	},
 }
@@ -134,286 +125,123 @@ func adoptForceAdoption(
 	return tx.Commit()
 }
 
-type adoptTreeInfo struct {
-	branches        map[plumbing.ReferenceName]*treedetector.BranchPiece
-	rootNodes       []*stackutils.StackTreeNode
-	adoptionTargets []plumbing.ReferenceName
-}
-
 type adoptViewModel struct {
 	repo              *git.Repo
 	db                meta.DB
 	currentHEADBranch plumbing.ReferenceName
-
-	help               help.Model
-	spinner            spinner.Model
-	currentCursor      plumbing.ReferenceName
-	chosenTargets      map[plumbing.ReferenceName]bool
-	treeInfo           *adoptTreeInfo
-	adoptionComplete   bool
-	adoptionInProgress bool
-
-	err error
+	views             []tea.Model
+	branches          map[plumbing.ReferenceName]*treedetector.BranchPiece
+	err               error
 }
 
 func (vm *adoptViewModel) Init() tea.Cmd {
-	return tea.Batch(vm.spinner.Tick, vm.initCmd)
+	return vm.initModel()
 }
 
 func (vm *adoptViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			return vm, tea.Quit
+		}
+	case uiutils.SimpleCommandMsg:
+		return vm, msg.Cmd
 	case error:
 		vm.err = msg
 		return vm, tea.Quit
-	case *adoptTreeInfo:
-		vm.treeInfo = msg
-		if len(vm.treeInfo.adoptionTargets) == 0 {
-			return vm, tea.Quit
-		}
-		for _, branch := range vm.treeInfo.adoptionTargets {
-			// By default choose everything.
-			vm.chosenTargets[branch] = true
-		}
-		vm.currentCursor = vm.treeInfo.adoptionTargets[0]
-		if adoptFlags.DryRun {
-			return vm, tea.Quit
-		}
-	case adoptionCompleteMsg:
-		vm.adoptionComplete = true
-		return vm, tea.Quit
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "q":
-			return vm, tea.Quit
-		}
-		if vm.treeInfo != nil {
-			switch msg.String() {
-			case "up", "k", "ctrl+p":
-				vm.currentCursor = vm.getPreviousBranch()
-			case "down", "j", "ctrl+n":
-				vm.currentCursor = vm.getNextBranch()
-			case " ":
-				vm.toggleAdoption(vm.currentCursor)
-			case "enter":
-				vm.adoptionInProgress = true
-				return vm, vm.adoptBranches
-			}
-		}
-	case spinner.TickMsg:
+	}
+	if len(vm.views) > 0 {
+		idx := len(vm.views) - 1
 		var cmd tea.Cmd
-		vm.spinner, cmd = vm.spinner.Update(msg)
+		vm.views[idx], cmd = vm.views[idx].Update(msg)
 		return vm, cmd
 	}
 	return vm, nil
 }
 
-func (vm *adoptViewModel) initCmd() tea.Msg {
-	unmanagedBranches, err := vm.getUnmanagedBranches()
-	if err != nil {
-		return err
-	}
-	pieces, err := treedetector.DetectBranches(context.Background(), vm.repo, unmanagedBranches)
-	if err != nil {
-		return err
-	}
-	if len(pieces) == 0 {
-		return errors.New("no branch to adopt")
-	}
-	nodes := treedetector.ConvertToStackTree(vm.db, pieces, plumbing.HEAD, false)
-	return &adoptTreeInfo{
-		branches:        pieces,
-		rootNodes:       nodes,
-		adoptionTargets: vm.getAdoptionTargets(nodes[0]),
-	}
-}
-
-func (vm *adoptViewModel) getUnmanagedBranches() ([]plumbing.ReferenceName, error) {
-	tx := vm.db.ReadTx()
-	adoptedBranches := tx.AllBranches()
-	branches, err := vm.repo.GoGitRepo().Branches()
-	if err != nil {
-		return nil, err
-	}
-	var ret []plumbing.ReferenceName
-	if err := branches.ForEach(func(ref *plumbing.Reference) error {
-		if ref.Type() != plumbing.HashReference {
-			return nil
-		}
-		if _, adopted := adoptedBranches[ref.Name().Short()]; !adopted {
-			ret = append(ret, ref.Name())
-		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return ret, nil
-}
-
-func (vm *adoptViewModel) getAdoptionTargets(
-	node *stackutils.StackTreeNode,
-) []plumbing.ReferenceName {
-	var ret []plumbing.ReferenceName
-	for _, child := range node.Children {
-		ret = append(ret, vm.getAdoptionTargets(child)...)
-	}
-	if node.Branch.ParentBranchName != "" {
-		_, adopted := vm.db.ReadTx().Branch(node.Branch.BranchName)
-		if !adopted {
-			ret = append(ret, plumbing.NewBranchReferenceName(node.Branch.BranchName))
-		}
-	}
-	return ret
-}
-
-func (vm *adoptViewModel) getPreviousBranch() plumbing.ReferenceName {
-	if vm.treeInfo == nil {
-		return vm.currentCursor
-	}
-	for i, branch := range vm.treeInfo.adoptionTargets {
-		if branch == vm.currentCursor {
-			if i == 0 {
-				return vm.currentCursor
-			}
-			return vm.treeInfo.adoptionTargets[i-1]
-		}
-	}
-	return vm.currentCursor
-}
-
-func (vm *adoptViewModel) getNextBranch() plumbing.ReferenceName {
-	if vm.treeInfo == nil {
-		return vm.currentCursor
-	}
-	for i, branch := range vm.treeInfo.adoptionTargets {
-		if branch == vm.currentCursor {
-			if i == len(vm.treeInfo.adoptionTargets)-1 {
-				return vm.currentCursor
-			}
-			return vm.treeInfo.adoptionTargets[i+1]
-		}
-	}
-	return vm.currentCursor
-}
-
-func (vm *adoptViewModel) toggleAdoption(branch plumbing.ReferenceName) {
-	if vm.treeInfo == nil {
-		return
-	}
-	if vm.chosenTargets[branch] {
-		// Going to unchoose. Unchoose all children as well.
-		children := treedetector.GetChildren(vm.treeInfo.branches, branch)
-		for bn := range children {
-			delete(vm.chosenTargets, bn)
-		}
-		delete(vm.chosenTargets, branch)
-	} else {
-		// Going to choose. Choose all parents as well.
-		piece := vm.treeInfo.branches[branch]
-		for sliceutils.Contains(vm.treeInfo.adoptionTargets, piece.Name) {
-			vm.chosenTargets[piece.Name] = true
-			if piece.Parent == "" || piece.ParentIsTrunk {
-				break
-			}
-			piece = vm.treeInfo.branches[piece.Parent]
-		}
-	}
-}
-
-type adoptionCompleteMsg struct{}
-
-func (vm *adoptViewModel) adoptBranches() tea.Msg {
-	tx := vm.db.WriteTx()
-	for branch := range vm.chosenTargets {
-		piece := vm.treeInfo.branches[branch]
-		bi, _ := tx.Branch(branch.Short())
-		bi.Parent = meta.BranchState{
-			Name:  piece.Parent.Short(),
-			Trunk: piece.ParentIsTrunk,
-		}
-		if !piece.ParentIsTrunk {
-			bi.Parent.Head = piece.ParentMergeBase.String()
-		}
-		tx.SetBranch(bi)
-	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	return adoptionCompleteMsg{}
-}
-
 func (vm *adoptViewModel) View() string {
 	var ss []string
-	if vm.treeInfo != nil {
-		choosing := false
-		if len(vm.treeInfo.adoptionTargets) == 0 {
-			ss = append(ss, colors.SuccessStyle.Render("✓ No branch to adopt"))
-		} else if vm.adoptionComplete {
-			ss = append(ss, colors.SuccessStyle.Render("✓ Adoption complete"))
-		} else if vm.adoptionInProgress {
-			ss = append(ss, colors.ProgressStyle.Render(vm.spinner.View()+"Adopting the chosen branches..."))
-		} else {
-			choosing = true
-			ss = append(ss, colors.QuestionStyle.Render("Choose which branches to adopt"))
-		}
-		for _, rootNode := range vm.treeInfo.rootNodes {
-			ss = append(ss, "")
-			ss = append(
-				ss,
-				stackutils.RenderTree(
-					rootNode,
-					func(branchName string, isTrunk bool) string {
-						bn := plumbing.NewBranchReferenceName(branchName)
-						out := vm.renderBranch(bn, isTrunk)
-						if choosing && bn == vm.currentCursor {
-							out = strings.TrimSuffix(out, "\n")
-							out = colors.PromptChoice.Render(out)
-						}
-						return out
-					},
-				),
-			)
-		}
-		if choosing {
-			ss = append(ss, "")
-			ss = append(ss, vm.help.ShortHelpView(promptKeys))
-		}
-	}
-	if vm.adoptionInProgress || vm.adoptionComplete {
-		ss = append(ss, "")
-		var branches []plumbing.ReferenceName
-		for branch := range vm.chosenTargets {
-			branches = append(branches, branch)
-		}
-		slices.Sort(branches)
-		if len(branches) == 0 {
-			ss = append(ss, "No branch is adopted")
-		} else if vm.adoptionComplete {
-			ss = append(ss, "Adopted the following branches:")
-			ss = append(ss, "")
-		} else if vm.adoptionInProgress {
-			ss = append(ss, "Adopting the following branches:")
-			ss = append(ss, "")
-		}
-		for _, branch := range branches {
-			ss = append(ss, "  "+branch.Short())
-			piece := vm.treeInfo.branches[branch]
-			for _, c := range piece.IncludedCommits {
-				title, _, _ := strings.Cut(c.Message, "\n")
-				ss = append(ss, "    "+title)
-			}
+	for _, v := range vm.views {
+		r := v.View()
+		if r != "" {
+			ss = append(ss, r)
 		}
 	}
 
 	var ret string
 	if len(ss) != 0 {
-		ret = lipgloss.NewStyle().MarginTop(1).MarginBottom(1).MarginLeft(2).Render(
-			lipgloss.JoinVertical(0, ss...),
-		) + "\n"
+		ret = lipgloss.NewStyle().MarginTop(1).MarginBottom(1).MarginLeft(2).Render(lipgloss.JoinVertical(0, ss...))
 	}
 	if vm.err != nil {
+		if len(ret) != 0 {
+			ret += "\n"
+		}
 		ret += renderError(vm.err)
 	}
+	if len(ret) > 0 && ret[len(ret)-1] != '\n' {
+		ret += "\n"
+	}
 	return ret
+}
+
+func (vm *adoptViewModel) addView(m tea.Model) tea.Cmd {
+	vm.views = append(vm.views, m)
+	return m.Init()
+}
+
+func (vm *adoptViewModel) initModel() tea.Cmd {
+	return vm.addView(
+		actions.NewFindAdoptableLocalBranchesModel(
+			vm.repo,
+			vm.db,
+			vm.initTreeSelector,
+		),
+	)
+}
+
+func (vm *adoptViewModel) initTreeSelector(branches map[plumbing.ReferenceName]*treedetector.BranchPiece, rootNodes []*stackutils.StackTreeNode, adoptionTargets []plumbing.ReferenceName) tea.Cmd {
+	if branches == nil || len(rootNodes) == 0 || len(adoptionTargets) == 0 {
+		return tea.Batch(
+			vm.addView(uiutils.SimpleMessageView{Message: colors.SuccessStyle.Render("✓ No branch to adopt")}),
+			tea.Quit,
+		)
+	}
+	vm.branches = branches
+	cmd := vm.addView(
+		actions.NewAdoptTreeSelectorModel(
+			vm.db,
+			branches,
+			rootNodes,
+			adoptionTargets,
+			vm.currentHEADBranch,
+			vm.initAdoption,
+		),
+	)
+	if adoptFlags.DryRun {
+		return tea.Batch(
+			cmd,
+			vm.addView(uiutils.SimpleMessageView{Message: colors.SuccessStyle.Render("✓ Running as dry-run. Quitting without adopting branches.")}),
+			tea.Quit,
+		)
+	}
+	return cmd
+}
+
+func (vm *adoptViewModel) initAdoption(chosenTargets []plumbing.ReferenceName) tea.Cmd {
+	if len(chosenTargets) == 0 {
+		return tea.Batch(
+			vm.addView(uiutils.SimpleMessageView{Message: colors.SuccessStyle.Render("✓ No branch adopted")}),
+			tea.Quit,
+		)
+	}
+	return vm.addView(
+		actions.NewAdoptBranchesModel(
+			vm.db,
+			chosenTargets,
+			vm.branches,
+			func() tea.Cmd { return tea.Quit },
+		),
+	)
 }
 
 func (vm *adoptViewModel) ExitError() error {
@@ -421,39 +249,6 @@ func (vm *adoptViewModel) ExitError() error {
 		return actions.ErrExitSilently{ExitCode: 1}
 	}
 	return nil
-}
-
-func (vm *adoptViewModel) renderBranch(branch plumbing.ReferenceName, isTrunk bool) string {
-	if isTrunk {
-		return branch.Short()
-	}
-	_, adopted := vm.db.ReadTx().Branch(branch.Short())
-
-	sb := strings.Builder{}
-	if adopted && !vm.chosenTargets[branch] {
-		sb.WriteString(branch.Short())
-	} else if vm.chosenTargets[branch] {
-		sb.WriteString("[✓] " + branch.Short())
-	} else {
-		sb.WriteString("[ ] " + branch.Short())
-	}
-
-	var status []string
-	if vm.currentHEADBranch == branch {
-		status = append(status, "HEAD")
-	}
-	if len(status) != 0 {
-		sb.WriteString(" (" + strings.Join(status, ", ") + ")")
-	}
-	if !adopted || vm.chosenTargets[branch] {
-		sb.WriteString("\n")
-		piece := vm.treeInfo.branches[branch]
-		for _, c := range piece.IncludedCommits {
-			title, _, _ := strings.Cut(c.Message, "\n")
-			sb.WriteString("  " + title + "\n")
-		}
-	}
-	return sb.String()
 }
 
 func init() {
@@ -473,27 +268,4 @@ func init() {
 			return branches, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
-}
-
-var promptKeys = []key.Binding{
-	key.NewBinding(
-		key.WithKeys("up", "k"),
-		key.WithHelp("↑/k", "move up"),
-	),
-	key.NewBinding(
-		key.WithKeys("down", "j"),
-		key.WithHelp("↓/j", "move down"),
-	),
-	key.NewBinding(
-		key.WithKeys("space"),
-		key.WithHelp("space", "select / unselect"),
-	),
-	key.NewBinding(
-		key.WithKeys("enter"),
-		key.WithHelp("enter", "adopt selected branches"),
-	),
-	key.NewBinding(
-		key.WithKeys("ctrl+c"),
-		key.WithHelp("ctrl+c", "cancel"),
-	),
 }

--- a/internal/actions/adopt_branches.go
+++ b/internal/actions/adopt_branches.go
@@ -1,0 +1,85 @@
+package actions
+
+import (
+	"strings"
+
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/treedetector"
+	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/aviator-co/av/internal/utils/uiutils"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func NewAdoptBranchesModel(
+	db meta.DB,
+	chosenTargets []plumbing.ReferenceName,
+	branches map[plumbing.ReferenceName]*treedetector.BranchPiece,
+	onDone func() tea.Cmd,
+) tea.Model {
+	return &AdoptBranchesModel{
+		db:            db,
+		spinner:       spinner.New(spinner.WithSpinner(spinner.Dot)),
+		chosenTargets: chosenTargets,
+		branches:      branches,
+		onDone:        onDone,
+	}
+}
+
+type AdoptBranchesModel struct {
+	db            meta.DB
+	spinner       spinner.Model
+	chosenTargets []plumbing.ReferenceName
+	branches      map[plumbing.ReferenceName]*treedetector.BranchPiece
+	done          bool
+	onDone        func() tea.Cmd
+}
+
+func (m *AdoptBranchesModel) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, m.adoptBranches)
+}
+
+func (m *AdoptBranchesModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return m, nil
+}
+
+func (m *AdoptBranchesModel) View() string {
+	var ss []string
+	if m.done {
+		ss = append(ss, colors.SuccessStyle.Render("✓ Adoption complete"))
+	} else {
+		ss = append(ss, colors.ProgressStyle.Render(m.spinner.View()+"Adopting the chosen branches..."))
+	}
+	ss = append(ss, "")
+	for _, branch := range m.chosenTargets {
+		piece := m.branches[branch]
+		ss = append(ss, "  * "+branch.Short()+" → "+piece.Parent.Short())
+		for _, c := range piece.IncludedCommits {
+			title, _, _ := strings.Cut(c.Message, "\n")
+			ss = append(ss, "    * "+title)
+		}
+	}
+	return strings.Join(ss, "\n")
+}
+
+func (m *AdoptBranchesModel) adoptBranches() tea.Msg {
+	tx := m.db.WriteTx()
+	for _, branch := range m.chosenTargets {
+		piece := m.branches[branch]
+		bi, _ := tx.Branch(branch.Short())
+		bi.Parent = meta.BranchState{
+			Name:  piece.Parent.Short(),
+			Trunk: piece.ParentIsTrunk,
+		}
+		if !piece.ParentIsTrunk {
+			bi.Parent.Head = piece.ParentMergeBase.String()
+		}
+		tx.SetBranch(bi)
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	m.done = true
+	return uiutils.SimpleCommandMsg{Cmd: m.onDone()}
+}

--- a/internal/actions/adopt_tree_selector.go
+++ b/internal/actions/adopt_tree_selector.go
@@ -1,0 +1,218 @@
+package actions
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/treedetector"
+	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/aviator-co/av/internal/utils/stackutils"
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func NewAdoptTreeSelectorModel(
+	db meta.DB,
+	branches map[plumbing.ReferenceName]*treedetector.BranchPiece,
+	rootNodes []*stackutils.StackTreeNode,
+	adoptionTargets []plumbing.ReferenceName,
+	currentHEADBranch plumbing.ReferenceName,
+	onDone func(chosenTargets []plumbing.ReferenceName) tea.Cmd,
+) tea.Model {
+	chosenTargets := make(map[plumbing.ReferenceName]bool)
+	for _, branch := range adoptionTargets {
+		// By default choose everything.
+		chosenTargets[branch] = true
+	}
+	return &AdoptTreeSelectorModel{
+		db:                db,
+		help:              help.New(),
+		branches:          branches,
+		rootNodes:         rootNodes,
+		adoptionTargets:   adoptionTargets,
+		currentHEADBranch: currentHEADBranch,
+		currentCursor:     adoptionTargets[0],
+		chosenTargets:     chosenTargets,
+		onDone:            onDone,
+	}
+}
+
+type AdoptTreeSelectorModel struct {
+	db                meta.DB
+	help              help.Model
+	branches          map[plumbing.ReferenceName]*treedetector.BranchPiece
+	rootNodes         []*stackutils.StackTreeNode
+	adoptionTargets   []plumbing.ReferenceName
+	currentHEADBranch plumbing.ReferenceName
+	onDone            func(chosenTargets []plumbing.ReferenceName) tea.Cmd
+
+	done          bool
+	currentCursor plumbing.ReferenceName
+	chosenTargets map[plumbing.ReferenceName]bool
+}
+
+func (m *AdoptTreeSelectorModel) Init() tea.Cmd {
+	return func() tea.Msg {
+		return nil
+	}
+}
+
+func (m *AdoptTreeSelectorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q":
+			return m, tea.Quit
+		case "up", "k", "ctrl+p":
+			m.currentCursor = m.getPreviousBranch()
+		case "down", "j", "ctrl+n":
+			m.currentCursor = m.getNextBranch()
+		case " ":
+			m.toggleAdoption(m.currentCursor)
+		case "enter":
+			m.done = true
+			var chosenTargets []plumbing.ReferenceName
+			for bn := range m.chosenTargets {
+				chosenTargets = append(chosenTargets, bn)
+			}
+			return m, m.onDone(chosenTargets)
+		}
+	}
+	return m, nil
+}
+
+func (m *AdoptTreeSelectorModel) View() string {
+	var ss []string
+	if m.done {
+		ss = append(ss, colors.SuccessStyle.Render("✓ Choose which branches to adopt"))
+	} else {
+		ss = append(ss, colors.QuestionStyle.Render("Choose which branches to adopt"))
+	}
+	for _, rootNode := range m.rootNodes {
+		ss = append(ss, "")
+		ss = append(
+			ss,
+			stackutils.RenderTree(
+				rootNode,
+				func(branchName string, isTrunk bool) string {
+					bn := plumbing.NewBranchReferenceName(branchName)
+					out := m.renderBranch(bn, isTrunk)
+					if !m.done && bn == m.currentCursor {
+						out = strings.TrimSuffix(out, "\n")
+						out = colors.PromptChoice.Render(out)
+					}
+					return out
+				},
+			),
+		)
+	}
+	ss = append(ss, "")
+	if !m.done {
+		ss = append(ss, m.help.ShortHelpView(promptKeys))
+	}
+	return strings.Join(ss, "\n")
+}
+
+func (m *AdoptTreeSelectorModel) renderBranch(branch plumbing.ReferenceName, isTrunk bool) string {
+	if isTrunk {
+		return branch.Short()
+	}
+	_, adopted := m.db.ReadTx().Branch(branch.Short())
+
+	sb := strings.Builder{}
+	if adopted && !m.chosenTargets[branch] {
+		sb.WriteString(branch.Short())
+	} else if m.chosenTargets[branch] {
+		sb.WriteString("[✓] " + branch.Short())
+	} else {
+		sb.WriteString("[ ] " + branch.Short())
+	}
+
+	var status []string
+	if m.currentHEADBranch == branch {
+		status = append(status, "HEAD")
+	}
+	if len(status) != 0 {
+		sb.WriteString(" (" + strings.Join(status, ", ") + ")")
+	}
+	if !adopted || m.chosenTargets[branch] {
+		sb.WriteString("\n")
+		piece := m.branches[branch]
+		for _, c := range piece.IncludedCommits {
+			title, _, _ := strings.Cut(c.Message, "\n")
+			sb.WriteString("  " + title + "\n")
+		}
+	}
+	return sb.String()
+}
+
+func (m *AdoptTreeSelectorModel) getPreviousBranch() plumbing.ReferenceName {
+	for i, branch := range m.adoptionTargets {
+		if branch == m.currentCursor {
+			if i == 0 {
+				return m.currentCursor
+			}
+			return m.adoptionTargets[i-1]
+		}
+	}
+	return m.currentCursor
+}
+
+func (m *AdoptTreeSelectorModel) getNextBranch() plumbing.ReferenceName {
+	for i, branch := range m.adoptionTargets {
+		if branch == m.currentCursor {
+			if i == len(m.adoptionTargets)-1 {
+				return m.currentCursor
+			}
+			return m.adoptionTargets[i+1]
+		}
+	}
+	return m.currentCursor
+}
+
+func (m *AdoptTreeSelectorModel) toggleAdoption(branch plumbing.ReferenceName) {
+	if m.chosenTargets[branch] {
+		// Going to unchoose. Unchoose all children as well.
+		children := treedetector.GetChildren(m.branches, branch)
+		for bn := range children {
+			delete(m.chosenTargets, bn)
+		}
+		delete(m.chosenTargets, branch)
+	} else {
+		// Going to choose. Choose all parents as well.
+		piece := m.branches[branch]
+		for slices.Contains(m.adoptionTargets, piece.Name) {
+			m.chosenTargets[piece.Name] = true
+			if piece.Parent == "" || piece.ParentIsTrunk {
+				break
+			}
+			piece = m.branches[piece.Parent]
+		}
+	}
+}
+
+var promptKeys = []key.Binding{
+	key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "move up"),
+	),
+	key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "move down"),
+	),
+	key.NewBinding(
+		key.WithKeys("space"),
+		key.WithHelp("space", "select / unselect"),
+	),
+	key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "adopt selected branches"),
+	),
+	key.NewBinding(
+		key.WithKeys("ctrl+c"),
+		key.WithHelp("ctrl+c", "cancel"),
+	),
+}

--- a/internal/actions/find_adoptable_local_branches.go
+++ b/internal/actions/find_adoptable_local_branches.go
@@ -1,0 +1,128 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/treedetector"
+	"github.com/aviator-co/av/internal/utils/colors"
+	"github.com/aviator-co/av/internal/utils/stackutils"
+	"github.com/aviator-co/av/internal/utils/uiutils"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func NewFindAdoptableLocalBranchesModel(
+	repo *git.Repo,
+	db meta.DB,
+	onDone func(
+		branches map[plumbing.ReferenceName]*treedetector.BranchPiece,
+		rootNodes []*stackutils.StackTreeNode,
+		adoptionTargets []plumbing.ReferenceName,
+	) tea.Cmd,
+) tea.Model {
+	return &FindAdoptableLocalBranchesModel{
+		repo:    repo,
+		db:      db,
+		spinner: spinner.New(spinner.WithSpinner(spinner.Dot)),
+		onDone:  onDone,
+	}
+}
+
+type FindAdoptableLocalBranchesModel struct {
+	repo    *git.Repo
+	db      meta.DB
+	spinner spinner.Model
+	done    bool
+	onDone  func(
+		branches map[plumbing.ReferenceName]*treedetector.BranchPiece,
+		rootNodes []*stackutils.StackTreeNode,
+		adoptionTargets []plumbing.ReferenceName,
+	) tea.Cmd
+}
+
+func (m *FindAdoptableLocalBranchesModel) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, func() tea.Msg {
+		unmanagedBranches, err := m.getUnmanagedBranches()
+		if err != nil {
+			return err
+		}
+		branches, err := treedetector.DetectBranches(context.Background(), m.repo, unmanagedBranches)
+		if err != nil {
+			return err
+		}
+		if len(branches) == 0 {
+			m.done = true
+			return uiutils.SimpleCommandMsg{
+				Cmd: m.onDone(nil, nil, nil),
+			}
+		}
+		rootNodes := treedetector.ConvertToStackTree(m.db, branches, plumbing.HEAD, false)
+		if len(rootNodes) == 0 {
+			m.done = true
+			return uiutils.SimpleCommandMsg{
+				Cmd: m.onDone(nil, nil, nil),
+			}
+		}
+		adoptionTargets := m.getAdoptionTargets(rootNodes[0])
+		m.done = true
+		return uiutils.SimpleCommandMsg{
+			Cmd: m.onDone(branches, rootNodes, adoptionTargets),
+		}
+	})
+}
+
+func (m *FindAdoptableLocalBranchesModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m *FindAdoptableLocalBranchesModel) View() string {
+	if m.done {
+		return ""
+	}
+	return colors.ProgressStyle.Render(m.spinner.View() + "Finding adoptable branches...")
+}
+
+func (m *FindAdoptableLocalBranchesModel) getUnmanagedBranches() ([]plumbing.ReferenceName, error) {
+	tx := m.db.ReadTx()
+	adoptedBranches := tx.AllBranches()
+	branches, err := m.repo.GoGitRepo().Branches()
+	if err != nil {
+		return nil, err
+	}
+	var ret []plumbing.ReferenceName
+	if err := branches.ForEach(func(ref *plumbing.Reference) error {
+		if ref.Type() != plumbing.HashReference {
+			return nil
+		}
+		if _, adopted := adoptedBranches[ref.Name().Short()]; !adopted {
+			ret = append(ret, ref.Name())
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (m *FindAdoptableLocalBranchesModel) getAdoptionTargets(node *stackutils.StackTreeNode) []plumbing.ReferenceName {
+	var ret []plumbing.ReferenceName
+	for _, child := range node.Children {
+		ret = append(ret, m.getAdoptionTargets(child)...)
+	}
+	if node.Branch.ParentBranchName != "" {
+		_, adopted := m.db.ReadTx().Branch(node.Branch.BranchName)
+		if !adopted {
+			ret = append(ret, plumbing.NewBranchReferenceName(node.Branch.BranchName))
+		}
+	}
+	return ret
+}

--- a/internal/utils/uiutils/simple_command.go
+++ b/internal/utils/uiutils/simple_command.go
@@ -1,0 +1,7 @@
+package uiutils
+
+import tea "github.com/charmbracelet/bubbletea"
+
+type SimpleCommandMsg struct {
+	Cmd tea.Cmd
+}


### PR DESCRIPTION
This is to prepare for adding remote branch adoption feature.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
