### PR TITLE
Allow specifying the branching point even for trunk parents

### DIFF
--- a/cmd/av/adopt.go
+++ b/cmd/av/adopt.go
@@ -131,9 +131,9 @@ func adoptForceAdoption(
 			return err
 		}
 		branch.Parent = meta.BranchState{
-			Name:  parent,
-			Trunk: false,
-			Head:  mergeBase,
+			Name:                     parent,
+			Trunk:                    false,
+			BranchingPointCommitHash: mergeBase,
 		}
 		tx.SetBranch(branch)
 	}
@@ -242,7 +242,7 @@ func (vm *adoptViewModel) initAdoption(chosenTargets []plumbing.ReferenceName) t
 			},
 		}
 		if !piece.ParentIsTrunk {
-			ab.Parent.Head = piece.ParentMergeBase.String()
+			ab.Parent.BranchingPointCommitHash = piece.ParentMergeBase.String()
 		}
 		branches = append(branches, ab)
 	}

--- a/cmd/av/branch.go
+++ b/cmd/av/branch.go
@@ -373,9 +373,9 @@ func createBranch(
 	tx.SetBranch(meta.Branch{
 		Name: branchName,
 		Parent: meta.BranchState{
-			Name:  parentBranchName,
-			Trunk: isBranchFromTrunk,
-			Head:  parentHead,
+			Name:                     parentBranchName,
+			Trunk:                    isBranchFromTrunk,
+			BranchingPointCommitHash: parentHead,
 		},
 	})
 

--- a/cmd/av/branchmeta.go
+++ b/cmd/av/branchmeta.go
@@ -108,9 +108,9 @@ var branchMetaSetCmd = &cobra.Command{
 				}
 			}
 			br.Parent = meta.BranchState{
-				Name:  branchMetaFlags.parent,
-				Trunk: branchMetaFlags.trunk,
-				Head:  parentHead,
+				Name:                     branchMetaFlags.parent,
+				Trunk:                    branchMetaFlags.trunk,
+				BranchingPointCommitHash: parentHead,
 			}
 		}
 		tx.SetBranch(br)

--- a/cmd/av/diff.go
+++ b/cmd/av/diff.go
@@ -90,7 +90,7 @@ Generates the diff between the working tree and the parent branch
 			// have those changes). Instead, we want to compute the diff between
 			// 1a and 2a. We can't just use merge-base here to account for the
 			// fact that one might be amended (not just advanced).
-			diffArgs = append(diffArgs, branch.Parent.Head)
+			diffArgs = append(diffArgs, branch.Parent.BranchingPointCommitHash)
 
 			// Determine if the branch is up-to-date with the parent and warn if
 			// not.
@@ -98,7 +98,7 @@ Generates the diff between the working tree and the parent branch
 			if err != nil {
 				return err
 			}
-			notUpToDate = currentParentHead != branch.Parent.Head
+			notUpToDate = currentParentHead != branch.Parent.BranchingPointCommitHash
 		}
 
 		// NOTE:

--- a/e2e_tests/restack_test.go
+++ b/e2e_tests/restack_test.go
@@ -149,16 +149,16 @@ func TestRestack(t *testing.T) {
 		Trunk: true,
 	}, GetStoredParentBranchState(t, repo, "stack-1"))
 	require.Equal(t, meta.BranchState{
-		Name: "stack-1",
-		Head: stack1Commit.String(),
+		Name:                     "stack-1",
+		BranchingPointCommitHash: stack1Commit.String(),
 	}, GetStoredParentBranchState(t, repo, "stack-2"))
 	require.Equal(t, meta.BranchState{
-		Name: "stack-2",
-		Head: stack2Commit.String(),
+		Name:                     "stack-2",
+		BranchingPointCommitHash: stack2Commit.String(),
 	}, GetStoredParentBranchState(t, repo, "stack-3"))
 	require.Equal(t, meta.BranchState{
-		Name: "stack-1",
-		Head: stack1Commit.String(),
+		Name:                     "stack-1",
+		BranchingPointCommitHash: stack1Commit.String(),
 	}, GetStoredParentBranchState(t, repo, "stack-4"))
 }
 
@@ -214,8 +214,8 @@ func TestStackRestackAbort(t *testing.T) {
 	// Because we aborted the sync, the stack-2 parent HEAD must stay at the original stack-1
 	// HEAD.
 	require.Equal(t, meta.BranchState{
-		Name: "stack-1",
-		Head: origStack1Commit.String(),
+		Name:                     "stack-1",
+		BranchingPointCommitHash: origStack1Commit.String(),
 	}, GetStoredParentBranchState(t, repo, "stack-2"))
 }
 

