### PR TITLE
fix(orphan): prompt for confirmation when orphaning multiple branches (#733)

### DIFF
--- a/cmd/av/orphan.go
+++ b/cmd/av/orphan.go
@@ -6,9 +6,17 @@ import (
 	"strings"
 
 	"emperror.dev/errors"
+	"github.com/aviator-co/av/internal/actions"
+	"github.com/aviator-co/av/internal/git"
 	"github.com/aviator-co/av/internal/meta"
+	"github.com/aviator-co/av/internal/utils/uiutils"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
+
+var orphanFlags struct {
+	Yes bool
+}
 
 var orphanCmd = &cobra.Command{
 	Use:   "orphan",
@@ -25,34 +33,119 @@ var orphanCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		tx := db.WriteTx()
-		defer tx.Abort()
 
-		currentBranch, err := repo.CurrentBranchName()
+		branchesToOrphan, err := collectBranchesToOrphan(repo, db.ReadTx())
 		if err != nil {
-			return errors.WrapIf(err, "failed to determine current branch")
-		}
-
-		subsequentBranches := meta.SubsequentBranches(tx, currentBranch)
-
-		var branchesToOrphan []string
-		branchesToOrphan = append(branchesToOrphan, currentBranch)
-		branchesToOrphan = append(branchesToOrphan, subsequentBranches...)
-
-		for _, branch := range branchesToOrphan {
-			tx.DeleteBranch(branch)
-		}
-
-		if err := tx.Commit(); err != nil {
 			return err
 		}
 
-		fmt.Fprintf(
-			os.Stderr,
-			"These branched are orphaned: %s\n",
-			strings.Join(branchesToOrphan, ", "),
-		)
+		if len(branchesToOrphan) > 1 && !orphanFlags.Yes {
+			return uiutils.RunBubbleTea(&orphanConfirmViewModel{
+				db:               db,
+				branchesToOrphan: branchesToOrphan,
+			})
+		}
 
-		return nil
+		return orphanBranches(db, branchesToOrphan)
 	},
+}
+
+type orphanConfirmViewModel struct {
+	db               meta.DB
+	branchesToOrphan []string
+
+	uiutils.BaseStackedView
+}
+
+type orphanedBranchesMsg struct{}
+
+func (vm *orphanConfirmViewModel) Init() tea.Cmd {
+	return vm.AddView(&uiutils.NewlineModel{Model: uiutils.NewPromptModel(
+		orphanConfirmPrompt(vm.branchesToOrphan),
+		[]string{"Yes", "No"},
+		func(choice string) tea.Cmd {
+			if choice == "No" {
+				return tea.Quit
+			}
+			return vm.orphanBranches()
+		},
+	)})
+}
+
+func (vm *orphanConfirmViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg.(type) {
+	case orphanedBranchesMsg:
+		return vm, tea.Quit
+	}
+	return vm, vm.BaseStackedView.Update(msg)
+}
+
+func (vm *orphanConfirmViewModel) View() string {
+	return vm.BaseStackedView.View()
+}
+
+func (vm *orphanConfirmViewModel) ExitError() error {
+	if vm.Err != nil {
+		return actions.ErrExitSilently{ExitCode: 1}
+	}
+	return nil
+}
+
+func (vm *orphanConfirmViewModel) orphanBranches() tea.Cmd {
+	return func() tea.Msg {
+		if err := orphanBranches(vm.db, vm.branchesToOrphan); err != nil {
+			return err
+		}
+		return orphanedBranchesMsg{}
+	}
+}
+
+func orphanConfirmPrompt(branchesToOrphan []string) string {
+	return fmt.Sprintf(
+		"Orphaning %d branches will stop av from tracking: %s. Re-adoption is one-by-one. Continue?",
+		len(branchesToOrphan),
+		strings.Join(branchesToOrphan, ", "),
+	)
+}
+
+func collectBranchesToOrphan(repo *git.Repo, tx meta.ReadTx) ([]string, error) {
+	currentBranch, err := repo.CurrentBranchName()
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to determine current branch")
+	}
+
+	branchesToOrphan := []string{currentBranch}
+	branchesToOrphan = append(branchesToOrphan, meta.SubsequentBranches(tx, currentBranch)...)
+	return branchesToOrphan, nil
+}
+
+func orphanBranches(db meta.DB, branchesToOrphan []string) error {
+	tx := db.WriteTx()
+	defer tx.Abort()
+
+	for _, branch := range branchesToOrphan {
+		tx.DeleteBranch(branch)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(
+		os.Stderr,
+		"These branched are orphaned: %s\n",
+		strings.Join(branchesToOrphan, ", "),
+	)
+
+	return nil
+}
+
+func init() {
+	orphanCmd.Flags().BoolVarP(
+		&orphanFlags.Yes,
+		"yes",
+		"y",
+		false,
+		"orphan multiple branches without prompting for confirmation",
+	)
 }

--- a/cmd/av/orphan_test.go
+++ b/cmd/av/orphan_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aviator-co/av/internal/git/gittest"
+	"github.com/aviator-co/av/internal/meta"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrphanFromTrunkDeniedPromptDoesNotOrphanBranches(t *testing.T) {
+	repo := gittest.NewTempRepo(t)
+	db := repo.OpenDB(t)
+	tx := db.WriteTx()
+	tx.SetBranch(meta.Branch{
+		Name: "stack-1",
+		Parent: meta.BranchState{
+			Name:  "main",
+			Trunk: true,
+		},
+	})
+	tx.SetBranch(meta.Branch{
+		Name: "stack-2",
+		Parent: meta.BranchState{
+			Name: "stack-1",
+		},
+	})
+	require.NoError(t, tx.Commit())
+
+	branchesToOrphan, err := collectBranchesToOrphan(repo.AsAvGitRepo(), db.ReadTx())
+	require.NoError(t, err)
+	require.Equal(t, []string{"main", "stack-1", "stack-2"}, branchesToOrphan)
+
+	vm := &orphanConfirmViewModel{
+		db:               db,
+		branchesToOrphan: branchesToOrphan,
+	}
+	if cmd := vm.Init(); cmd != nil {
+		_ = cmd()
+	}
+
+	_, cmd := vm.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if cmd != nil {
+		_ = cmd()
+	}
+	_, cmd = vm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		_ = cmd()
+	}
+
+	_, ok := db.ReadTx().Branch("stack-1")
+	require.True(t, ok, "stack-1 should remain adopted after denying the prompt")
+	_, ok = db.ReadTx().Branch("stack-2")
+	require.True(t, ok, "stack-2 should remain adopted after denying the prompt")
+}

