### PR TITLE
fix: adopt --remote fails when branches aren't ordered parent-first

### DIFF
--- a/cmd/av/adopt.go
+++ b/cmd/av/adopt.go
@@ -373,21 +373,21 @@ func (vm *remoteAdoptViewModel) initGitFetch(prs []actions.RemotePRInfo, chosenT
 }
 
 func (vm *remoteAdoptViewModel) initAdoption(prs []actions.RemotePRInfo, chosenTargets []plumbing.ReferenceName) tea.Cmd {
+	chosenSet := make(map[string]bool)
+	for _, target := range chosenTargets {
+		chosenSet[target.Short()] = true
+	}
 	prMap := make(map[string]actions.RemotePRInfo)
 	for _, prInfo := range prs {
 		prMap[prInfo.Name] = prInfo
 	}
 	var branches []actions.AdoptingBranch
-	for _, target := range chosenTargets {
-		idx := slices.IndexFunc(prs, func(prInfo actions.RemotePRInfo) bool {
-			return prInfo.Name == target.Short()
-		})
-		if idx == -1 {
-			return uiutils.ErrCmd(fmt.Errorf("internal error: failed to find PR info for branch %s", target.Short()))
+	for _, pr := range slices.Backward(prs) {
+		if !chosenSet[pr.Name] {
+			continue
 		}
-		pr := prs[idx]
 		ab := actions.AdoptingBranch{
-			Name:        target.Short(),
+			Name:        pr.Name,
 			Parent:      pr.Parent,
 			PullRequest: &pr.PullRequest,
 		}


### PR DESCRIPTION
## Summary
- `av adopt --remote` fails with "ancestor branch is missing from av metadata" when adopting stacks
- Root cause: `initAdoption` built the branches slice by iterating `chosenTargets` from the tree selector, which has no guaranteed order. The remote PR walker returns PRs leaf-first, but `chosenTargets` doesn't preserve that order. When a child branch was adopted before its parent, `ValidateNoCycle` failed because the parent wasn't in metadata yet.
- Fix: iterate `prs` in reverse (parent-first) filtered to chosen targets, instead of iterating `chosenTargets` directly. Only the `--remote` codepath is affected; local adopt is unchanged.

## Test plan
- [x] Existing `TestAdopt` e2e tests pass
- [x] `pre-commit run --all-files` passes
- [x] Manually verified with a 7-branch stack (`av adopt --remote inbox/suspense`) that previously failed

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
