### PR TITLE
fix goreleaser ignore_tags pattern to use glob syntax

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,7 @@ version: 2
 
 git:
   ignore_tags:
-    - ".*-nightly"
+    - "*-nightly"
 
 before:
   hooks:


### PR DESCRIPTION
goreleaser passes ignore_tags to git describe --exclude which expects glob, not regex