### PR TITLE
fix(adopt): treat empty trunk metadata as terminal parent

### DIFF
--- a/internal/actions/get_remote_stacked_pr.go
+++ b/internal/actions/get_remote_stacked_pr.go
@@ -103,7 +103,7 @@ func (m *GetRemoteStackedPRModel) Init() tea.Cmd {
 				Name: strings.TrimPrefix(pr.HeadRefName, "refs/heads/"),
 				Parent: meta.BranchState{
 					Name:                     prMeta.Parent,
-					Trunk:                    prMeta.Trunk == prMeta.Parent,
+					Trunk:                    prMeta.Trunk == prMeta.Parent || prMeta.ParentPull == 0,
 					BranchingPointCommitHash: prMeta.ParentHead,
 				},
 				PullRequest: meta.PullRequest{


### PR DESCRIPTION
before
<img width="825" height="373" alt="image" src="https://github.com/user-attachments/assets/85d0d4c8-5ff8-48b0-b14c-e49b07110fcf" />

after
<img width="608" height="338" alt="image" src="https://github.com/user-attachments/assets/777273df-017f-42a5-815a-2d33731b7100" />


## Summary

Fixes an infinite loop in `av adopt --remote` when a PR's body contains av metadata with an empty `trunk` field and no `parentPull`.

### Repro

Running `av adopt --remote <branch>` against a PR whose body contains metadata like:

```json
{"parent":"master","parentHead":"","trunk":""}
```

…shows the spinner counter incrementing ("found 1 PR", "found 2 PRs", "found 3 PRs", …) against the same PR before timing out.

### Root cause

In `internal/actions/get_remote_stacked_pr.go`, the walker uses `prMeta.Trunk == prMeta.Parent` to decide when to stop climbing the stack. When `Trunk` is empty but `Parent` is set (e.g. `"master"`), the check is false. `ParentPull` is also 0, so `nextPRNumber` stays 0 and the next iteration re-enters the initial-branch lookup path — fetching and appending the same PR forever.

### Fix

Treat an empty `Trunk` combined with an empty `ParentPull` as "parent is the trunk". This matches the existing `ErrNoPRMetadata` fallback, which sets `Trunk = Parent`, and gives the loop a well-defined termination point when metadata is partial.

## Test plan

- [x] `go build ./...`
- [x] Manual repro against a PR with empty-trunk metadata now terminates with a single PR
- [ ] Add regression testscript under `e2e_tests/testdata/script/`