--- a/e2e_tests/sync_test.go
+++ b/e2e_tests/sync_test.go
@@ -155,16 +155,16 @@ func TestSync(t *testing.T) {
 		Trunk: true,
 	}, GetStoredParentBranchState(t, repo, "stack-1"))
 	require.Equal(t, meta.BranchState{
-		Name: "stack-1",
-		Head: stack1Commit.String(),
+		Name:                     "stack-1",
+		BranchingPointCommitHash: stack1Commit.String(),
 	}, GetStoredParentBranchState(t, repo, "stack-2"))
 	require.Equal(t, meta.BranchState{
-		Name: "stack-2",
-		Head: stack2Commit.String(),
+		Name:                     "stack-2",
+		BranchingPointCommitHash: stack2Commit.String(),
 	}, GetStoredParentBranchState(t, repo, "stack-3"))
 	require.Equal(t, meta.BranchState{
-		Name: "stack-1",
-		Head: stack1Commit.String(),
+		Name:                     "stack-1",
+		BranchingPointCommitHash: stack1Commit.String(),
 	}, GetStoredParentBranchState(t, repo, "stack-4"))
 }
 
@@ -222,8 +222,8 @@ func TestStackSyncAbort(t *testing.T) {
 	// Because we aborted the sync, the stack-2 parent HEAD must stay at the original stack-1
 	// HEAD.
 	require.Equal(t, meta.BranchState{
-		Name: "stack-1",
-		Head: origStack1Commit.String(),
+		Name:                     "stack-1",
+		BranchingPointCommitHash: origStack1Commit.String(),
 	}, GetStoredParentBranchState(t, repo, "stack-2"))
 }
 

