### PR TITLE
fix(hooks): pass --allow-unknown-hook-name on git 2.44+

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -357,7 +357,7 @@ func queue(ctx context.Context) error {
 
 func runPRHook(ctx context.Context, repo *git.Repo, hookType string) error {
 	output, err := repo.Run(ctx, &git.RunOpts{
-		Args:        []string{"hook", "run", "--ignore-missing", "pre-av-pr"},
+		Args:        repo.HookRunArgs(ctx, "pre-av-pr"),
 		Env:         []string{"AV_PR_HOOK_TYPE=" + hookType},
 		Interactive: true,
 		ExitError:   true,

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -440,7 +440,8 @@ func (m *preAvSyncHookModel) Init() tea.Cmd {
 		return uiutils.ErrCmd(err)
 	}
 	m.hasHook = true
-	cmd := m.repo.Cmd(context.Background(), []string{"hook", "run", "--ignore-missing", "pre-av-sync"}, nil)
+	ctx := context.Background()
+	cmd := m.repo.Cmd(ctx, m.repo.HookRunArgs(ctx, "pre-av-sync"), nil)
 	if !isatty.IsTerminal(os.Stdin.Fd()) || !isatty.IsTerminal(os.Stdout.Fd()) {
 		// When not in a terminal, run the hook as a regular subprocess instead of
 		// tea.ExecProcess. ExecProcess tries to suspend and re-initialize bubbletea's

--- a/internal/git/version.go
+++ b/internal/git/version.go
@@ -1,0 +1,63 @@
+package git
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"emperror.dev/errors"
+)
+
+// Version returns the installed git version as (major, minor). Patch level and
+// any build suffix (e.g. "(Apple Git-152)") are ignored.
+func (r *Repo) Version(ctx context.Context) (major, minor int, err error) {
+	out, err := r.Git(ctx, "--version")
+	if err != nil {
+		return 0, 0, err
+	}
+	return parseGitVersion(out)
+}
+
+func parseGitVersion(out string) (int, int, error) {
+	// e.g. "git version 2.54.0", "git version 2.45.2 (Apple Git-152)"
+	fields := strings.Fields(out)
+	if len(fields) < 3 || fields[0] != "git" || fields[1] != "version" {
+		return 0, 0, errors.Errorf("unexpected git version output: %q", out)
+	}
+	parts := strings.SplitN(fields[2], ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, errors.Errorf("unexpected git version string: %q", fields[2])
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, errors.Wrapf(err, "parse git major version %q", parts[0])
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, errors.Wrapf(err, "parse git minor version %q", parts[1])
+	}
+	return major, minor, nil
+}
+
+// HookRunArgs returns the arguments to pass to `git` to run a custom
+// (non-native) hook. The --allow-unknown-hook-name flag is appended on git
+// versions that support it (>= 2.44); it is accepted on 2.44–2.53 and
+// required on 2.54+, which rejects non-native hook names otherwise.
+func (r *Repo) HookRunArgs(ctx context.Context, hookName string) []string {
+	args := []string{"hook", "run", "--ignore-missing"}
+	if r.supportsAllowUnknownHookName(ctx) {
+		args = append(args, "--allow-unknown-hook-name")
+	}
+	return append(args, hookName)
+}
+
+func (r *Repo) supportsAllowUnknownHookName(ctx context.Context) bool {
+	major, minor, err := r.Version(ctx)
+	if err != nil {
+		// If we can't determine the version, assume a modern git so that
+		// the flag is included and `git hook run` doesn't fail on 2.54+.
+		r.log.WithError(err).Debug("failed to determine git version")
+		return true
+	}
+	return major > 2 || (major == 2 && minor >= 44)
+}

--- a/internal/git/version_test.go
+++ b/internal/git/version_test.go
@@ -1,0 +1,38 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGitVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		out       string
+		wantMajor int
+		wantMinor int
+		wantErr   bool
+	}{
+		{"stable", "git version 2.54.0", 2, 54, false},
+		{"patch", "git version 2.44.1", 2, 44, false},
+		{"apple suffix", "git version 2.45.2 (Apple Git-152)", 2, 45, false},
+		{"trailing newline", "git version 2.30.0\n", 2, 30, false},
+		{"bad prefix", "hg version 2.30.0", 0, 0, true},
+		{"missing minor", "git version 2", 0, 0, true},
+		{"non-numeric", "git version foo.bar", 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, err := parseGitVersion(tt.out)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMajor, major)
+			assert.Equal(t, tt.wantMinor, minor)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Git 2.54 tightened `git hook run` to reject non-native hook names unless `--allow-unknown-hook-name` is passed. Since av invokes `git hook run pre-av-pr` and `git hook run pre-av-sync` — both custom names — every `av pr` and `av sync` fails on git 2.54+ with:

```
error: unknown hook event 'pre-av-pr';
use --allow-unknown-hook-name to allow non-native hook names
```

This is closely related to #724, but that PR passes the flag unconditionally. `--allow-unknown-hook-name` was only introduced in git 2.44, so on older gits the flag itself would be rejected. This PR gates the flag on a parsed `git --version`.

## Changes

- `internal/git/version.go`: adds `Repo.Version(ctx)` which parses `git --version` into `(major, minor)`, and `Repo.HookRunArgs(ctx, hookName)` which builds the `git hook run` arg list and conditionally appends `--allow-unknown-hook-name` when git >= 2.44. If version detection fails, the flag is still included so modern git keeps working.
- `internal/git/version_test.go`: unit tests covering stable, patch, Apple-suffixed, newline-trailed, and malformed version strings.
- `cmd/av/pr.go`: `runPRHook` uses `repo.HookRunArgs(ctx, "pre-av-pr")`.
- `cmd/av/sync.go`: `preAvSyncHookModel.Init` uses `m.repo.HookRunArgs(ctx, "pre-av-sync")`.

Behavior by git version:
- `< 2.44` — flag omitted (avoids "unknown option" errors on old git).
- `2.44`–`2.53` — flag included, accepted but not required.
- `>= 2.54` — flag included and required; prevents the "unknown hook event" failure.

## Test plan

- [x] `go build ./...`
- [x] `go tool golangci-lint run ./internal/git/... ./cmd/av/...`
- [x] `go test --vet=all ./internal/git/... ./cmd/av/...`
- [x] CI green

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
