### PR TITLE
Extract MergeCommit for remote branches

### DIFF
--- a/internal/actions/get_remote_stacked_pr.go
+++ b/internal/actions/get_remote_stacked_pr.go
@@ -33,6 +33,7 @@ type RemotePRInfo struct {
 	Name        string
 	Parent      meta.BranchState
 	PullRequest meta.PullRequest
+	MergeCommit string
 	Title       string
 }
 
@@ -104,7 +105,8 @@ func (m *GetRemoteStackedPRModel) Init() tea.Cmd {
 					Permalink: pr.Permalink,
 					State:     pr.State,
 				},
-				Title: pr.Title,
+				MergeCommit: pr.GetMergeCommit(),
+				Title:       pr.Title,
 			}
 			m.prs = append(m.prs, remotePRInfo)
 			if remotePRInfo.Parent.Trunk {


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"no_branch_adopted","parentHead":"031950c78f5b38b5e42e243f76ad57bfdf1ca9bb","parentPull":618,"trunk":"master"}
```
-->
