### PR TITLE
fix nightly homebrew publish, pin goreleaser tag, disable fury for nightly

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -43,9 +43,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          git tag "v${VERSION}-nightly"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push origin "v${VERSION}-nightly"
+          git tag "v${VERSION}-nightly" 2>/dev/null || echo "Tag v${VERSION}-nightly already exists"
+          git push origin "v${VERSION}-nightly" 2>/dev/null || echo "Tag v${VERSION}-nightly already on remote"
       - name: configure nightly prerelease
         run: yq '.release.prerelease = true' .goreleaser.yaml > /tmp/goreleaser-nightly.yaml
       - name: install go
@@ -57,8 +57,9 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: release --clean --config /tmp/goreleaser-nightly.yaml --skip=aur --skip=publish --skip=nfpm
+          args: release --clean --config /tmp/goreleaser-nightly.yaml --skip=aur --skip=nfpm
         env:
+          GORELEASER_CURRENT_TAG: "v${{ inputs.aviator_release_candidate_version }}-nightly"
           RELEASE_ENV: nightly
           AVIATOR_CO_HOMEBREW_REPO_SSH_KEY: ${{ secrets.AVIATOR_CO_HOMEBREW_REPO_SSH_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
+          GORELEASER_CURRENT_TAG: ${{ inputs.aviator_release_candidate_version && format('v{0}', inputs.aviator_release_candidate_version) || github.ref_name }}
           AVIATOR_CO_HOMEBREW_REPO_SSH_KEY: ${{ secrets.AVIATOR_CO_HOMEBREW_REPO_SSH_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FURY_TOKEN: ${{ secrets.FURY_PUSH_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,6 +114,7 @@ aurs:
 
 publishers:
   - name: fury.io
+    disable: '{{ if eq (index .Env "RELEASE_ENV") "nightly" }}true{{ else }}false{{ end }}'
     ids:
       - packages
     dir: "{{ dir .ArtifactPath }}"


### PR DESCRIPTION
skip=publish was skipping all publishing including homebrew. use disable template on fury publisher instead, pin GORELEASER_CURRENT_TAG to avoid stale tag issues.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
