### PR TITLE
Handle worktreeConfig with go-git v5

### DIFF
--- a/cmd/av/helpers.go
+++ b/cmd/av/helpers.go
@@ -25,6 +25,7 @@ func getRepo(ctx context.Context) (*git.Repo, error) {
 			"rev-parse",
 			"--path-format=absolute",
 			"--show-toplevel",
+			"--git-dir",
 			"--git-common-dir",
 		)
 
@@ -39,12 +40,12 @@ func getRepo(ctx context.Context) (*git.Repo, error) {
 			)
 		}
 
-		dir, gitDir, found := strings.Cut(strings.TrimSpace(string(paths)), "\n")
-		if !found {
-			return nil, errors.New("Unexpected format, not able to parse toplevel and common dir.")
+		lines := strings.Split(strings.TrimSpace(string(paths)), "\n")
+		if len(lines) != 3 {
+			return nil, errors.New("Unexpected format, not able to parse toplevel, git dir, and common dir.")
 		}
 
-		cachedRepo, err = git.OpenRepo(dir, gitDir)
+		cachedRepo, err = git.OpenRepo(lines[0], lines[1], lines[2])
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to open git repo")
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/erikgeiser/promptkit v0.9.0
 	github.com/fatih/color v1.19.0
+	github.com/go-git/go-billy/v5 v5.8.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/text v0.2.0
@@ -54,7 +55,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golangci/go-printf-func-name v0.1.0 // indirect
 	github.com/golangci/golangci-lint/v2 v2.0.2 // indirect

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -16,8 +16,14 @@ import (
 	"emperror.dev/errors"
 	"github.com/aviator-co/av/internal/config"
 	giturls "github.com/chainguard-dev/git-urls"
+	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
+	gogitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/storage"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,17 +39,14 @@ type Repo struct {
 	defaultBranch plumbing.ReferenceName
 }
 
-func OpenRepo(repoDir string, gitDir string) (*Repo, error) {
-	repo, err := git.PlainOpenWithOptions(repoDir, &git.PlainOpenOptions{
-		DetectDotGit:          true,
-		EnableDotGitCommonDir: true,
-	})
+func OpenRepo(repoDir, gitDir, commonGitDir string) (*Repo, error) {
+	repo, err := openGoGitRepo(repoDir, gitDir, commonGitDir)
 	if err != nil {
 		return nil, errors.Errorf("failed to open git repo: %v", err)
 	}
 	r := &Repo{
 		repoDir:       repoDir,
-		gitDir:        gitDir,
+		gitDir:        commonGitDir,
 		gitRepo:       repo,
 		log:           logrus.WithFields(logrus.Fields{"repo": filepath.Base(repoDir)}),
 		defaultBranch: "",
@@ -66,6 +69,34 @@ func OpenRepo(repoDir string, gitDir string) (*Repo, error) {
 	}
 	r.defaultBranch = plumbing.NewBranchReferenceName(strings.TrimPrefix(ref.Target().String(), fmt.Sprintf("refs/remotes/%s/", remoteName)))
 	return r, nil
+}
+
+type worktreeConfigCompatStorage struct {
+	storage.Storer
+}
+
+func (s worktreeConfigCompatStorage) Config() (*gogitconfig.Config, error) {
+	cfg, err := s.Storer.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.Raw != nil && cfg.Raw.HasSection("extensions") {
+		cfg.Raw.Section("extensions").RemoveOption("worktreeConfig")
+	}
+
+	return cfg, nil
+}
+
+func openGoGitRepo(repoDir, gitDir, commonGitDir string) (*git.Repository, error) {
+	dot := osfs.New(gitDir)
+	repositoryFS := dot
+	if filepath.Clean(gitDir) != filepath.Clean(commonGitDir) {
+		repositoryFS = dotgit.NewRepositoryFilesystem(dot, osfs.New(commonGitDir))
+	}
+
+	storer := filesystem.NewStorage(repositoryFS, cache.NewObjectLRUDefault())
+	return git.Open(worktreeConfigCompatStorage{Storer: storer}, osfs.New(repoDir))
 }
 
 func (r *Repo) Dir() string {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,9 @@
 package git_test
 
 import (
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aviator-co/av/internal/config"
@@ -45,4 +48,44 @@ func TestGetRemoteName(t *testing.T) {
 	config.Av.Remote = "new-remote"
 	require.Equal(t, avGitRepo.GetRemoteName(), "new-remote")
 	config.Av.Remote = ""
+}
+
+func TestOpenRepoAllowsWorktreeConfigExtension(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	repo.Git(t, "config", "extensions.worktreeConfig", "true")
+
+	_, err := git.OpenRepo(repo.RepoDir, repo.GitDir, repo.GitDir)
+	require.NoError(t, err)
+}
+
+func TestOpenRepoAllowsWorktreeConfigExtensionInLinkedWorktree(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	repo.Git(t, "config", "extensions.worktreeConfig", "true")
+
+	worktreeDir := filepath.Join(t.TempDir(), "linked")
+	repo.Git(t, "worktree", "add", worktreeDir, "-b", "linked")
+
+	linkedGitDir, linkedCommonGitDir := gitDirs(t, worktreeDir)
+	_, err := git.OpenRepo(worktreeDir, linkedGitDir, linkedCommonGitDir)
+	require.NoError(t, err)
+}
+
+func gitDirs(t *testing.T, dir string) (string, string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(
+		t.Context(),
+		"git",
+		"rev-parse",
+		"--path-format=absolute",
+		"--git-dir",
+		"--git-common-dir",
+	)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	require.Len(t, lines, 2)
+	return lines[0], lines[1]
 }

--- a/internal/git/gittest/repo.go
+++ b/internal/git/gittest/repo.go
@@ -122,7 +122,7 @@ type GitTestRepo struct {
 }
 
 func (r *GitTestRepo) AsAvGitRepo() *avgit.Repo {
-	repo, err := avgit.OpenRepo(r.RepoDir, r.GitDir)
+	repo, err := avgit.OpenRepo(r.RepoDir, r.GitDir, r.GitDir)
 	if err != nil {
 		panic(fmt.Sprintf("failed to open av git repo: %v", err))
 	}


### PR DESCRIPTION
## Summary
- keep the existing go-git v5.18.0 dependency; no forked module and no vendored copy
- ask `git rev-parse` for both the per-worktree git dir and common git dir, then open go-git with its public filesystem storage APIs
- wrap only config loading so v5 ignores the known `extensions.worktreeConfig` marker instead of rejecting the repository
- add regressions for normal and linked worktrees with `extensions.worktreeConfig=true`

Fixes #745.

## Validation
- `go test ./internal/git/... -count=1`
- `go build ./...`
- `go tool golangci-lint run`