### PR TITLE
fix(hooks): gate --allow-unknown-hook-name on git 2.54+

### DIFF
--- a/internal/git/version.go
+++ b/internal/git/version.go
@@ -41,8 +41,8 @@ func parseGitVersion(out string) (int, int, error) {
 
 // HookRunArgs returns the arguments to pass to `git` to run a custom
 // (non-native) hook. The --allow-unknown-hook-name flag is appended on git
-// versions that support it (>= 2.44); it is accepted on 2.44–2.53 and
-// required on 2.54+, which rejects non-native hook names otherwise.
+// 2.54+, which introduced it and simultaneously began rejecting non-native
+// hook names without it. Older gits don't recognize the flag.
 func (r *Repo) HookRunArgs(ctx context.Context, hookName string) []string {
 	args := []string{"hook", "run", "--ignore-missing"}
 	if r.supportsAllowUnknownHookName(ctx) {
@@ -59,5 +59,5 @@ func (r *Repo) supportsAllowUnknownHookName(ctx context.Context) bool {
 		r.log.WithError(err).Debug("failed to determine git version")
 		return true
 	}
-	return major > 2 || (major == 2 && minor >= 44)
+	return major > 2 || (major == 2 && minor >= 54)
 }


### PR DESCRIPTION
## Summary

Follow-up to #727. That PR gated `--allow-unknown-hook-name` at git 2.44 based on incorrect version information. The flag was actually introduced in git 2.54 alongside the stricter hook-name validation, so passing it on 2.44–2.53 would be rejected as an unknown flag.

## Change

- `internal/git/version.go`: bump the threshold in `supportsAllowUnknownHookName` from `>= 2.44` to `>= 2.54`, and update the surrounding comments.

Behavior now:
- `< 2.54` — flag omitted (no unknown-flag errors on older git).
- `>= 2.54` — flag included; required to allow non-native hook names like `pre-av-pr`/`pre-av-sync`.

If version detection fails, we still include the flag so modern git keeps working.

## Test plan

- [x] `go build ./...`
- [x] `go tool golangci-lint run ./internal/git/... ./cmd/av/...`
- [x] `go test --vet=all ./internal/git/... ./cmd/av/...`
- [x] Locally upgraded to git 2.54.0 and can confirm `av sync` now invokes the `pre-av-sync` hook instead of failing with `unknown hook event`.
- [ ] CI green