### PR TITLE
fix stable release changelog to include all changes since last stable

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -47,7 +47,7 @@ jobs:
           git tag "v${VERSION}-nightly" 2>/dev/null || echo "Tag v${VERSION}-nightly already exists"
           git push origin "v${VERSION}-nightly" 2>/dev/null || echo "Tag v${VERSION}-nightly already on remote"
       - name: configure nightly prerelease
-        run: yq '.release.prerelease = true' .goreleaser.yaml > /tmp/goreleaser-nightly.yaml
+        run: yq '.release.prerelease = true | del(.git.ignore_tags)' .goreleaser.yaml > /tmp/goreleaser-nightly.yaml
       - name: install go
         uses: actions/setup-go@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,9 @@
 version: 2
 
+git:
+  ignore_tags:
+    - ".*-nightly"
+
 before:
   hooks:
     - "rm -rf man"


### PR DESCRIPTION
goreleaser was picking the nightly tag as the previous tag, so stable releases only showed incremental changes instead of the full changelog since last stable.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
