### PR TITLE
Fix the documentation to use $GIT_EDITOR instead of $EDITOR

### DIFF
--- a/docs/av-commit.1.md
+++ b/docs/av-commit.1.md
@@ -37,7 +37,7 @@ git-add(1) to incrementally "add" changes to the index.
 : Amend the last commit, using the same message as last commit by default
 
 `--edit`
-: When amending a commit, open the default git `$EDITOR` for modifying the
+: When amending a commit, open the default `$GIT_EDITOR` for modifying the
   commit message
 
 `-b, --branch`

--- a/docs/av-pr.1.md
+++ b/docs/av-pr.1.md
@@ -16,8 +16,8 @@ av pr create [-t <title>| --title=<title>] [-b <body>| --body=<body>]
 
 Push the current branch and create a pull request if not exist. If the branch
 has a parent branch, you need to make a pull-request for the parent first. If
-title and body are not provided, `$EDITOR` pops up and you are asked to provide
-them.
+title and body are not provided, `$GIT_EDITOR` pops up and you are asked to
+provide them.
 
 When there's already a pull-request, the command just pushes the branch to
 remote, and you are not asked to provide the title and the body. If you want to


### PR DESCRIPTION
Fixes https://github.com/aviator-co/av/issues/617


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
