### PR TITLE
fix(push): chunk git push so stacks > 20 branches don't fail

### DIFF
--- a/internal/gh/ghui/push.go
+++ b/internal/gh/ghui/push.go
@@ -36,6 +36,14 @@ const (
 	reasonPRIsClosed        = "PR is closed."
 	reasonParentNotPushed   = "Parent branch is not pushed to remote."
 	reasonNoPR              = "Some branches in a stack do not have a PR."
+
+	// gitPushChunkSize caps how many ref updates we send in a single
+	// `git push` invocation. GitHub rejects pushes with more than 20 ref
+	// updates ("max ref updates exceeded"), so we split the candidate set
+	// into chunks of this size and push each one separately. Each chunk is
+	// still atomic (--atomic), but the operation as a whole is not
+	// (#638).
+	gitPushChunkSize = 20
 )
 
 type pushCandidate struct {
@@ -286,33 +294,47 @@ func (vm *GitHubPushModel) runUpdate() (ret tea.Msg) {
 
 func (vm *GitHubPushModel) runGitPush() error {
 	ctx := context.Background()
-	pushArgs := []string{"push", vm.repo.GetRemoteName(), "--atomic"}
-	for _, branch := range vm.pushCandidates {
-		// Do a compare-and-swap to be strict on what we show as a difference.
-		pushArgs = append(
-			pushArgs,
-			fmt.Sprintf(
-				"--force-with-lease=%s:%s",
-				branch.branch.String(),
-				branch.remoteCommit.Hash.String(),
-			),
-		)
-	}
-	for _, branch := range vm.pushCandidates {
-		// Push the exact commit hash to be strict on what we show as a difference.
-		pushArgs = append(
-			pushArgs,
-			fmt.Sprintf("%s:%s", branch.localCommit.Hash.String(), branch.branch.String()),
-		)
-	}
-	res, err := vm.repo.Run(ctx, &git.RunOpts{
-		Args: pushArgs,
-	})
-	if err != nil {
-		return errors.WrapIff(err, "failed to push branches to GitHub")
-	}
-	if res.ExitCode != 0 {
-		return errors.Errorf("failed to push branches to GitHub\n%s\n%s", res.Stdout, res.Stderr)
+	// Split into chunks so we don't exceed GitHub's per-push ref-update
+	// limit (#638). Each chunk is still atomic on its own; only the
+	// cross-chunk operation is non-atomic.
+	for start := 0; start < len(vm.pushCandidates); start += gitPushChunkSize {
+		end := start + gitPushChunkSize
+		if end > len(vm.pushCandidates) {
+			end = len(vm.pushCandidates)
+		}
+		chunk := vm.pushCandidates[start:end]
+		pushArgs := []string{"push", vm.repo.GetRemoteName(), "--atomic"}
+		for _, branch := range chunk {
+			// Do a compare-and-swap to be strict on what we show as a difference.
+			pushArgs = append(
+				pushArgs,
+				fmt.Sprintf(
+					"--force-with-lease=%s:%s",
+					branch.branch.String(),
+					branch.remoteCommit.Hash.String(),
+				),
+			)
+		}
+		for _, branch := range chunk {
+			// Push the exact commit hash to be strict on what we show as a difference.
+			pushArgs = append(
+				pushArgs,
+				fmt.Sprintf("%s:%s", branch.localCommit.Hash.String(), branch.branch.String()),
+			)
+		}
+		res, err := vm.repo.Run(ctx, &git.RunOpts{
+			Args: pushArgs,
+		})
+		if err != nil {
+			return errors.WrapIff(err, "failed to push branches to GitHub")
+		}
+		if res.ExitCode != 0 {
+			return errors.Errorf(
+				"failed to push branches to GitHub\n%s\n%s",
+				res.Stdout,
+				res.Stderr,
+			)
+		}
 	}
 
 	var errs []error


### PR DESCRIPTION
## Summary

Closes #638.

`av sync` fails when a stack has more than 20 PRs because GitHub rejects pushes with more than 20 ref updates. The reporter's workaround was manually pushing a few branches to drop under 20 before letting `av sync` finish.

This splits `pushCandidates` into chunks of 20 and runs `git push --atomic --force-with-lease=...` once per chunk. Each chunk is still atomic on its own; only the whole-operation atomicity is relaxed, which is the intended trade-off (no other way to make >20-branch stacks pushable at all).

## Files

- `internal/gh/ghui/push.go`:
  - New `gitPushChunkSize = 20` constant with a comment pointing at #638.
  - `runGitPush` now loops `start += gitPushChunkSize` over `vm.pushCandidates`, building per-chunk `pushArgs` and calling `vm.repo.Run` once per chunk. Each chunk includes its own `--atomic` and per-branch `--force-with-lease=` so safety guarantees inside a chunk are unchanged.

## Verification

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./internal/gh/ghui/...` passes (no test files in this package, returns "no test files").
- The pre-existing typecheck warning in `internal/gh/ghui/push.go:553` (`mapToRemoteTrackingBranch undefined`) reproduces on `master` without these changes and is not introduced by this PR.

## Test plan

- [x] `go build ./...` clean.
- [x] Stacks with <= 20 branches still push in a single chunk (loop runs once).
- [x] Each chunk uses `--atomic` + `--force-with-lease=`, preserving safety inside the chunk.
- [ ] Manual: run `av sync` on a stack with > 20 PRs and confirm all branches push without the GitHub limit error (no fixture in this repo's tests).

## Notes

- Cross-chunk atomicity is relaxed by design. If the first chunk pushes successfully and the second fails, the user is left with a partial push. Same observable behaviour as the reporter's manual workaround.
- 20 was chosen because it's the documented GitHub limit; if GitHub ever raises it, the constant is the only knob to change.