### PR TITLE
fix(branch): reject extra args with --rename/-m and add cycle detection

### DIFF
--- a/cmd/av/branch.go
+++ b/cmd/av/branch.go
@@ -71,6 +71,11 @@ internal tracking metadata that defines the order of branches within a stack.`),
 		}
 
 		if branchFlags.Rename {
+			if len(args) > 1 && !strings.ContainsRune(args[0], ':') {
+				return errors.New("unexpected extra arguments with --rename/-m flag\n" +
+					"  To rename a branch: av branch --rename <new-name>\n" +
+					"  To create a branch: av branch <name> (without -m)")
+			}
 			return branchMove(ctx, repo, db, branchName, branchFlags.Force)
 		}
 		if branchFlags.Split {

--- a/cmd/av/branch.go
+++ b/cmd/av/branch.go
@@ -71,7 +71,7 @@ internal tracking metadata that defines the order of branches within a stack.`),
 		}
 
 		if branchFlags.Rename {
-			if len(args) > 1 && !strings.ContainsRune(args[0], ':') {
+			if len(args) > 1 {
 				return errors.New("unexpected extra arguments with --rename/-m flag\n" +
 					"  To rename a branch: av branch --rename <new-name>\n" +
 					"  To create a branch: av branch <name> (without -m)")

--- a/internal/meta/branch.go
+++ b/internal/meta/branch.go
@@ -122,12 +122,22 @@ func PreviousBranches(tx ReadTx, name string) ([]string, error) {
 // If the tree is not a straight line (which isn't explicitly supported!), the
 // branches will be returned in depth-first traversal order.
 func SubsequentBranches(tx ReadTx, name string) []string {
+	visited := map[string]bool{name: true}
+	return subsequentBranches(tx, name, visited)
+}
+
+func subsequentBranches(tx ReadTx, name string, visited map[string]bool) []string {
 	logrus.Debugf("finding subsequent branches for %q", name)
 	var res []string
 	children := Children(tx, name)
 	for _, child := range children {
+		if visited[child.Name] {
+			logrus.Warnf("cycle detected in branch graph: %q already visited while traversing children of %q", child.Name, name)
+			continue
+		}
+		visited[child.Name] = true
 		res = append(res, child.Name)
-		res = append(res, SubsequentBranches(tx, child.Name)...)
+		res = append(res, subsequentBranches(tx, child.Name, visited)...)
 	}
 	return res
 }
@@ -136,17 +146,27 @@ func SubsequentBranches(tx ReadTx, name string) []string {
 // name in "dependency order", optionally skipping branches that are excluded
 // from sync --all and their descendants.
 func SubsequentBranchesFiltered(tx ReadTx, name string, skipExcluded bool) []string {
+	visited := map[string]bool{name: true}
+	return subsequentBranchesFiltered(tx, name, skipExcluded, visited)
+}
+
+func subsequentBranchesFiltered(tx ReadTx, name string, skipExcluded bool, visited map[string]bool) []string {
 	logrus.Debugf("finding subsequent branches for %q (skipExcluded=%v)", name, skipExcluded)
 	var res []string
 	children := Children(tx, name)
 	for _, child := range children {
+		if visited[child.Name] {
+			logrus.Warnf("cycle detected in branch graph: %q already visited while traversing children of %q", child.Name, name)
+			continue
+		}
 		if skipExcluded && child.ExcludeFromSyncAll {
 			// Skip this branch and its entire subtree
 			logrus.Debugf("skipping excluded branch %q and its descendants", child.Name)
 			continue
 		}
+		visited[child.Name] = true
 		res = append(res, child.Name)
-		res = append(res, SubsequentBranchesFiltered(tx, child.Name, skipExcluded)...)
+		res = append(res, subsequentBranchesFiltered(tx, child.Name, skipExcluded, visited)...)
 	}
 	return res
 }


### PR DESCRIPTION
## Summary

Fixes #717

- Reject unexpected extra positional arguments when `--rename`/`-m` flag is used with `av branch`, preventing silent misuse where `-m 'message'` triggers a rename instead of branch creation
- Add visited-set cycle detection to `SubsequentBranches` and `SubsequentBranchesFiltered` so a corrupted branch graph (e.g., self-referencing parent) logs a warning instead of crashing with a stack overflow

## Test plan

- [ ] `av branch foo -m 'bar'` now returns a clear error instead of silently renaming
- [ ] `av branch --rename new-name` still works correctly
- [ ] `av branch old:new -m` still works (colon syntax for rename)
- [ ] Existing tests pass (`go test ./...`)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
