### PR TITLE
Report commits dropped via --skip at the end of restack/sync/reparent

### DIFF
--- a/e2e_tests/testdata/script/restack_skip_reports_dropped_commits.txtar
+++ b/e2e_tests/testdata/script/restack_skip_reports_dropped_commits.txtar
@@ -1,0 +1,33 @@
+# A commit dropped with `restack --skip` must be reported in the final output.
+# Without the report, the restack ends with a green "done" tree and the skipped
+# commit silently disappears from the branch.
+
+exec av branch stack-1
+commit-file my-file '1a\n' 'Commit 1a'
+exec av branch stack-2
+commit-file my-file '1a\n2a\n' 'Commit 2a'
+commit-file other-file 'safe\n' 'Commit 2b'
+
+# Conflicting commit on the parent branch.
+exec git checkout stack-1
+commit-file my-file '1a\n1b\n' 'Commit 1b'
+
+# Rebasing stack-2 conflicts on 'Commit 2a'.
+! exec av restack
+stdout 'could not apply.*Commit 2a'
+
+# Skip the conflicting commit; 'Commit 2b' applies cleanly and the restack
+# completes — but the output must name the dropped commit.
+exec av restack --skip
+stdout 'commit\(s\) were dropped with --skip'
+stdout 'Commit 2a \(was on stack-2\)'
+stdout 'git cherry-pick'
+
+# The skipped commit's change is really gone from stack-2, the clean commit survives.
+exec git checkout stack-2
+cmp my-file $WORK/expected-my-file.txt
+exec cat other-file
+
+-- expected-my-file.txt --
+1a
+1b

--- a/internal/sequencer/sequencer.go
+++ b/internal/sequencer/sequencer.go
@@ -63,6 +63,19 @@ type Sequencer struct {
 	DetachedWorktrees map[string]string
 	// Branches skipped due to dirty worktrees. Maps branch name (short) to reason.
 	SkippedBranches map[string]string
+	// Commits dropped by the user via --skip while resolving rebase conflicts.
+	// These commits are NOT part of the rebased branches.
+	SkippedCommits []SkippedCommit
+}
+
+// SkippedCommit identifies a commit dropped via --skip during a rebase conflict.
+type SkippedCommit struct {
+	// The branch the commit was dropped from.
+	Branch plumbing.ReferenceName
+	// The full commit hash.
+	Hash string
+	// The commit's subject line.
+	Subject string
 }
 
 func NewSequencer(remoteName string, db meta.DB, ops []RestackOp) *Sequencer {
@@ -161,6 +174,16 @@ func (seq *Sequencer) runFromInterruptedState(
 		return result, nil
 	}
 	if seqSkip {
+		// Record the commit being dropped before it disappears from the rebase;
+		// REBASE_HEAD is the commit the rebase stopped on.
+		if hash, err := repo.Git(ctx, "rev-parse", "REBASE_HEAD"); err == nil && hash != "" {
+			subject, _ := repo.Git(ctx, "log", "-1", "--format=%s", hash)
+			seq.SkippedCommits = append(seq.SkippedCommits, SkippedCommit{
+				Branch:  seq.CurrentSyncRef,
+				Hash:    hash,
+				Subject: subject,
+			})
+		}
 		result, err := repo.RebaseParse(ctx, git.RebaseOpts{Skip: true})
 		if err != nil {
 			return nil, errors.Errorf("failed to skip in-progress rebase: %v", err)

--- a/internal/sequencer/sequencerui/ui.go
+++ b/internal/sequencer/sequencerui/ui.go
@@ -2,6 +2,7 @@ package sequencerui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"charm.land/bubbles/v2/spinner"
@@ -207,6 +208,26 @@ func (vm *RestackModel) View() tea.View {
 			}
 			sb.WriteString("\n")
 		}
+	}
+	if vm.state != nil && vm.state.Seq != nil && vm.state.Seq.CurrentSyncRef == "" &&
+		len(vm.state.Seq.SkippedCommits) > 0 {
+		sb.WriteString("\n")
+		sb.WriteString(colors.FailureStyle.Render(
+			fmt.Sprintf(
+				"⚠ %d commit(s) were dropped with --skip and are NOT in the restacked branches:",
+				len(vm.state.Seq.SkippedCommits),
+			),
+		) + "\n")
+		for _, sc := range vm.state.Seq.SkippedCommits {
+			hash := sc.Hash
+			if len(hash) > 7 {
+				hash = hash[:7]
+			}
+			sb.WriteString("  " + hash + " " + sc.Subject + " (was on " + sc.Branch.Short() + ")\n")
+		}
+		sb.WriteString(
+			colors.Faint("Recover a dropped commit with: git cherry-pick <hash>") + "\n",
+		)
 	}
 	if len(vm.worktreeMessages) > 0 {
 		sb.WriteString("\n")


### PR DESCRIPTION
Fixes #772

## Problem

A conflict resolved with `--skip` drops the commit via `git rebase --skip`, but nothing records what was dropped: the run ends with a green ✓ tree and the commit is silently gone from the branch.

## Change

- `internal/sequencer`: before running the skip, record the `REBASE_HEAD` commit (branch, hash, subject) in a new `SkippedCommits` field on `Sequencer`. The sequencer state is already JSON-persisted between invocations, so skips accumulate correctly across the multi-process continue/skip flow.
- `internal/sequencer/sequencerui`: at completion, print a summary of dropped commits with a cherry-pick recovery hint:

```
✓ Restack is done
  ...
⚠ 1 commit(s) were dropped with --skip and are NOT in the restacked branches:
  efbcd77 Commit 2a (was on stack-2)
Recover a dropped commit with: git cherry-pick <hash>
```

Git's automatic empty-commit drops don't go through the `--skip` code path, so the report only fires on user-initiated skips — a clean sync stays quiet.

Covers `restack`, `sync`, and `reparent` (shared sequencer UI).

## Testing

New e2e fixture `restack_skip_reports_dropped_commits.txtar`: builds a stack, conflicts, skips, asserts the summary names the dropped commit and that the branch content really lost it. Existing restack/sync/reparent e2e suites and `internal/...` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restack now reports commits dropped with `--skip`, including each commit’s abbreviated hash, message, and source branch.
  * Added guidance for recovering dropped commits with `git cherry-pick`.

* **Bug Fixes**
  * Improved visibility into skipped changes during interrupted restack operations.

* **Tests**
  * Added end-to-end coverage confirming dropped commits are reported and their changes are correctly excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->