### PR TITLE
fix(pr): use stdin body when --body=- is passed

### DIFF
--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -124,8 +124,7 @@ Examples:
 		tx := db.WriteTx()
 		defer tx.Abort()
 
-		body := prFlags.Body
-		// Special case: ready body from stdin
+		// Special case: read body from stdin
 		if prFlags.Body == "-" {
 			bodyBytes, err := io.ReadAll(os.Stdin)
 			if err != nil {
@@ -133,6 +132,7 @@ Examples:
 			}
 			prFlags.Body = string(bodyBytes)
 		}
+		body := prFlags.Body
 
 		draft := config.Av.PullRequest.Draft
 		if cmd.Flags().Changed("draft") {


### PR DESCRIPTION
The `body` local was captured from `prFlags.Body` **before** the stdin read, so when `--body=-` was passed, the stdin contents were written into `prFlags.Body` but the subsequent call to `actions.CreatePullRequest` still used the stale `body` local (= the literal `"-"`). As a result the PR body ended up as `-`.

Fix: move the `body := prFlags.Body` capture to after the stdin read.

### Reproduce (before fix)

```sh
echo 'hello world' | av pr --title test --body -
# -> PR body becomes "-" instead of "hello world"
```

### After fix

```sh
echo 'hello world' | av pr --title test --body -
# -> PR body becomes "hello world"
```