### PR TITLE
fix: skip $AV_HOME config path when env var is unset

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"emperror.dev/errors"
 	"github.com/sirupsen/logrus"
@@ -98,7 +99,7 @@ func loadFromFile(repoConfigDir string) error {
 	config.AddConfigPath("$XDG_CONFIG_HOME/av")
 	config.AddConfigPath("$HOME/.config/av")
 	config.AddConfigPath("$HOME/.av")
-	if os.Getenv("AV_HOME") != "" {
+	if strings.TrimSpace(os.Getenv("AV_HOME")) != "" {
 		config.AddConfigPath("$AV_HOME")
 	}
 	if err := config.ReadInConfig(); err != nil {


### PR DESCRIPTION
## Summary

When `$AV_HOME` is unset, `config.AddConfigPath("$AV_HOME")` resolves to an empty string, causing Viper to search the current working directory for config files. In large monorepos that have an unrelated `config.json` at the repo root (e.g. with `//` comments, which is invalid JSON), this causes `av init` and other commands to fail with:

```
error: failed to load configuration: While parsing config: invalid character '/' looking for beginning of value
```

This PR guards the `$AV_HOME` config path so it is only added when the environment variable is actually set.

## Test plan

- [x] Verified `av init` succeeds in a monorepo with a `config.json` at the root that contains `//` comments
- [x] Verified `av init` still works normally when `$AV_HOME` is set