### PR TITLE
feat(sync): fast-forward branches behind remote

### DIFF
--- a/cmd/av/reorder.go
+++ b/cmd/av/reorder.go
@@ -69,7 +69,8 @@ squashed, dropped, or moved within the stack.
 			}
 			continuation = reorder.Continuation{}
 			if reorderFlags.Continue || reorderFlags.Abort {
-				fmt.Fprint(os.Stderr,
+				fmt.Fprint(
+					os.Stderr,
 					colors.Failure("ERROR: no reorder in progress\n"),
 				)
 				return actions.ErrExitSilently{ExitCode: 127}

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -233,6 +233,16 @@ func (vm *syncViewModel) initGitFetch() tea.Cmd {
 		vm.client,
 		currentBranchRef,
 		targetBranches,
+		func() tea.Cmd {
+			return vm.initFastForwardBranches(targetBranches)
+		},
+	))
+}
+
+func (vm *syncViewModel) initFastForwardBranches(targetBranches []plumbing.ReferenceName) tea.Cmd {
+	return vm.AddView(gitui.NewFastForwardBranchesModel(
+		vm.repo,
+		targetBranches,
 		vm.initSequencerState,
 	))
 }

--- a/internal/git/gitui/ff_branches.go
+++ b/internal/git/gitui/ff_branches.go
@@ -1,0 +1,113 @@
+package gitui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aviator-co/av/internal/git"
+	"github.com/aviator-co/av/internal/utils/colors"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// FastForwardBranchesModel is a Bubbletea model that fast-forwards each local
+// branch in targetBranches whose remote tracking branch is strictly ahead of
+// the local branch. This lets users adopt commits that someone else pushed on
+// top of their branch.
+type FastForwardBranchesModel struct {
+	repo           *git.Repo
+	targetBranches []plumbing.ReferenceName
+	onDone         func() tea.Cmd
+
+	ffBranches []string
+	done       bool
+}
+
+type ffBranchesDone struct{}
+
+func NewFastForwardBranchesModel(
+	repo *git.Repo,
+	targetBranches []plumbing.ReferenceName,
+	onDone func() tea.Cmd,
+) *FastForwardBranchesModel {
+	return &FastForwardBranchesModel{
+		repo:           repo,
+		targetBranches: targetBranches,
+		onDone:         onDone,
+	}
+}
+
+func (m *FastForwardBranchesModel) Init() tea.Cmd {
+	return m.run
+}
+
+func (m *FastForwardBranchesModel) run() tea.Msg {
+	ctx := context.Background()
+	remote := m.repo.GetRemoteName()
+
+	currentBranch, err := m.repo.CurrentBranchName()
+	if err != nil {
+		currentBranch = ""
+	}
+
+	for _, br := range m.targetBranches {
+		name := br.Short()
+		localRef := br.String()
+		remoteRef := fmt.Sprintf("refs/remotes/%s/%s", remote, name)
+		remoteExists, err := m.repo.DoesRefExist(ctx, remoteRef)
+		if err != nil || !remoteExists {
+			continue
+		}
+
+		// Skip if local is not an ancestor of remote (diverged or local is ahead).
+		isBehind, err := m.repo.IsAncestor(ctx, localRef, remoteRef)
+		if err != nil || !isBehind {
+			continue
+		}
+		// Skip if remote is also an ancestor of local, meaning they point at
+		// the same commit and there is nothing to fast-forward.
+		isAhead, err := m.repo.IsAncestor(ctx, remoteRef, localRef)
+		if err != nil || isAhead {
+			continue
+		}
+
+		if currentBranch == name {
+			if _, err := m.repo.Run(ctx, &git.RunOpts{
+				Args:      []string{"merge", "--ff-only", remoteRef},
+				ExitError: true,
+			}); err != nil {
+				continue
+			}
+		} else {
+			if err := m.repo.UpdateRef(ctx, &git.UpdateRef{
+				Ref: localRef,
+				New: remoteRef,
+			}); err != nil {
+				continue
+			}
+		}
+		m.ffBranches = append(m.ffBranches, name)
+	}
+	m.done = true
+	return ffBranchesDone{}
+}
+
+func (m *FastForwardBranchesModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg.(type) {
+	case ffBranchesDone:
+		return m, m.onDone()
+	}
+	return m, nil
+}
+
+func (m *FastForwardBranchesModel) View() string {
+	if !m.done || len(m.ffBranches) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, name := range m.ffBranches {
+		sb.WriteString(colors.SuccessStyle.Render(fmt.Sprintf("✓ Fast-forwarded %s to match remote", name)) + "\n")
+	}
+	return sb.String()
+}


### PR DESCRIPTION
## Summary

When the remote tracking branch has commits on top of a local branch (i.e. local is strictly an ancestor of remote), `av sync` now fast-forwards the local branch to match remote before restacking. This lets users adopt commits pushed by collaborators (or by themselves from another machine) instead of clobbering them on the next push.

Diverged or local-ahead branches are left untouched — the check is strictly `merge-base --is-ancestor local remote` with local != remote.

## Implementation

- New `gitui.FastForwardBranchesModel` mirrors the existing `FastForwardTrunkModel` pattern.
  - Uses `git merge --ff-only` when the current branch is the one being fast-forwarded, `git update-ref` otherwise.
  - Iterates over the same target branches the sync flow already computes.
  - Prints `✓ Fast-forwarded <branch> to match remote` for each branch advanced; stays silent when there's nothing to do.
- Wired into the sync flow between `GitHubFetch` and the restack sequencer so the newly adopted commits flow through the rebase.

## Behavior

- Always on; no flag, since it's a no-op when FF is not trivially safe.
- Trunk fast-forward continues to be opt-in via `--ff-trunk` / `config.Av.Sync.FastForwardTrunk` and runs at the end of sync as before.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