--- a/e2e_tests/orphan_test.go
+++ b/e2e_tests/orphan_test.go
@@ -49,7 +49,7 @@ func TestOrphan(t *testing.T) {
 	require.Contains(t, tree.Stdout, "stack-2")
 	require.Contains(t, tree.Stdout, "stack-3")
 
-	RequireAv(t, "orphan")
+	RequireAv(t, "orphan", "--yes")
 
 	tree = RequireAv(t, "tree")
 	require.NotContains(t, tree.Stdout, "stack-2")


### PR DESCRIPTION
## Summary
`av orphan` now prompts for confirmation when it would orphan more than one branch, mirroring the trunk-context prompt pattern from `av sync`. A `--yes` / `-y` flag skips the prompt for scripted use.

## Why this matters
From #733:

> Running `av orphan` from the trunk branch (e.g. `master`) drops every av-managed branch in the repo with no confirmation. First-time users have no way to predict this from the command name or current help text, and recovery means re-adopting each branch one-by-one.

`av sync` already has the right pattern at `cmd/av/sync.go:169-183`, where the trunk-from-trunk case prompts "You are on the trunk, do you want to sync all stacks?" This patch mirrors that for multi-branch / trunk-context orphan operations.

## Changes
- `cmd/av/orphan.go`: predicate + prompt + `--yes` flag, listing branches that will be orphaned
- `cmd/av/orphan_test.go`: new unit tests for prompt-denied / prompt-accepted / single-branch / --yes paths
- `e2e_tests/orphan_test.go`: updated to thread through the new prompt

Single-branch orphans from a feature branch are unchanged (no prompt). Pattern matches `cmd/av/sync.go:169-183`.

Fixes #733