### PR TITLE
fix(hooks): pass --allow-unknown-hook-name to git hook run

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -357,7 +357,13 @@ func queue(ctx context.Context) error {
 
 func runPRHook(ctx context.Context, repo *git.Repo, hookType string) error {
 	output, err := repo.Run(ctx, &git.RunOpts{
-		Args:        []string{"hook", "run", "--ignore-missing", "pre-av-pr"},
+		Args: []string{
+			"hook",
+			"run",
+			"--ignore-missing",
+			"--allow-unknown-hook-name",
+			"pre-av-pr",
+		},
 		Env:         []string{"AV_PR_HOOK_TYPE=" + hookType},
 		Interactive: true,
 		ExitError:   true,

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -440,7 +440,17 @@ func (m *preAvSyncHookModel) Init() tea.Cmd {
 		return uiutils.ErrCmd(err)
 	}
 	m.hasHook = true
-	cmd := m.repo.Cmd(context.Background(), []string{"hook", "run", "--ignore-missing", "pre-av-sync"}, nil)
+	cmd := m.repo.Cmd(
+		context.Background(),
+		[]string{
+			"hook",
+			"run",
+			"--ignore-missing",
+			"--allow-unknown-hook-name",
+			"pre-av-sync",
+		},
+		nil,
+	)
 	if !isatty.IsTerminal(os.Stdin.Fd()) || !isatty.IsTerminal(os.Stdout.Fd()) {
 		// When not in a terminal, run the hook as a regular subprocess instead of
 		// tea.ExecProcess. ExecProcess tries to suspend and re-initialize bubbletea's


### PR DESCRIPTION
## Summary

Git 2.54 tightened `git hook run` to reject non-native hook names unless `--allow-unknown-hook-name` is passed. Since av invokes `git hook run pre-av-pr` and `git hook run pre-av-sync` — both custom names — every `av pr` and `av sync` currently fails on git 2.54 with:

```
error: unknown hook event 'pre-av-pr';
use --allow-unknown-hook-name to allow non-native hook names
```

…which av treats as a hook failure, aborting the command before any push or PR creation happens (even when the user has no such hook configured, because `--ignore-missing` no longer suppresses the unknown-name error).

This PR adds `--allow-unknown-hook-name` at the two call sites:
- `cmd/av/pr.go` — `runPRHook` invoking `pre-av-pr`
- `cmd/av/sync.go` — `preAvSyncHookModel.Init` invoking `pre-av-sync`

The flag is also accepted by `git hook run` on pre-2.54 versions, so no version gating is needed.

## Reproduction (before the fix)

```
$ git --version
git version 2.54.0
$ av pr --debug
...
time=... level=debug msg="git [hook run --ignore-missing pre-av-pr]"
error: unknown hook event 'pre-av-pr';
use --allow-unknown-hook-name to allow non-native hook names
error: pre-av-pr hook failed: git [hook run --ignore-missing pre-av-pr] (): exit status 1
```

## Test plan

- [x] `go build ./...`
- [x] `go tool golangci-lint run`
- [x] `go test ./cmd/av/...`
- [x] Ran the patched binary against a repo on git 2.54.0 — `av pr` now passes the hook stage and proceeds to push / PR creation as expected (debug log shows `git [hook run --ignore-missing --allow-unknown-hook-name pre-av-pr]` succeeding).
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)