### PR TITLE
feat(adopt): non-interactive --include ancestors for remote adoption

### DIFF
--- a/cmd/av/adopt.go
+++ b/cmd/av/adopt.go
@@ -25,7 +25,11 @@ var adoptFlags struct {
 	Parent           string
 	DryRun           bool
 	RemoteBranchName string
+	Include          string
 }
+
+// adoptIncludeValues are the valid values for the --include flag.
+var adoptIncludeValues = []string{"ancestors"}
 
 var adoptCmd = &cobra.Command{
 	Use:   "adopt",
@@ -42,10 +46,22 @@ the parent.
 
 If you want to adopt branches on the remote repository, use --remote $BRANCH_NAME to adopt branches.
 The command will adopt the stack of pull requests starting from the specified branch name.
+
+By default --remote opens an interactive picker. Pass --include ancestors to skip the picker and
+non-interactively adopt the named branch together with its ancestor branches up to the trunk.
 `),
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		ctx := cmd.Context()
+		if adoptFlags.Include != "" {
+			if adoptFlags.RemoteBranchName == "" {
+				return errors.New("--include can only be used together with --remote")
+			}
+			if !slices.Contains(adoptIncludeValues, adoptFlags.Include) {
+				return errors.New("invalid value for --include; must be one of " +
+					strings.Join(adoptIncludeValues, ", "))
+			}
+		}
 		repo, err := getRepo(ctx)
 		if err != nil {
 			return err
@@ -71,10 +87,11 @@ The command will adopt the stack of pull requests starting from the specified br
 				return err
 			}
 			return uiutils.RunBubbleTea(&remoteAdoptViewModel{
-				repo:       repo,
-				db:         db,
-				ghClient:   client,
-				branchName: adoptFlags.RemoteBranchName,
+				repo:           repo,
+				db:             db,
+				ghClient:       client,
+				branchName:     adoptFlags.RemoteBranchName,
+				nonInteractive: adoptFlags.Include != "",
 			})
 		}
 		return uiutils.RunBubbleTea(&adoptViewModel{
@@ -262,10 +279,11 @@ func (vm *adoptViewModel) ExitError() error {
 }
 
 type remoteAdoptViewModel struct {
-	repo       *git.Repo
-	db         meta.DB
-	ghClient   *gh.Client
-	branchName string
+	repo           *git.Repo
+	db             meta.DB
+	ghClient       *gh.Client
+	branchName     string
+	nonInteractive bool
 
 	uiutils.BaseStackedView
 }
@@ -310,6 +328,26 @@ func (vm *remoteAdoptViewModel) initTreeSelector(prs []actions.RemotePRInfo) tea
 			vm.AddView(uiutils.SimpleMessageView{Message: colors.SuccessStyle.Render("✓ No branch to adopt")}),
 			tea.Quit,
 		)
+	}
+	if vm.nonInteractive {
+		// --include ancestors: adopt the named branch and its ancestors without
+		// prompting. adoptionTargets already holds that chain (the open, not-yet
+		// adopted PRs walked up from the named branch to the trunk).
+		if adoptFlags.DryRun {
+			parents := make(map[string]string, len(prs))
+			for _, prInfo := range prs {
+				parents[prInfo.Name] = prInfo.Parent.Name
+			}
+			lines := []string{"Would adopt:"}
+			for _, target := range adoptionTargets {
+				lines = append(lines, fmt.Sprintf("  %s (parent: %s)", target.Short(), parents[target.Short()]))
+			}
+			return tea.Batch(
+				vm.AddView(uiutils.SimpleMessageView{Message: colors.SuccessStyle.Render(strings.Join(lines, "\n"))}),
+				tea.Quit,
+			)
+		}
+		return vm.initGitFetch(prs, adoptionTargets)
 	}
 	var lastNode *stackutils.StackTreeNode
 	for _, prInfo := range prs {
@@ -447,12 +485,22 @@ func init() {
 		&adoptFlags.RemoteBranchName, "remote", "",
 		"adopt branches from remote pull requests, starting from the specified branch",
 	)
+	adoptCmd.Flags().StringVar(
+		&adoptFlags.Include, "include", "",
+		"with --remote, non-interactively adopt the named branch and related branches\n(ancestors)",
+	)
 
 	_ = adoptCmd.RegisterFlagCompletionFunc(
 		"parent",
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			branches, _ := allBranches(cmd.Context())
 			return branches, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	_ = adoptCmd.RegisterFlagCompletionFunc(
+		"include",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return adoptIncludeValues, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
 }

--- a/cmd/av/adopt.go
+++ b/cmd/av/adopt.go
@@ -360,10 +360,13 @@ func (vm *remoteAdoptViewModel) initGitFetch(prs []actions.RemotePRInfo, chosenT
 			tea.Quit,
 		)
 	}
+	remote := vm.repo.GetRemoteName()
 	refspecs := []string{}
 	for _, target := range chosenTargets {
-		// Directly clone as a local branch.
+		// Clone as a local branch, and create the remote-tracking ref so we can
+		// set upstream tracking after adoption.
 		refspecs = append(refspecs, fmt.Sprintf("refs/heads/%s:refs/heads/%s", target.Short(), target.Short()))
+		refspecs = append(refspecs, fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", target.Short(), remote, target.Short()))
 	}
 	return vm.AddView(
 		actions.NewGitFetchModel(vm.repo, refspecs, func() tea.Cmd {
@@ -405,9 +408,11 @@ func (vm *remoteAdoptViewModel) initAdoption(prs []actions.RemotePRInfo, chosenT
 			vm.db,
 			branches,
 			func() tea.Cmd {
+				remote := vm.repo.GetRemoteName()
 				hasChild := make(map[string]bool)
 				for _, ab := range branches {
 					hasChild[ab.Parent.Name] = true
+					_ = vm.repo.BranchSetUpstream(context.Background(), ab.Name, remote)
 				}
 				for _, ab := range branches {
 					if !hasChild[ab.Name] {

--- a/docs/av-adopt.1.md
+++ b/docs/av-adopt.1.md
@@ -7,7 +7,7 @@ av-adopt - Adopt branches that are not managed by `av`
 ## SYNOPSIS
 
 ```synopsis
-av adopt [--dry-run] [--parent=<parent> | --remote=<branch>]
+av adopt [--dry-run] [--parent=<parent> | --remote=<branch> [--include=ancestors]]
 ```
 
 ## DESCRIPTION
@@ -43,6 +43,12 @@ You can also adopt branches from a remote repository by using the
 `--remote` option. This option fetches the specified remote branch and adopts
 it along with its parent branches.
 
+By default `--remote` opens an interactive picker to choose which branches to
+adopt. Pass `--include=ancestors` to skip the picker and non-interactively adopt
+the named branch together with its ancestor branches up to the trunk. This is
+useful for scripts and agents that want to mirror a remote stack locally without
+a prompt. Combine with `--dry-run` to print the adoption plan without applying it.
+
 ## OPTIONS
 
 `--parent=<parent>`
@@ -53,6 +59,11 @@ it along with its parent branches.
 
 `--remote=<branch>`
 : Specify a remote branch to adopt from.
+
+`--include=<set>`
+: With `--remote`, non-interactively adopt the named branch and a related set of
+branches instead of opening the picker. The only supported value is `ancestors`,
+which adopts the named branch and its ancestors up to the trunk.
 
 ## SEE ALSO
 

--- a/e2e_tests/mock_ghgql_server.go
+++ b/e2e_tests/mock_ghgql_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -71,9 +72,50 @@ func (s *mockGitHubServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	if strings.Contains(req.Query, "pullRequest(number") {
+		s.t.Logf("Received PR-by-number query: %s", req.Variables)
+		if err := json.NewEncoder(w).Encode(s.handlePRByNumberQuery(req)); err != nil {
+			s.t.Logf("Failed to encode response: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
 
 	s.t.Logf("Received unexpected query: %s", req.Query)
 	w.WriteHeader(http.StatusInternalServerError)
+}
+
+func (s *mockGitHubServer) prToGQL(pr mockPR) map[string]any {
+	gqlpr := map[string]any{
+		"id":          pr.ID,
+		"number":      pr.Number,
+		"headRefName": pr.HeadRefName,
+		"baseRefName": pr.BaseRefName,
+		"isDraft":     pr.IsDraft,
+		"permalink":   fmt.Sprintf("https://github.invalid/mock/mock/pulls/%d", pr.Number),
+		"state":       pr.State,
+		"title":       pr.Title,
+		"body":        pr.Body,
+		"author":      map[string]string{"login": "mock-user"},
+		"createdAt":   "2026-01-01T00:00:00Z",
+	}
+	if pr.MergeCommitOID != "" {
+		gqlpr["mergeCommit"] = map[string]string{"oid": pr.MergeCommitOID}
+	}
+	if pr.ClosedCommitOID != "" {
+		gqlpr["timelineItems"] = map[string]any{
+			"nodes": []any{
+				map[string]any{
+					"__typename": "ClosedEvent",
+					"closer": map[string]any{
+						"__typename": "Commit",
+						"oid":        pr.ClosedCommitOID,
+					},
+				},
+			},
+		}
+	}
+	return gqlpr
 }
 
 func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
@@ -83,36 +125,7 @@ func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
 		if pr.HeadRefName != headRefName {
 			continue
 		}
-		gqlpr := map[string]any{
-			"id":          pr.ID,
-			"number":      pr.Number,
-			"headRefName": pr.HeadRefName,
-			"baseRefName": pr.BaseRefName,
-			"isDraft":     pr.IsDraft,
-			"permalink":   fmt.Sprintf("https://github.invalid/mock/mock/pulls/%d", pr.Number),
-			"state":       pr.State,
-			"title":       pr.Title,
-			"body":        pr.Body,
-			"author":      map[string]string{"login": "mock-user"},
-			"createdAt":   "2026-01-01T00:00:00Z",
-		}
-		if pr.MergeCommitOID != "" {
-			gqlpr["mergeCommit"] = map[string]string{"oid": pr.MergeCommitOID}
-		}
-		if pr.ClosedCommitOID != "" {
-			gqlpr["timelineItems"] = map[string]any{
-				"nodes": []any{
-					map[string]any{
-						"__typename": "ClosedEvent",
-						"closer": map[string]any{
-							"__typename": "Commit",
-							"oid":        pr.ClosedCommitOID,
-						},
-					},
-				},
-			}
-		}
-		prs = append(prs, gqlpr)
+		prs = append(prs, s.prToGQL(pr))
 	}
 	return graphqlResponse{
 		Data: map[string]any{
@@ -120,6 +133,25 @@ func (s *mockGitHubServer) handlePRQuery(req graphqlRequest) graphqlResponse {
 				"pullRequests": map[string]any{
 					"nodes": prs,
 				},
+			},
+		},
+	}
+}
+
+func (s *mockGitHubServer) handlePRByNumberQuery(req graphqlRequest) graphqlResponse {
+	// JSON numbers decode to float64.
+	number := int(req.Variables["number"].(float64))
+	var pr any
+	for _, candidate := range s.pulls {
+		if candidate.Number == number {
+			pr = s.prToGQL(candidate)
+			break
+		}
+	}
+	return graphqlResponse{
+		Data: map[string]any{
+			"repository": map[string]any{
+				"pullRequest": pr,
 			},
 		},
 	}

--- a/e2e_tests/testdata/script/adopt_remote_include_ancestors.txtar
+++ b/e2e_tests/testdata/script/adopt_remote_include_ancestors.txtar
@@ -1,0 +1,38 @@
+# Test non-interactive remote adoption with --include ancestors.
+#
+# Remote stack:  main -> feat-a (PR1) -> feat-b (PR2)
+#
+# `av adopt --remote feat-b --include ancestors` should adopt feat-b and its
+# ancestor feat-a without opening the interactive picker. Here we use --dry-run
+# to assert the adoption plan.
+
+# --include requires --remote.
+! exec av adopt --include ancestors
+stderr '--include can only be used together with --remote'
+
+# --include only accepts known values.
+! exec av adopt --remote feat-b --include cousins
+stderr 'invalid value for --include'
+
+# Model the remote PR stack: each PR body carries av stack metadata so the
+# walk can climb from feat-b up to the trunk.
+mock-pull feat-a 1 OPEN base=main body=$WORK/feat-a-body.txt
+mock-pull feat-b 2 OPEN base=feat-a body=$WORK/feat-b-body.txt
+
+exec av adopt --remote feat-b --include ancestors --dry-run
+stdout 'Would adopt:'
+stdout 'feat-b \(parent: feat-a\)'
+stdout 'feat-a \(parent: main\)'
+
+-- feat-a-body.txt --
+<!-- av pr metadata
+```
+{"parent":"main","trunk":"main"}
+```
+-->
+-- feat-b-body.txt --
+<!-- av pr metadata
+```
+{"parent":"feat-a","parentPull":1,"trunk":"main"}
+```
+-->

--- a/e2e_tests/testscript_test.go
+++ b/e2e_tests/testscript_test.go
@@ -347,16 +347,18 @@ func cmdSetBranchMergeCommit(ts *testscript.TestScript, neg bool, args []string)
 	}
 }
 
-// mock-pull <headRefName> <number> <state> [mergeCommitRef]
+// mock-pull <headRefName> <number> <state> [mergeCommitRef] [base=<ref>] [body=<file>]
 //
-// Adds a mock PR to the GitHub server. If mergeCommitRef is provided,
-// it is resolved via git rev-parse.
+// Adds a mock PR to the GitHub server. If mergeCommitRef is provided (a bare
+// positional arg), it is resolved via git rev-parse. base=<ref> sets the PR's
+// base branch and body=<file> loads the PR body from a fixture file (used to
+// model av stack metadata for remote-adoption tests).
 func cmdMockPull(ts *testscript.TestScript, neg bool, args []string) {
 	if neg {
 		ts.Fatalf("mock-pull does not support negation")
 	}
 	if len(args) < 3 {
-		ts.Fatalf("usage: mock-pull <headRefName> <number> <state> [mergeCommitRef]")
+		ts.Fatalf("usage: mock-pull <headRefName> <number> <state> [mergeCommitRef] [base=<ref>] [body=<file>]")
 	}
 	number, err := strconv.Atoi(args[1])
 	if err != nil {
@@ -368,13 +370,32 @@ func cmdMockPull(ts *testscript.TestScript, neg bool, args []string) {
 		HeadRefName: args[0],
 		State:       args[2],
 	}
-	if len(args) >= 4 && args[3] != "" {
-		dir := ts.MkAbs(".")
-		oid, err := resolveRef(dir, args[3])
-		if err != nil {
-			ts.Fatalf("%v", err)
+	for _, arg := range args[3:] {
+		if arg == "" {
+			continue
 		}
-		pr.MergeCommitOID = oid
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			// Bare positional: merge commit ref.
+			oid, err := resolveRef(ts.MkAbs("."), arg)
+			if err != nil {
+				ts.Fatalf("%v", err)
+			}
+			pr.MergeCommitOID = oid
+			continue
+		}
+		switch key {
+		case "base":
+			pr.BaseRefName = value
+		case "body":
+			body, err := os.ReadFile(ts.MkAbs(value))
+			if err != nil {
+				ts.Fatalf("read body file: %v", err)
+			}
+			pr.Body = string(body)
+		default:
+			ts.Fatalf("unknown mock-pull argument %q", arg)
+		}
 	}
 	server := ts.Value(mockServerKey{}).(*mockGitHubServer)
 	server.pulls = append(server.pulls, pr)


### PR DESCRIPTION
pls 🙏 my Claude needs non-interactive adoption of entire stacks

## What

`av adopt --remote <branch>` always drops into the interactive picker, which is a wall for scripts and agents trying to mirror a coworker's stack locally. This adds an `--include ancestors` flag that skips the picker:

```
av adopt --remote feat-c --include ancestors            # adopt feat-c + its ancestors, no prompt
av adopt --remote feat-c --include ancestors --dry-run  # print the adoption plan only
```

It adopts the named branch and its ancestor chain up to the trunk without prompting. Bare `--remote` still opens the picker, so this is non-breaking. `--include` is a validated string flag (only `ancestors` today) so it can grow to `descendants`/`stack` later without adding new flags.

## Tests

Extends the e2e harness, which had no coverage of the remote-adopt path:
- the mock GitHub server now answers the `pullRequest(number:)` query used to walk parent PRs
- `mock-pull` accepts `base=<ref>` and `body=<file>` so a remote stack with av stack metadata can be modeled

New testscript covers the `--dry-run` plan and `--include` validation.

Stacked on #755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `av adopt --remote` now supports `--include=ancestors` for non-interactive adoption of a remote branch and its ancestor branches.
  - Adoption can now show a dry-run plan before making changes.
  - Adopted branches now keep upstream tracking set automatically where possible.

- **Documentation**
  - Updated command help and manual pages to describe the new remote adoption workflow and `--include` option.

- **Bug Fixes**
  - Improved remote adoption behavior so branch selection and adoption plans work more reliably in automated flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->