### PR TITLE
avoid unnecessary pr update calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ man/
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 cmd/av/av
-.claude/settings.local.json
+.claude/

--- a/cmd/av/auth.go
+++ b/cmd/av/auth.go
@@ -44,7 +44,8 @@ func checkAviatorAuthStatus(ctx context.Context) error {
 		return errors.Wrap(err, "Failed to query Aviator")
 	}
 
-	fmt.Fprint(os.Stderr,
+	fmt.Fprint(
+		os.Stderr,
 		"Logged in to Aviator as ", colors.UserInput(query.Viewer.FullName),
 		" (", colors.UserInput(query.Viewer.Email), ").\n",
 	)
@@ -69,7 +70,8 @@ func checkGitHubAuthStatus(ctx context.Context) error {
 		return errors.Wrap(err, "Failed to query GitHub")
 	}
 
-	fmt.Fprint(os.Stderr,
+	fmt.Fprint(
+		os.Stderr,
 		"Logged in to GitHub as ", colors.UserInput(viewer.Name),
 		" (", colors.UserInput(viewer.Login), ").\n",
 	)

--- a/cmd/av/branch.go
+++ b/cmd/av/branch.go
@@ -368,7 +368,8 @@ func createBranch(
 	// On failure, we want to delete the branch we created so that the user
 	// can try again (e.g., to fix issues surfaced by a pre-commit hook).
 	cu.Add(func() {
-		fmt.Fprint(os.Stderr,
+		fmt.Fprint(
+			os.Stderr,
 			colors.Faint("  - Cleaning up branch "),
 			colors.UserInput(branchName),
 			colors.Faint(" because commit was not successful."),

--- a/cmd/av/commit.go
+++ b/cmd/av/commit.go
@@ -114,7 +114,8 @@ func runCreate(ctx context.Context, repo *git.Repo, db meta.DB) error {
 			ExitError: true,
 		})
 		if err != nil {
-			fmt.Fprint(os.Stderr,
+			fmt.Fprint(
+				os.Stderr,
 				"\n", colors.Failure("Failed to stage files: ", err.Error()), "\n",
 			)
 			return actions.ErrExitSilently{ExitCode: 1}
@@ -217,7 +218,8 @@ func runAmend(
 			ExitError: true,
 		})
 		if err != nil {
-			fmt.Fprint(os.Stderr,
+			fmt.Fprint(
+				os.Stderr,
 				"\n", colors.Failure("Failed to stage files: ", err.Error()), "\n",
 			)
 			return actions.ErrExitSilently{ExitCode: 1}
@@ -292,7 +294,8 @@ func branchAndCommit(
 			ExitError: true,
 		})
 		if err != nil {
-			fmt.Fprint(os.Stderr,
+			fmt.Fprint(
+				os.Stderr,
 				"\n", colors.Failure("Failed to stage files: ", err.Error()), "\n",
 			)
 			return actions.ErrExitSilently{ExitCode: 1}
@@ -309,7 +312,8 @@ func branchAndCommit(
 		ExitError:   true,
 		Interactive: true,
 	}); err != nil {
-		fmt.Fprint(os.Stderr,
+		fmt.Fprint(
+			os.Stderr,
 			"\n", colors.Failure("Failed to create commit."), "\n",
 		)
 		return actions.ErrExitSilently{ExitCode: 1}

--- a/cmd/av/diff.go
+++ b/cmd/av/diff.go
@@ -113,7 +113,8 @@ Generates the diff between the working tree and the parent branch
 		// We need to display this **after** the diff to ensure that the diff
 		// output pager doesn't eat this message.
 		if notUpToDate {
-			fmt.Fprint(os.Stderr,
+			fmt.Fprint(
+				os.Stderr,
 				colors.Warning("\nWARNING: Branch "), colors.UserInput(currentBranchName),
 				colors.Warning(" is not up to date with parent branch "),
 				colors.UserInput(branch.Parent.Name), colors.Warning(". Run "),

--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -71,7 +71,8 @@ func getOrCreateDB(repo *git.Repo) (meta.DB, bool, error) {
 	dbPath := filepath.Join(repo.AvDir(), "av.db")
 	db, exists, err := jsonfiledb.OpenPath(dbPath)
 	if err != nil {
-		return nil, false, errors.WrapIff(err,
+		return nil, false, errors.WrapIff(
+			err,
 			"failed to open av database at %q (the file may be corrupted; try deleting it and running 'av init')",
 			dbPath,
 		)

--- a/cmd/av/pr.go
+++ b/cmd/av/pr.go
@@ -419,7 +419,8 @@ func init() {
 	)
 	prCmd.Flags().BoolVar(
 		&prFlags.Current, "current", false,
-		"create pull requests up to the current branch")
+		"create pull requests up to the current branch",
+	)
 	_ = prCmd.Flags().MarkHidden("current")
 
 	deprecatedCreateCmd := deprecateCommand(*prCmd, "av pr", "create")

--- a/cmd/av/reorder.go
+++ b/cmd/av/reorder.go
@@ -50,7 +50,8 @@ squashed, dropped, or moved within the stack.
 		var continuation reorder.Continuation
 		if err := repo.ReadStateFile(git.StateFileKindReorder, &continuation); os.IsNotExist(err) {
 			if reorderFlags.Continue || reorderFlags.Abort {
-				fmt.Fprint(os.Stderr,
+				fmt.Fprint(
+					os.Stderr,
 					colors.Failure("ERROR: no reorder in progress\n"),
 				)
 				return actions.ErrExitSilently{ExitCode: 127}
@@ -90,7 +91,8 @@ squashed, dropped, or moved within the stack.
 			}
 			if stat != nil {
 				if err := repo.CherryPick(ctx, git.CherryPick{Resume: git.CherryPickContinue}); err != nil {
-					fmt.Fprint(os.Stderr,
+					fmt.Fprint(
+						os.Stderr,
 						colors.Failure("Failed to continue cherry-pick: ", err.Error(), "\n"),
 						colors.Warning("Resolve the conflict and run "),
 						colors.CliCmd("av reorder --continue"),
@@ -126,7 +128,8 @@ squashed, dropped, or moved within the stack.
 					return err
 				}
 				if currentHead == state.Head {
-					fmt.Fprint(os.Stderr,
+					fmt.Fprint(
+						os.Stderr,
 						colors.Failure("ERROR: cannot continue squash/fixup — the cherry-pick was not applied.\n"),
 						colors.Warning("If you aborted or skipped the cherry-pick, run "),
 						colors.CliCmd("av reorder --abort"),
@@ -137,7 +140,8 @@ squashed, dropped, or moved within the stack.
 
 				if err := pickCmd.PerformSquash(ctx, repo, state.BranchBase); err != nil {
 					if errors.Is(err, reorder.ErrEmptySquashMessage) {
-						fmt.Fprint(os.Stderr,
+						fmt.Fprint(
+							os.Stderr,
 							colors.Failure("squash commit message is empty after editing\n"),
 							colors.Warning("Edit the message and run "),
 							colors.CliCmd("av reorder --continue"),
@@ -165,7 +169,8 @@ squashed, dropped, or moved within the stack.
 			state.Head = head
 		} else {
 			if continuation.State != nil {
-				fmt.Fprint(os.Stderr,
+				fmt.Fprint(
+					os.Stderr,
 					colors.Failure("ERROR: reorder already in progress\n"),
 					colors.Failure("	   use --continue or --abort to continue or abort the reorder\n"),
 				)
@@ -178,7 +183,8 @@ squashed, dropped, or moved within the stack.
 			}
 			root, ok := meta.Root(tx, currentBranch)
 			if !ok {
-				fmt.Fprint(os.Stderr,
+				fmt.Fprint(
+					os.Stderr,
 					colors.Failure("ERROR: branch "), colors.UserInput(currentBranch),
 					colors.Failure(" is not part of a stack\n"),
 				)
@@ -215,7 +221,8 @@ squashed, dropped, or moved within the stack.
 			if err := repo.WriteStateFile(git.StateFileKindReorder, nil); err != nil {
 				return err
 			}
-			fmt.Fprint(os.Stderr,
+			fmt.Fprint(
+				os.Stderr,
 				colors.Success("\nThe stack was reordered successfully.\n"),
 			)
 			return nil
@@ -225,7 +232,8 @@ squashed, dropped, or moved within the stack.
 		if err := repo.WriteStateFile(git.StateFileKindReorder, &continuation); err != nil {
 			return err
 		}
-		fmt.Fprint(os.Stderr,
+		fmt.Fprint(
+			os.Stderr,
 			colors.Warning("\nThe reorder was interrupted by a conflict.\n"),
 			colors.Warning("Resolve the conflict and run "),
 			colors.CliCmd("av reorder --continue"),
@@ -255,7 +263,8 @@ edit:
 		return nil, err
 	}
 	if len(plan) == 0 {
-		fmt.Fprint(os.Stderr,
+		fmt.Fprint(
+			os.Stderr,
 			colors.Failure("ERROR: reorder plan is empty\n"),
 		)
 		return nil, actions.ErrExitSilently{ExitCode: 127}

--- a/cmd/av/stack_foreach.go
+++ b/cmd/av/stack_foreach.go
@@ -74,12 +74,14 @@ Examples:
 			}
 		}
 
-		_, _ = fmt.Fprint(os.Stderr,
+		_, _ = fmt.Fprint(
+			os.Stderr,
 			"Executing command ", colors.CliCmd(executils.FormatCommandLine(args)),
 			" for ", colors.UserInput(len(branches)), " branches:\n",
 		)
 		for _, branch := range branches {
-			_, _ = fmt.Fprint(os.Stderr,
+			_, _ = fmt.Fprint(
+				os.Stderr,
 				"  - switching to branch ", colors.UserInput(branch), "\n",
 			)
 			if _, err := repo.CheckoutBranch(ctx, &git.CheckoutBranch{Name: branch}); err != nil {

--- a/cmd/av/switch.go
+++ b/cmd/av/switch.go
@@ -66,7 +66,8 @@ var switchCmd = &cobra.Command{
 		for _, node := range rootNodes {
 			branchList = append(
 				branchList,
-				switchBranchList(ctx, repo, tx, branches, node)...)
+				switchBranchList(ctx, repo, tx, branches, node)...,
+			)
 		}
 		if len(branchList) == 0 {
 			return errors.New("no branches found")

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -543,19 +543,22 @@ func init() {
 	syncCmd.MarkFlagsMutuallyExclusive("continue", "abort", "skip")
 
 	// Deprecated flags
-	syncCmd.Flags().Bool("no-fetch", false,
+	syncCmd.Flags().Bool(
+		"no-fetch", false,
 		"(deprecated; use av restack for offline restacking) do not fetch the latest status from GitHub",
 	)
 	_ = syncCmd.Flags().
 		MarkDeprecated("no-fetch", "please use av restack for offline restacking")
 
-	syncCmd.Flags().Bool("trunk", false,
+	syncCmd.Flags().Bool(
+		"trunk", false,
 		"(deprecated; use --rebase-to-trunk to rebase all branches to trunk) rebase the stack on the trunk branch",
 	)
 	_ = syncCmd.Flags().
 		MarkDeprecated("trunk", "please use --rebase-to-trunk to rebase all branches to trunk")
 
-	syncCmd.Flags().String("parent", "",
+	syncCmd.Flags().String(
+		"parent", "",
 		"(deprecated; use 'av adopt' or 'av reparent') parent branch to rebase onto",
 	)
 	_ = syncCmd.Flags().

--- a/docs/internal/md2man/md2man.go
+++ b/docs/internal/md2man/md2man.go
@@ -10,7 +10,8 @@ var returns = regexp.MustCompile(`\n+`)
 
 func RenderToRoff(text []byte, section int, version, source, volume string) []byte {
 	renderer := NewRoffRenderer(section, version, source, volume)
-	bs := blackfriday.Run(text,
+	bs := blackfriday.Run(
+		text,
 		[]blackfriday.Option{
 			blackfriday.WithRenderer(renderer),
 			blackfriday.WithExtensions(renderer.GetExtensions()),

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -157,14 +157,16 @@ func CreatePullRequest(
 		var err error
 		existingPR, err = getExistingOpenPR(ctx, client, repoMeta, branchMeta, opts.BranchName)
 		if closed, ok := errutils.As[errPullRequestClosed](err); ok {
-			_, _ = fmt.Fprint(os.Stderr,
+			_, _ = fmt.Fprint(
+				os.Stderr,
 				colors.Failure("Existing pull request for branch "),
 				colors.UserInput(opts.BranchName),
 				colors.Failure(" is "), colors.UserInput(closed.State),
 				colors.Failure(": "), colors.UserInput(closed.Permalink),
 				"\n",
 			)
-			_, _ = fmt.Fprint(os.Stderr,
+			_, _ = fmt.Fprint(
+				os.Stderr,
 				colors.Faint("  - use "), colors.CliCmd("av pr --force"),
 				colors.Faint(" to create a new pull request for this branch\n"),
 			)
@@ -183,7 +185,8 @@ func CreatePullRequest(
 	if existingPR != nil {
 		verb = "Updating"
 	}
-	_, _ = fmt.Fprint(os.Stderr,
+	_, _ = fmt.Fprint(
+		os.Stderr,
 		verb, " pull request for branch ", colors.UserInput(opts.BranchName), ":",
 		"\n",
 	)
@@ -203,7 +206,8 @@ func CreatePullRequest(
 		pushFlags = append(pushFlags, remote, opts.BranchName)
 		logrus.Debug("pushing latest changes")
 
-		_, _ = fmt.Fprint(os.Stderr,
+		_, _ = fmt.Fprint(
+			os.Stderr,
 			"  - pushing to ", color.CyanString("%s/%s", remote, opts.BranchName),
 			"\n",
 		)
@@ -220,7 +224,8 @@ func CreatePullRequest(
 			return nil, err
 		}
 	} else {
-		_, _ = fmt.Fprint(os.Stderr,
+		_, _ = fmt.Fprint(
+			os.Stderr,
 			"  - skipping push to GitHub",
 			"\n",
 		)
@@ -403,7 +408,8 @@ func CreatePullRequest(
 		existingPR:  existingPR,
 	})
 	if err != nil {
-		_, _ = fmt.Fprint(os.Stderr,
+		_, _ = fmt.Fprint(
+			os.Stderr,
 			colors.Failure("  - failed to create pull request: "), err, "\n",
 		)
 		return nil, errors.WrapIf(err, "failed to create PR")
@@ -422,7 +428,8 @@ func CreatePullRequest(
 	} else {
 		action = "synchronized"
 	}
-	_, _ = fmt.Fprint(os.Stderr,
+	_, _ = fmt.Fprint(
+		os.Stderr,
 		"  - ", action, " pull request ",
 		colors.UserInput(pull.Permalink), "\n",
 	)
@@ -437,7 +444,8 @@ func CreatePullRequest(
 
 func OpenPullRequestInBrowser(ctx context.Context, pullRequestLink string) {
 	if err := browser.Open(ctx, pullRequestLink); err != nil {
-		_, _ = fmt.Fprint(os.Stderr,
+		_, _ = fmt.Fprint(
+			os.Stderr,
 			"  - couldn't open browser ",
 			colors.UserInput(err),
 			" for pull request link ",
@@ -452,7 +460,8 @@ func savePRDescriptionToTemporaryFile(saveFile string, contents string) {
 			Error("failed to write pull request description to temporary file")
 		return
 	}
-	_, _ = fmt.Fprint(os.Stderr,
+	_, _ = fmt.Fprint(
+		os.Stderr,
 		"  - saved pull request description to ", colors.UserInput(saveFile),
 		" (it will be automatically re-used if you try again)\n",
 	)

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -544,11 +544,10 @@ func ensurePR(
 
 	if opts.existingPR != nil {
 		newBody := AddPRMetadataAndStack(opts.body, opts.meta, opts.headRefName, initialStack, tx)
-		updatedPR, err := client.UpdatePullRequest(ctx, githubv4.UpdatePullRequestInput{
-			PullRequestID: opts.existingPR.ID,
-			Title:         gh.Ptr(githubv4.String(opts.title)),
-			Body:          gh.Ptr(githubv4.String(newBody)),
-			BaseRefName:   gh.Ptr(githubv4.String(opts.baseRefName)),
+		updatedPR, err := client.UpdatePullRequestIfChanged(ctx, opts.existingPR, gh.UpdatePullRequestFields{
+			Title:       gh.Ptr(opts.title),
+			Body:        gh.Ptr(newBody),
+			BaseRefName: gh.Ptr(opts.baseRefName),
 		})
 		if err != nil {
 			return nil, false, errors.WithStack(err)
@@ -959,11 +958,9 @@ func UpdatePullRequestWithStack(
 	}
 
 	newBody := AddPRMetadataAndStack(body, prMeta, branchName, stackToWrite, tx)
-	_, err = client.UpdatePullRequest(ctx, githubv4.UpdatePullRequestInput{
-		PullRequestID: existingPR.ID,
-		Body:          gh.Ptr(githubv4.String(newBody)),
-	})
-	if err != nil {
+	if _, err := client.UpdatePullRequestIfChanged(ctx, existingPR, gh.UpdatePullRequestFields{
+		Body: gh.Ptr(newBody),
+	}); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/internal/actions/reviewers.go
+++ b/internal/actions/reviewers.go
@@ -21,7 +21,8 @@ func AddPullRequestReviewers(
 	prID githubv4.ID,
 	reviewers []string,
 ) error {
-	_, _ = fmt.Fprint(os.Stderr,
+	_, _ = fmt.Fprint(
+		os.Stderr,
 		"  - adding ", colors.UserInput(len(reviewers)), " reviewer(s) to pull request\n",
 	)
 

--- a/internal/gh/ghui/push.go
+++ b/internal/gh/ghui/push.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/shurcooL/githubv4"
 )
 
 const (
@@ -388,10 +387,9 @@ func (vm *GitHubPushModel) updatePRs(ghPRs map[plumbing.ReferenceName]*gh.PullRe
 			stackToWrite,
 			vm.db.ReadTx(),
 		)
-		if _, err := vm.client.UpdatePullRequest(context.Background(), githubv4.UpdatePullRequestInput{
-			PullRequestID: pr.ID,
-			BaseRefName:   githubv4.NewString(githubv4.String(avbr.Parent.Name)),
-			Body:          githubv4.NewString(githubv4.String(prBody)),
+		if _, err := vm.client.UpdatePullRequestIfChanged(context.Background(), pr, gh.UpdatePullRequestFields{
+			Body:        gh.Ptr(prBody),
+			BaseRefName: gh.Ptr(avbr.Parent.Name),
 		}); err != nil {
 			return err
 		}

--- a/internal/gh/ghui/push.go
+++ b/internal/gh/ghui/push.go
@@ -301,7 +301,8 @@ func (vm *GitHubPushModel) runGitPush() error {
 	}
 	for _, branch := range vm.pushCandidates {
 		// Push the exact commit hash to be strict on what we show as a difference.
-		pushArgs = append(pushArgs,
+		pushArgs = append(
+			pushArgs,
 			fmt.Sprintf("%s:%s", branch.localCommit.Hash.String(), branch.branch.String()),
 		)
 	}

--- a/internal/gh/pullrequest.go
+++ b/internal/gh/pullrequest.go
@@ -198,6 +198,51 @@ func (c *Client) UpdatePullRequest(
 	return &mutation.UpdatePullRequest.PullRequest, nil
 }
 
+// UpdatePullRequestFields are the fields that may be updated on a pull request.
+// A nil field is left untouched. A non-nil field is included in the mutation
+// only if its value differs from the existing pull request.
+type UpdatePullRequestFields struct {
+	Title       *string
+	Body        *string
+	BaseRefName *string
+}
+
+// UpdatePullRequestIfChanged calls UpdatePullRequest only when at least one
+// field in desired differs from existing. Sending unchanged fields (especially
+// BaseRefName) causes GitHub to fire an extra pull_request webhook that
+// duplicates workflow runs, so callers should prefer this over UpdatePullRequest.
+func (c *Client) UpdatePullRequestIfChanged(
+	ctx context.Context,
+	existing *PullRequest,
+	desired UpdatePullRequestFields,
+) (*PullRequest, error) {
+	input := githubv4.UpdatePullRequestInput{PullRequestID: githubv4.ID(existing.ID)}
+	changed := false
+	if desired.Title != nil && *desired.Title != existing.Title {
+		input.Title = Ptr(githubv4.String(*desired.Title))
+		changed = true
+	}
+	if desired.Body != nil {
+		// GitHub sometimes returns bodies with \r\n line endings while
+		// callers compute new bodies with \n, so normalize both sides
+		// before comparing to avoid spurious updates.
+		desiredBody := strings.ReplaceAll(*desired.Body, "\r\n", "\n")
+		existingBody := strings.ReplaceAll(existing.Body, "\r\n", "\n")
+		if desiredBody != existingBody {
+			input.Body = Ptr(githubv4.String(*desired.Body))
+			changed = true
+		}
+	}
+	if desired.BaseRefName != nil && *desired.BaseRefName != existing.BaseBranchName() {
+		input.BaseRefName = Ptr(githubv4.String(*desired.BaseRefName))
+		changed = true
+	}
+	if !changed {
+		return existing, nil
+	}
+	return c.UpdatePullRequest(ctx, input)
+}
+
 // RequestReviews requests reviews from the given users on the given pull
 // request.
 func (c *Client) RequestReviews(

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -385,7 +385,8 @@ func (r *Repo) BranchesContainCommittish(
 	ctx context.Context,
 	committish string,
 ) ([]BranchAndCommit, error) {
-	lines, err := r.Git(ctx,
+	lines, err := r.Git(
+		ctx,
 		"for-each-ref",
 		"--contains",
 		committish,

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -142,13 +142,14 @@ func (r *GitTestRepo) Git(t *testing.T, args ...string) string {
 	if err != nil && !errors.As(err, &exitError) {
 		t.Fatal(err)
 	}
-	t.Logf("Running git\n"+
-		"args: %v\n"+
-		"exit code: %v\n"+
-		"stdout:\n"+
-		"%s"+
-		"stderr:\n"+
-		"%s",
+	t.Logf(
+		"Running git\n"+
+			"args: %v\n"+
+			"exit code: %v\n"+
+			"stdout:\n"+
+			"%s"+
+			"stderr:\n"+
+			"%s",
 		args,
 		cmd.ProcessState.ExitCode(),
 		text.Indent(stdout.String(), "  "),

--- a/internal/reorder/deletebranch.go
+++ b/internal/reorder/deletebranch.go
@@ -32,7 +32,8 @@ func (d DeleteBranchCmd) Execute(ctx *Context) error {
 	}
 
 	if !d.DeleteGitRef {
-		_, _ = fmt.Fprint(os.Stderr,
+		_, _ = fmt.Fprint(
+			os.Stderr,
 			"Orphaned branch ", colors.UserInput(d.Name), ".\n",
 			"  - Run ", colors.CliCmd("git branch --delete ", d.Name),
 			" to delete the branch from your repository.\n",
@@ -47,7 +48,8 @@ func (d DeleteBranchCmd) Execute(ctx *Context) error {
 	if exiterr, ok := errutils.As[*exec.ExitError](err); ok {
 		stderr := string(exiterr.Stderr)
 		if strings.Contains(stderr, "not found") {
-			_, _ = fmt.Fprint(os.Stderr,
+			_, _ = fmt.Fprint(
+				os.Stderr,
 				colors.Warning("Branch "), colors.UserInput(d.Name),
 				colors.Warning(" was already deleted.\n"),
 			)
@@ -65,7 +67,8 @@ func (d DeleteBranchCmd) Execute(ctx *Context) error {
 		return err
 	}
 
-	_, _ = fmt.Fprint(os.Stderr,
+	_, _ = fmt.Fprint(
+		os.Stderr,
 		"Deleted branch ", colors.UserInput(d.Name), ".\n",
 	)
 	return nil


### PR DESCRIPTION
resending unchanged fields like BaseRefName makes github fire extra pull_request webhooks, doubling workflow runs in consumer repos.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
