### PR TITLE
Check if the default branch is set when opening a repository

### DIFF
--- a/cmd/av/adopt.go
+++ b/cmd/av/adopt.go
@@ -105,16 +105,11 @@ func adoptForceAdoption(
 		return errors.New("cannot adopt the current branch as its parent")
 	}
 
-	if isCurrentBranchTrunk, err := repo.IsTrunkBranch(ctx, currentBranch); err != nil {
-		return errors.Wrap(err, "failed to check if the current branch is trunk")
-	} else if isCurrentBranchTrunk {
+	if repo.IsTrunkBranch(currentBranch) {
 		return errors.New("cannot adopt the default branch")
 	}
 
-	isParentBranchTrunk, err := repo.IsTrunkBranch(ctx, parent)
-	if err != nil {
-		return errors.Wrap(err, "failed to check if the parent branch is trunk")
-	}
+	isParentBranchTrunk := repo.IsTrunkBranch(parent)
 	if isParentBranchTrunk {
 		branch.Parent = meta.BranchState{
 			Name:  parent,

--- a/cmd/av/branch.go
+++ b/cmd/av/branch.go
@@ -268,10 +268,7 @@ func createBranch(
 ) (reterr error) {
 	// Determine important contextual information from Git
 	// or if a parent branch is provided, check it allows as a default branch
-	defaultBranch, err := repo.DefaultBranch(ctx)
-	if err != nil {
-		return errors.WrapIf(err, "failed to determine repository default branch")
-	}
+	defaultBranch := repo.DefaultBranch()
 
 	tx := db.WriteTx()
 	cu := cleanup.New(func() {
@@ -283,7 +280,7 @@ func createBranch(
 	// Determine the parent branch and make sure it's checked out
 	if parentBranchName == "" {
 		var err error
-		parentBranchName, err = repo.CurrentBranchName(ctx)
+		parentBranchName, err = repo.CurrentBranchName()
 		if err != nil {
 			return errors.WrapIff(err, "failed to get current branch name")
 		}
@@ -295,10 +292,7 @@ func createBranch(
 	}
 	parentBranchName = strings.TrimPrefix(parentBranchName, remoteName+"/")
 
-	isBranchFromTrunk, err := repo.IsTrunkBranch(ctx, parentBranchName)
-	if err != nil {
-		return errors.WrapIf(err, "failed to determine if branch is a trunk")
-	}
+	isBranchFromTrunk := repo.IsTrunkBranch(parentBranchName)
 	checkoutStartingPoint := parentBranchName
 	var parentHead string
 	if isBranchFromTrunk {
@@ -403,7 +397,7 @@ func branchMove(
 		oldBranch, newBranch, _ = strings.Cut(newBranch, ":")
 	} else {
 		var err error
-		oldBranch, err = repo.CurrentBranchName(ctx)
+		oldBranch, err = repo.CurrentBranchName()
 		if err != nil {
 			return err
 		}
@@ -422,10 +416,7 @@ func branchMove(
 
 	currentMeta, ok := tx.Branch(oldBranch)
 	if !ok {
-		defaultBranch, err := repo.DefaultBranch(ctx)
-		if err != nil {
-			return errors.WrapIf(err, "failed to determine repository default branch")
-		}
+		defaultBranch := repo.DefaultBranch()
 		currentMeta.Parent = meta.BranchState{
 			Name:  defaultBranch,
 			Trunk: true,

--- a/cmd/av/commit.go
+++ b/cmd/av/commit.go
@@ -103,7 +103,7 @@ var commitCmd = &cobra.Command{
 }
 
 func runCreate(ctx context.Context, repo *git.Repo, db meta.DB) error {
-	currentBranch, err := repo.CurrentBranchName(ctx)
+	currentBranch, err := repo.CurrentBranchName()
 	if err != nil {
 		return errors.WrapIf(err, "failed to determine current branch")
 	}
@@ -182,7 +182,7 @@ func runAmend(
 	edit bool,
 	all bool,
 ) error {
-	currentBranch, err := repo.CurrentBranchName(ctx)
+	currentBranch, err := repo.CurrentBranchName()
 	if err != nil {
 		return errors.WrapIf(err, "failed to determine current branch")
 	}

--- a/cmd/av/commit_common.go
+++ b/cmd/av/commit_common.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"strings"
 
 	"emperror.dev/errors"
@@ -114,7 +113,7 @@ func (vm *postCommitRestackViewModel) writeState(state *sequencerui.RestackState
 }
 
 func (vm *postCommitRestackViewModel) createState() (*sequencerui.RestackState, error) {
-	currentBranch, err := vm.repo.CurrentBranchName(context.Background())
+	currentBranch, err := vm.repo.CurrentBranchName()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/av/diff.go
+++ b/cmd/av/diff.go
@@ -33,7 +33,7 @@ Generates the diff between the working tree and the parent branch
 			return err
 		}
 
-		currentBranchName, err := repo.CurrentBranchName(ctx)
+		currentBranchName, err := repo.CurrentBranchName()
 		if err != nil {
 			return err
 		}
@@ -41,10 +41,7 @@ Generates the diff between the working tree and the parent branch
 		tx := db.ReadTx()
 		branch, exists := tx.Branch(currentBranchName)
 		if !exists {
-			defaultBranch, err := repo.DefaultBranch(ctx)
-			if err != nil {
-				return err
-			}
+			defaultBranch := repo.DefaultBranch()
 			branch.Parent = meta.BranchState{
 				Name:  defaultBranch,
 				Trunk: true,

--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -57,7 +57,7 @@ var ErrRepoNotInitialized = errors.Sentinel(
 )
 
 func getDB(ctx context.Context, repo *git.Repo) (meta.DB, error) {
-	db, exists, err := getOrCreateDB(ctx, repo)
+	db, exists, err := getOrCreateDB(repo)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func getDB(ctx context.Context, repo *git.Repo) (meta.DB, error) {
 	return db, nil
 }
 
-func getOrCreateDB(ctx context.Context, repo *git.Repo) (meta.DB, bool, error) {
+func getOrCreateDB(repo *git.Repo) (meta.DB, bool, error) {
 	dbPath := filepath.Join(repo.AvDir(), "av.db")
 	return jsonfiledb.OpenPath(dbPath)
 }
@@ -82,11 +82,7 @@ func allBranches(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	defaultBranch, err := repo.DefaultBranch(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+	defaultBranch := repo.DefaultBranch()
 	tx := db.ReadTx()
 
 	branches := []string{defaultBranch}

--- a/cmd/av/init.go
+++ b/cmd/av/init.go
@@ -21,7 +21,7 @@ var initCmd = &cobra.Command{
 			return err
 		}
 
-		db, _, err := getOrCreateDB(ctx, repo)
+		db, _, err := getOrCreateDB(repo)
 		if err != nil {
 			return err
 		}

--- a/cmd/av/next.go
+++ b/cmd/av/next.go
@@ -80,7 +80,7 @@ func newNextModel(ctx context.Context, lastInStack bool, nInStack int) (stackNex
 		return stackNextModel{}, err
 	}
 
-	currentBranch, err := repo.CurrentBranchName(ctx)
+	currentBranch, err := repo.CurrentBranchName()
 	if err != nil {
 		return stackNextModel{}, err
 	}

--- a/cmd/av/orphan.go
+++ b/cmd/av/orphan.go
@@ -28,7 +28,7 @@ var orphanCmd = &cobra.Command{
 		tx := db.WriteTx()
 		defer tx.Abort()
 
-		currentBranch, err := repo.CurrentBranchName(ctx)
+		currentBranch, err := repo.CurrentBranchName()
 		if err != nil {
 			return errors.WrapIf(err, "failed to determine current branch")
 		}

--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -93,7 +93,7 @@ Examples:
 		if err != nil {
 			return err
 		}
-		branchName, err := repo.CurrentBranchName(ctx)
+		branchName, err := repo.CurrentBranchName()
 		if err != nil {
 			return errors.WrapIf(err, "failed to determine current branch")
 		}
@@ -183,7 +183,7 @@ func submitAll(ctx context.Context, current bool, draft bool) error {
 	cu := cleanup.New(func() { tx.Abort() })
 	defer cu.Cleanup()
 
-	currentBranch, err := repo.CurrentBranchName(ctx)
+	currentBranch, err := repo.CurrentBranchName()
 	if err != nil {
 		return err
 	}
@@ -288,7 +288,7 @@ func queue(ctx context.Context) error {
 	}
 
 	tx := db.ReadTx()
-	currentBranchName, err := repo.CurrentBranchName(ctx)
+	currentBranchName, err := repo.CurrentBranchName()
 	if err != nil {
 		return err
 	}

--- a/cmd/av/pr_status.go
+++ b/cmd/av/pr_status.go
@@ -211,7 +211,7 @@ func getQueryVariables(ctx context.Context) (map[string]any, error) {
 
 	tx := db.ReadTx()
 
-	currentBranchName, err := repo.CurrentBranchName(ctx)
+	currentBranchName, err := repo.CurrentBranchName()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/av/prev.go
+++ b/cmd/av/prev.go
@@ -33,14 +33,11 @@ var prevCmd = &cobra.Command{
 			return err
 		}
 		tx := db.ReadTx()
-		currentBranch, err := repo.CurrentBranchName(ctx)
+		currentBranch, err := repo.CurrentBranchName()
 		if err != nil {
 			return err
 		}
-		isCurrentBranchTrunk, err := repo.IsTrunkBranch(ctx, currentBranch)
-		if err != nil {
-			return err
-		} else if isCurrentBranchTrunk {
+		if repo.IsTrunkBranch(currentBranch) {
 			fmt.Fprint(os.Stderr, "already on trunk branch (", colors.UserInput(currentBranch), ")\n")
 			return nil
 		}

--- a/cmd/av/reorder.go
+++ b/cmd/av/reorder.go
@@ -87,7 +87,7 @@ squashed, dropped, or moved within the stack.
 				return actions.ErrExitSilently{ExitCode: 127}
 			}
 			tx := db.ReadTx()
-			currentBranch, err := repo.CurrentBranchName(ctx)
+			currentBranch, err := repo.CurrentBranchName()
 			if err != nil {
 				return err
 			}

--- a/cmd/av/reparent.go
+++ b/cmd/av/reparent.go
@@ -145,22 +145,18 @@ func (vm *reparentViewModel) writeState(state *sequencerui.RestackState) error {
 
 func (vm *reparentViewModel) createState() (*sequencerui.RestackState, error) {
 	ctx := context.Background()
-	currentBranch, err := vm.repo.CurrentBranchName(ctx)
+	currentBranch, err := vm.repo.CurrentBranchName()
 	if err != nil {
 		return nil, err
 	}
-	if isCurrentBranchTrunk, err := vm.repo.IsTrunkBranch(ctx, currentBranch); err != nil {
-		return nil, err
-	} else if isCurrentBranchTrunk {
+	if vm.repo.IsTrunkBranch(currentBranch) {
 		return nil, errors.New("current branch is a trunk branch")
 	}
 	if _, exist := vm.db.ReadTx().Branch(currentBranch); !exist {
 		return nil, errors.New("current branch is not adopted to av")
 	}
 
-	if isParentBranchTrunk, err := vm.repo.IsTrunkBranch(ctx, reparentFlags.Parent); err != nil {
-		return nil, err
-	} else if !isParentBranchTrunk {
+	if !vm.repo.IsTrunkBranch(reparentFlags.Parent) {
 		if _, exist := vm.db.ReadTx().Branch(reparentFlags.Parent); !exist {
 			return nil, errors.New("parent branch is not adopted to av")
 		}

--- a/cmd/av/squash.go
+++ b/cmd/av/squash.go
@@ -52,7 +52,7 @@ func runSquash(ctx context.Context, repo *git.Repo, db meta.DB) error {
 		)
 	}
 
-	currentBranchName, err := repo.CurrentBranchName(ctx)
+	currentBranchName, err := repo.CurrentBranchName()
 	if err != nil {
 		return err
 	}

--- a/cmd/av/stack_foreach.go
+++ b/cmd/av/stack_foreach.go
@@ -52,7 +52,7 @@ Examples:
 			return err
 		}
 		tx := db.ReadTx()
-		currentBranch, err := repo.CurrentBranchName(ctx)
+		currentBranch, err := repo.CurrentBranchName()
 		if err != nil {
 			return err
 		}

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -145,7 +145,7 @@ func (vm *syncViewModel) initSync() tea.Cmd {
 		return uiutils.ErrCmd(errors.New("no restack in progress"))
 	}
 
-	isTrunkBranch, err := vm.repo.IsCurrentBranchTrunk(context.Background())
+	isTrunkBranch, err := vm.repo.IsCurrentBranchTrunk()
 	if err != nil {
 		return uiutils.ErrCmd(err)
 	}

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -224,10 +224,7 @@ func CreatePullRequest(
 	// figure this out based on whether or not we're on a stacked branch
 	parentState := branchMeta.Parent
 	if parentState.Name == "" {
-		defaultBranch, err := repo.DefaultBranch(ctx)
-		if err != nil {
-			return nil, errors.WrapIf(err, "failed to determine default branch")
-		}
+		defaultBranch := repo.DefaultBranch()
 		parentState = meta.BranchState{
 			Name:  defaultBranch,
 			Trunk: true,

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -26,21 +26,23 @@ func TestOrigin(t *testing.T) {
 func TestTrunkBranches(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
 
-	branches, err := repo.AsAvGitRepo().TrunkBranches(t.Context())
-	require.NoError(t, err)
+	branches := repo.AsAvGitRepo().TrunkBranches()
 	require.Equal(t, branches, []string{"main"})
 
 	// add some branches to AdditionalTrunkBranches
 	config.Av.AdditionalTrunkBranches = []string{"develop", "staging"}
-	branches, err = repo.AsAvGitRepo().TrunkBranches(t.Context())
-	require.NoError(t, err)
+	branches = repo.AsAvGitRepo().TrunkBranches()
 	require.Equal(t, branches, []string{"main", "develop", "staging"})
 }
 
 func TestGetRemoteName(t *testing.T) {
 	repo := gittest.NewTempRepo(t)
-	require.Equal(t, repo.AsAvGitRepo().GetRemoteName(), git.DEFAULT_REMOTE_NAME)
+	avGitRepo := repo.AsAvGitRepo()
+	require.Equal(t, avGitRepo.GetRemoteName(), git.DEFAULT_REMOTE_NAME)
 
+	// This is a global config, so changing it here affects other tests. Be
+	// sure to reset it.
 	config.Av.Remote = "new-remote"
-	require.Equal(t, repo.AsAvGitRepo().GetRemoteName(), "new-remote")
+	require.Equal(t, avGitRepo.GetRemoteName(), "new-remote")
+	config.Av.Remote = ""
 }

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -80,6 +80,9 @@ func NewTempRepoWithGitHubServer(t *testing.T, serverURL string) *GitTestRepo {
 	repo.Git(t, "commit", "-m", "Initial commit")
 	repo.Git(t, "push", "origin", "main")
 
+	repo.Git(t, "remote", "set-head", "--auto", "origin")
+	repo.Git(t, "branch", "--all")
+
 	// Write metadata because some commands expect it to be there.
 	// This repository obviously doesn't exist so tests still need to be careful
 	// not to invoke operations that would communicate with GitHub (e.g.,
@@ -117,7 +120,10 @@ type GitTestRepo struct {
 }
 
 func (r *GitTestRepo) AsAvGitRepo() *avgit.Repo {
-	repo, _ := avgit.OpenRepo(r.RepoDir, r.GitDir)
+	repo, err := avgit.OpenRepo(r.RepoDir, r.GitDir)
+	if err != nil {
+		panic(fmt.Sprintf("failed to open av git repo: %v", err))
+	}
 	return repo
 }
 

--- a/internal/git/gitui/prune.go
+++ b/internal/git/gitui/prune.go
@@ -254,10 +254,7 @@ func (vm *PruneBranchModel) CheckoutInitialState() error {
 	}
 
 	// The branch is deleted. Let's checkout the default branch.
-	defaultBranch, err := vm.repo.DefaultBranch(context.Background())
-	if err != nil {
-		return err
-	}
+	defaultBranch := vm.repo.DefaultBranch()
 	defaultBranchRef := plumbing.NewBranchReferenceName(defaultBranch)
 	ref, err := vm.repo.GoGitRepo().Reference(defaultBranchRef, true)
 	if err == nil {

--- a/internal/sequencer/planner/planner.go
+++ b/internal/sequencer/planner/planner.go
@@ -120,10 +120,7 @@ func PlanForReparent(
 	if slices.Contains(children, newParentBranch.Short()) {
 		return nil, errors.New("cannot re-parent to a child branch")
 	}
-	isParentTrunk, err := repo.IsTrunkBranch(ctx, newParentBranch.Short())
-	if err != nil {
-		return nil, err
-	}
+	isParentTrunk := repo.IsTrunkBranch(newParentBranch.Short())
 	var ret []sequencer.RestackOp
 	ret = append(ret, sequencer.RestackOp{
 		Name:             currentBranch,

--- a/internal/sequencer/planner/targets.go
+++ b/internal/sequencer/planner/targets.go
@@ -48,7 +48,7 @@ func GetTargetBranches(
 		return ret, nil
 	}
 	if mode == CurrentAndParents {
-		curr, err := repo.CurrentBranchName(ctx)
+		curr, err := repo.CurrentBranchName()
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +69,7 @@ func GetTargetBranches(
 		return ret, nil
 	}
 	if mode == CurrentAndChildren {
-		curr, err := repo.CurrentBranchName(ctx)
+		curr, err := repo.CurrentBranchName()
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +83,7 @@ func GetTargetBranches(
 		}
 		return ret, nil
 	}
-	curr, err := repo.CurrentBranchName(ctx)
+	curr, err := repo.CurrentBranchName()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/treedetector/detector.go
+++ b/internal/treedetector/detector.go
@@ -49,7 +49,7 @@ func DetectBranches(
 			// don't have to adopt it.
 			continue
 		}
-		bp, err := traverseUntilTrunk(ctx, repo, bn, nearestTrunkCommit, hashToRefMap, refToHashMap)
+		bp, err := traverseUntilTrunk(repo, bn, nearestTrunkCommit, hashToRefMap, refToHashMap)
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +59,6 @@ func DetectBranches(
 }
 
 func traverseUntilTrunk(
-	ctx context.Context,
 	repo *avgit.Repo,
 	branch plumbing.ReferenceName,
 	nearestTrunkCommit plumbing.Hash,
@@ -77,10 +76,7 @@ func traverseUntilTrunk(
 	// commit that has multiple parents.
 	err = object.NewCommitPreorderIter(commit, nil, nil).ForEach(func(c *object.Commit) error {
 		if c.Hash == nearestTrunkCommit {
-			trunk, err := repo.DefaultBranch(ctx)
-			if err != nil {
-				return err
-			}
+			trunk := repo.DefaultBranch()
 			ret.Parent = plumbing.NewBranchReferenceName(trunk)
 			ret.ParentIsTrunk = true
 			ret.ParentMergeBase = c.Hash
@@ -116,10 +112,7 @@ func getNearestTrunkCommit(
 	repo *avgit.Repo,
 	ref plumbing.ReferenceName,
 ) (plumbing.Hash, error) {
-	trunk, err := repo.DefaultBranch(ctx)
-	if err != nil {
-		return plumbing.ZeroHash, err
-	}
+	trunk := repo.DefaultBranch()
 	rtb := fmt.Sprintf("refs/remotes/%s/%s", repo.GetRemoteName(), trunk)
 
 	mbArgs := []string{rtb, ref.String()}


### PR DESCRIPTION
We can check if the default branch at remote tracking branch
(refs/remotes/origin/HEAD) exists when opening a repository. By doing
so, we don't have to take context and do not have to do an error
handling in many situations.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"update_metadata_semantics","parentHead":"55a6700dc4c00be72721ad71f87e5a23659893bc","parentPull":621,"trunk":"master"}
```
-->
