### PR TITLE
handle merge queue rewrites in sync prune

### DIFF
--- a/e2e_tests/testdata/script/sync_delete_merged_queue_rewrite.txtar
+++ b/e2e_tests/testdata/script/sync_delete_merged_queue_rewrite.txtar
@@ -1,0 +1,39 @@
+# Test that sync prunes a merged branch when refs/pull/<N>/head diverges from
+# the local tip but the local commits are patch-equivalent to what's in the
+# merge commit. This simulates a merge queue that rewrites the PR head commit
+# before merging (e.g. Aviator MergeQueue doing a rebase merge). Exercises the
+# git-cherry fallback in prune's calculateMergedBranches.
+#
+#     main:    X --------------> 1S
+#     stack-1:  \ -> 1a
+#     refs/pull/42/head: queue-rewritten commit (different sha, same patch)
+
+exec av branch stack-1
+commit-file my-file '1a\n' 'Commit 1a'
+
+# Simulate a merge queue rewriting the PR head by pushing a different commit
+# to refs/pull/42/head.
+exec git checkout --detach
+exec git commit --allow-empty -m 'queue-rewritten 1a'
+exec git push origin HEAD:refs/pull/42/head
+exec git checkout stack-1
+
+# Squash-merge stack-1 into main.
+exec git checkout main
+exec git merge --squash stack-1
+exec git commit --no-edit
+exec git push origin main
+
+# Configure mock PR and av metadata.
+set-branch-pr stack-1 nodeid-42 42 OPEN
+mock-pull stack-1 42 MERGED HEAD
+
+exec git switch stack-1
+exec av sync --prune=yes
+
+# stack-1 should be deleted despite refs/pull/42/head mismatching the local tip.
+! exec git show-ref refs/heads/stack-1
+
+# HEAD should be on main.
+exec git rev-parse --symbolic-full-name HEAD
+stdout '^refs/heads/main$'

--- a/e2e_tests/testdata/script/sync_delete_merged_squash_rewrite.txtar
+++ b/e2e_tests/testdata/script/sync_delete_merged_squash_rewrite.txtar
@@ -1,0 +1,40 @@
+# Test that sync prunes a merged branch when a multi-commit PR was squash-
+# merged and refs/pull/<N>/head was rewritten by the merge queue. The squash
+# combines the individual commits into one, so their patch-ids no longer appear
+# in the merge commit's ancestry and the git-cherry fallback cannot recover.
+# This exercises the merge-tree fallback in prune's calculateMergedBranches.
+#
+#     main:    X --------------> 1S (squash of 1a + 1b)
+#     stack-1:  \ -> 1a -> 1b
+#     refs/pull/42/head: queue-rewritten commit
+
+exec av branch stack-1
+commit-file my-file '1a\n' 'Commit 1a'
+commit-file my-file '1a\n1b\n' 'Commit 1b'
+
+# Simulate a merge queue rewriting the PR head by pushing a different commit
+# to refs/pull/42/head.
+exec git checkout --detach
+exec git commit --allow-empty -m 'queue-rewritten tip'
+exec git push origin HEAD:refs/pull/42/head
+exec git checkout stack-1
+
+# Squash-merge stack-1 into main. The combined patch-id differs from each
+# individual commit's patch-id, so git cherry will not recognize them.
+exec git checkout main
+exec git merge --squash stack-1
+exec git commit --no-edit
+exec git push origin main
+
+set-branch-pr stack-1 nodeid-42 42 OPEN
+mock-pull stack-1 42 MERGED HEAD
+
+exec git switch stack-1
+exec av sync --prune=yes
+
+# stack-1 should be deleted via the merge-tree fallback.
+! exec git show-ref refs/heads/stack-1
+
+# HEAD should be on main.
+exec git rev-parse --symbolic-full-name HEAD
+stdout '^refs/heads/main$'

