### PR TITLE
improve error message when av.db is corrupted

### DIFF
--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -69,7 +69,14 @@ func getDB(ctx context.Context, repo *git.Repo) (meta.DB, error) {
 
 func getOrCreateDB(repo *git.Repo) (meta.DB, bool, error) {
 	dbPath := filepath.Join(repo.AvDir(), "av.db")
-	return jsonfiledb.OpenPath(dbPath)
+	db, exists, err := jsonfiledb.OpenPath(dbPath)
+	if err != nil {
+		return nil, false, errors.WrapIff(err,
+			"failed to open av database at %q (the file may be corrupted; try deleting it and running 'av init')",
+			dbPath,
+		)
+	}
+	return db, exists, nil
 }
 
 func allBranches(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
When av.db contains invalid JSON, commands crash with a raw JSON parse error. This wraps the error in getOrCreateDB with the file path and recovery instructions (delete file and run av init).

Closes #514

This contribution was developed with AI assistance (Claude Code).