### PR TITLE
fix golangci-lint ci failure and pin lint version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,4 +44,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: "v2.10.1"

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ man/
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 cmd/av/av
+.claude/settings.local.json

--- a/internal/git/gitui/prune.go
+++ b/internal/git/gitui/prune.go
@@ -197,7 +197,7 @@ func (vm *PruneBranchModel) View() string {
 func (vm *PruneBranchModel) viewCandidates() string {
 	sb := strings.Builder{}
 	for _, branch := range vm.deleteCandidates {
-		sb.WriteString(fmt.Sprintf("%s: %s\n", branch.branch.Short(), branch.commit.String()))
+		fmt.Fprintf(&sb, "%s: %s\n", branch.branch.Short(), branch.commit.String())
 	}
 	return sb.String()
 }


### PR DESCRIPTION
version: latest caused a stale check to pass on PR #664 while a newer golangci-lint introduced the QF1012 rule

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