--- a/e2e_tests/testdata/script/sync_keep_merged_unpushed_work.txtar
+++ b/e2e_tests/testdata/script/sync_keep_merged_unpushed_work.txtar
@@ -1,0 +1,29 @@
+# Test that sync does NOT prune a merged branch when the local branch has
+# unpushed local commits not represented in the merge commit. Both the
+# git-cherry and merge-tree fallbacks should refuse because the unpushed work
+# would be lost.
+#
+#     main:    X --------------> 1S
+#     stack-1:  \ -> 1a -> (unpushed local commit)
+
+exec av branch stack-1
+commit-file my-file '1a\n' 'Commit 1a'
+exec git push origin stack-1:refs/pull/42/head
+
+# Squash-merge stack-1 into main before the user adds any local work.
+exec git checkout main
+exec git merge --squash stack-1
+exec git commit --no-edit
+exec git push origin main
+
+set-branch-pr stack-1 nodeid-42 42 OPEN
+mock-pull stack-1 42 MERGED HEAD
+
+# Now the user adds a local commit on top of stack-1 that was never pushed.
+exec git switch stack-1
+commit-file my-other-file 'unpushed\n' 'Unpushed work'
+
+exec av sync --prune=yes
+
+# stack-1 must still exist: the unpushed commit is not in the merge commit.
+exec git show-ref refs/heads/stack-1

--- a/internal/git/gitui/prune.go
+++ b/internal/git/gitui/prune.go
@@ -379,17 +379,81 @@ func (vm *PruneBranchModel) calculateMergedBranches() tea.Msg {
 			return err
 		}
 		if ref.Hash().String() != remoteHash {
-			noDeleteBranches = append(
-				noDeleteBranches,
-				noDeleteBranch{branch: br, reason: reasonPRHeadIsDifferent},
-			)
-			continue
+			// Merge queues (e.g. Aviator MergeQueue) rebase or squash PR commits
+			// before merging, so refs/pull/<N>/head diverges from the local tip
+			// by SHA even when the work is identical. Two fallbacks capture the
+			// common cases: patch-id equivalence handles rebase merges, and a
+			// merge-tree comparison handles squash merges. If neither matches,
+			// the branch truly has work not represented in the merge.
+			if !vm.branchFullyPatchMerged(br, avbr.MergeCommit) &&
+				!vm.branchSquashMergedByTree(ref.Hash(), avbr.MergeCommit) {
+				noDeleteBranches = append(
+					noDeleteBranches,
+					noDeleteBranch{branch: br, reason: reasonPRHeadIsDifferent},
+				)
+				continue
+			}
 		}
 		deleteCandidates = append(deleteCandidates, deleteCandidate{branch: br, commit: ref.Hash()})
 	}
 	vm.noDeleteBranches = noDeleteBranches
 	vm.deleteCandidates = deleteCandidates
 	return &PruneBranchProgress{candidateCalculationDone: true}
+}
+
+func (vm *PruneBranchModel) branchFullyPatchMerged(
+	br plumbing.ReferenceName,
+	mergeCommitSHA string,
+) bool {
+	if mergeCommitSHA == "" {
+		return false
+	}
+	out, err := vm.repo.Run(context.Background(), &git.RunOpts{
+		Args: []string{"cherry", mergeCommitSHA, br.String()},
+	})
+	if err != nil || out.ExitCode != 0 {
+		return false
+	}
+	for line := range strings.SplitSeq(string(out.Stdout), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "+") {
+			return false
+		}
+	}
+	return true
+}
+
+func (vm *PruneBranchModel) branchSquashMergedByTree(
+	localHash plumbing.Hash,
+	mergeCommitSHA string,
+) bool {
+	if mergeCommitSHA == "" {
+		return false
+	}
+	ctx := context.Background()
+	mergeParent := mergeCommitSHA + "^"
+	mb, err := vm.repo.MergeBase(ctx, localHash.String(), mergeParent)
+	if err != nil || mb == "" {
+		return false
+	}
+	out, err := vm.repo.Run(ctx, &git.RunOpts{
+		Args: []string{
+			"merge-tree", "--write-tree",
+			"--merge-base=" + mb,
+			mergeParent, localHash.String(),
+		},
+	})
+	if err != nil || out.ExitCode != 0 {
+		return false
+	}
+	mergedTree := strings.TrimSpace(strings.SplitN(string(out.Stdout), "\n", 2)[0])
+	if mergedTree == "" {
+		return false
+	}
+	mc, err := vm.repo.GoGitRepo().CommitObject(plumbing.NewHash(mergeCommitSHA))
+	if err != nil {
+		return false
+	}
+	return mergedTree == mc.TreeHash.String()
 }
 
 func (vm *PruneBranchModel) hasOpenChildren(br plumbing.ReferenceName) bool {


### PR DESCRIPTION
merge queues rewrite pr commits so refs/pull/N/head diverges from the local tip by sha, which made the old prune check refuse to delete those branches. adds patch-id and merge-tree fallbacks

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
