### PR TITLE
make repo close nil-safe

### DIFF
--- a/cmd/av/main.go
+++ b/cmd/av/main.go
@@ -136,11 +136,7 @@ func run() int {
 	// runtime and various packages (e.g., package init functions).
 	startTime := time.Now()
 	colors.SetupBackgroundColorTypeFromEnv()
-	defer func() {
-		if cachedRepo != nil {
-			_ = cachedRepo.Close()
-		}
-	}()
+	defer func() { _ = cachedRepo.Close() }()
 	err := rootCmd.Execute()
 	logrus.WithField("duration", time.Since(startTime)).Debug("command exited")
 	checkCliVersion()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -108,6 +108,9 @@ func (r *Repo) GoGitRepo() *git.Repository {
 // open pack .idx files). go-git v6 requires this to avoid leaking file
 // descriptors, which on Windows also blocks removal of temporary directories.
 func (r *Repo) Close() error {
+	if r == nil || r.gitRepo == nil {
+		return nil
+	}
 	return r.gitRepo.Close()
 }
 


### PR DESCRIPTION
follow-up to #759, defensive nil guard on Repo.Close per review

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