--- a/internal/actions/get_remote_stacked_pr.go
+++ b/internal/actions/get_remote_stacked_pr.go
@@ -95,9 +95,9 @@ func (m *GetRemoteStackedPRModel) Init() tea.Cmd {
 			remotePRInfo := RemotePRInfo{
 				Name: strings.TrimPrefix(pr.HeadRefName, "refs/heads/"),
 				Parent: meta.BranchState{
-					Name:  prMeta.Parent,
-					Head:  prMeta.ParentHead,
-					Trunk: prMeta.ParentHead == "",
+					Name:                     prMeta.Parent,
+					Trunk:                    prMeta.Trunk == prMeta.Parent,
+					BranchingPointCommitHash: prMeta.ParentHead,
 				},
 				PullRequest: meta.PullRequest{
 					ID:        pr.ID,

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -73,7 +73,7 @@ func getPRMetadata(
 	trunk, _ := meta.Trunk(tx, branch.Name)
 	prMeta := PRMetadata{
 		Parent:     branch.Parent.Name,
-		ParentHead: branch.Parent.Head,
+		ParentHead: branch.Parent.BranchingPointCommitHash,
 		Trunk:      trunk,
 	}
 	if parent == nil && branch.Parent.Name != "" {

--- a/internal/gh/ghui/push.go
+++ b/internal/gh/ghui/push.go
@@ -566,7 +566,7 @@ func (vm *GitHubPushModel) createPRMetadata(branch meta.Branch) actions.PRMetada
 
 	metadata := actions.PRMetadata{
 		Parent:     branch.Parent.Name,
-		ParentHead: branch.Parent.Head,
+		ParentHead: branch.Parent.BranchingPointCommitHash,
 		Trunk:      trunk,
 	}
 

--- a/internal/meta/branchstate.go
+++ b/internal/meta/branchstate.go
@@ -18,11 +18,24 @@ type BranchState struct {
 	// master.
 	Trunk bool `json:"trunk,omitempty"`
 
-	// The commit SHA of the parent's latest commit. This is used when syncing
-	// the branch with the parent to identify the commits that belong to the
-	// child branch (since the HEAD of the parent branch may change).
-	// This will be unset if Trunk is true.
-	Head string `json:"head,omitempty"`
+	// The branching point commit hash.
+	//
+	// When we start a new branch off of a parent branch, we record the
+	// commit SHA of the parent's latest commit at that time as the
+	// branching point commit hash. This allows us to later identify which
+	// commits belong to the child branch when syncing with the parent
+	// branch.
+	//
+	// NOTE: This field is named "head" in the JSON for historical reasons.
+	//
+	// This field may be empty if the branching off from a trunk branch. In
+	// that case, we will find the branching point commit hash based on `git
+	// merge-base`. Note that this will only work if the trunk branch has
+	// not been rebased since the branch was created, which typically
+	// stands. On the other hand, when branching off of a non-trunk branch,
+	// we should almost always set this field as the non-trunk branches are
+	// tend to be rebased.
+	BranchingPointCommitHash string `json:"head,omitempty"`
 }
 
 // unmarshalBranchState unmarshals a BranchState from JSON (which can either be
@@ -42,7 +55,7 @@ func unmarshalBranchState(data []byte) (BranchState, error) {
 		if s == "" {
 			return BranchState{}, nil
 		}
-		return BranchState{Name: s, Head: ""}, nil
+		return BranchState{Name: s, BranchingPointCommitHash: ""}, nil
 	}
 
 	// Define a type alias here so that it doesn't have the UnmarshalJSON

--- a/internal/reorder/plan.go
+++ b/internal/reorder/plan.go
@@ -31,9 +31,9 @@ func CreatePlan(
 		var upstreamCommit string
 		// TODO: would be nice to show the user whether or not the branch is
 		// 		already up-to-date with the parent.
-		if branch.Parent.Head != "" {
+		if branch.Parent.BranchingPointCommitHash != "" {
 			branchCmd.Parent = branch.Parent.Name
-			upstreamCommit = branch.Parent.Head
+			upstreamCommit = branch.Parent.BranchingPointCommitHash
 		} else {
 			trunkCommit, err := repo.MergeBase(ctx, branchName, "origin/"+branch.Parent.Name)
 			if err != nil {

--- a/internal/reorder/plan_test.go
+++ b/internal/reorder/plan_test.go
@@ -38,9 +38,9 @@ func TestCreatePlan(t *testing.T) {
 	tx.SetBranch(meta.Branch{
 		Name: "two",
 		Parent: meta.BranchState{
-			Name:  "one",
-			Trunk: false,
-			Head:  c1b.String(),
+			Name:                     "one",
+			Trunk:                    false,
+			BranchingPointCommitHash: c1b.String(),
 		},
 	})
 	require.NoError(t, tx.Commit())

--- a/internal/reorder/stackbranch.go
+++ b/internal/reorder/stackbranch.go
@@ -64,7 +64,7 @@ func (b StackBranchCmd) Execute(ctx *Context) error {
 		if err != nil {
 			return err
 		}
-		parentState.Head = headCommit
+		parentState.BranchingPointCommitHash = headCommit
 	}
 	branch.Parent = parentState
 	tx.SetBranch(branch)

--- a/internal/sequencer/sequencer.go
+++ b/internal/sequencer/sequencer.go
@@ -83,7 +83,7 @@ func getBranchSnapshots(db meta.DB) map[plumbing.ReferenceName]*branchSnapshot {
 		if avbr.Parent.Trunk {
 			snapshot.IsParentTrunk = true
 		} else {
-			snapshot.PreviouslySyncedParentBranchHash = plumbing.NewHash(avbr.Parent.Head)
+			snapshot.PreviouslySyncedParentBranchHash = plumbing.NewHash(avbr.Parent.BranchingPointCommitHash)
 		}
 	}
 	return ret
@@ -274,7 +274,7 @@ func (seq *Sequencer) postRebaseBranchUpdate(db meta.DB, newParentHash plumbing.
 		Trunk: op.NewParentIsTrunk,
 	}
 	if !op.NewParentIsTrunk {
-		newParentBranchState.Head = newParentHash.String()
+		newParentBranchState.BranchingPointCommitHash = newParentHash.String()
 	}
 
 	tx := db.WriteTx()


### PR DESCRIPTION
This relax the semantics of the branch metadata. In the branch metadata,
we track `trunk: bool` and `head: string`, but only one of them could be
specified in the current semantics. This update allows them to specify
both. That is, even if the parent branch is a trunk branch, a branch
metadata can specify the branching point. Accordingly, we update the
internal name of that branching point as BranchingPointCommitHash.

Newly added av branch --remote motivates this change. In that command,
we might see a partially merged stack. In that case, we will have a case
where a topic branch would have a trunk branch as a parent (because its
original parent has been merged), but at the same time, such topic
branches would need to have an explicit branching point in order to
avoid already merged commits to be considered as a part of that topic
branch.

Behavior updates would be necessary in the sequencer, but we will do
that in the following PRs.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"deprecate_refmeta","parentHead":"cddea1f0bf2271e3d3b7c563a1c97a6b8ac487db","parentPull":620,"trunk":"master"}
```
-->
