### PR TITLE
Handle a case where a stack is partially merged

### DIFF
--- a/internal/actions/get_remote_stacked_pr.go
+++ b/internal/actions/get_remote_stacked_pr.go
@@ -88,7 +88,14 @@ func (m *GetRemoteStackedPRModel) Init() tea.Cmd {
 				}
 			}
 			prMeta, err := ReadPRMetadata(pr.Body)
-			if err != nil {
+			if errors.Is(err, ErrNoPRMetadata) {
+				prMeta = PRMetadata{
+					Parent:     pr.BaseBranchName(),
+					Trunk:      pr.BaseBranchName(),
+					ParentHead: "",
+					ParentPull: 0,
+				}
+			} else if err != nil {
 				m.failed = true
 				return errors.Wrapf(err, "failed to read metadata for PR %d", pr.Number)
 			}

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -29,6 +29,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var ErrNoPRMetadata = errors.Sentinel("no PR metadata found")
+
 type CreatePullRequestOpts struct {
 	// The HEAD branch to create a pull request for.
 	BranchName string
@@ -724,6 +726,10 @@ func extractContent(input string, start string, end string) (content string, out
 func ParsePRBody(input string) (body string, prMeta PRMetadata, retErr error) {
 	metadata, body := extractContent(input, PRMetadataCommentStart, PRMetadataCommentEnd)
 	metadataContent, _ := extractContent(metadata, "```", "```")
+	if metadataContent == "" {
+		retErr = ErrNoPRMetadata
+		return body, prMeta, retErr
+	}
 	if err := json.Unmarshal([]byte(metadataContent), &prMeta); err != nil {
 		retErr = errors.WrapIff(err, "decoding PR metadata")
 		return body, prMeta, retErr


### PR DESCRIPTION
There's a case where a stack is partially merged and not `av sync`ed. In
this case, the parent branch of the not-yet-merged branch no longer
exists on GitHub in many cases (but we can get the PR info via GraphQL
API). The current implementation fails on git-fetch as the branch
doesn't exist.

This change skips those merged branches and adopt only branches that are
still open. The branch metadata is (locally) updated to have a trunk
branch as the parent.

There was an issue that we couldn't restack those branches, but with a
series of changes around the branching point (such as
https://github.com/aviator-co/av/commit/e3a22062a5734108a7ddfb3345735d1c3b750168)
makes it possible to support this case.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
