### PR TITLE
avoid pack index scans in restack tree rendering

### DIFF
--- a/internal/sequencer/sequencerui/ui.go
+++ b/internal/sequencer/sequencerui/ui.go
@@ -181,9 +181,19 @@ func (vm *RestackModel) View() tea.View {
 					if avbr.MergeCommit != "" {
 						suffix += " (merged)"
 					}
-					hash, err := vm.repo.GoGitRepo().ResolveRevision(plumbing.Revision(branchName))
-					if err == nil && hash != nil {
-						suffix += " " + hash.String()[:7]
+					// Look up the branch ref directly instead of using
+					// ResolveRevision: revision resolution attempts hash-prefix
+					// expansion, which scans the entire pack index and is
+					// extremely slow on large repositories — especially here,
+					// where View is evaluated on every render frame.
+					ref, err := vm.repo.GoGitRepo().Reference(plumbing.NewBranchReferenceName(branchName), true)
+					if err != nil {
+						// The trunk may not exist as a local branch; fall back
+						// to its remote tracking branch.
+						ref, err = vm.repo.GoGitRepo().Reference(plumbing.NewRemoteReferenceName(vm.repo.GetRemoteName(), branchName), true)
+					}
+					if err == nil {
+						suffix += " " + ref.Hash().String()[:7]
 					}
 
 					bn := plumbing.NewBranchReferenceName(branchName)


### PR DESCRIPTION
the restack view resolved every branch per render frame via ResolveRevision, whose hash-prefix expansion linearly scans the whole pack index in go-git v6 (syscall per entry). on a 2.9M-object repo this turned no-op syncs into ~20s+ of pure CPU. direct ref lookup instead, verified ~112s -> 0.6s on a synthetic repo at that scale

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch revision display in the sequencer interface.
  * Branches now show the abbreviated hash from their current reference, with a fallback for remote-tracking references when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->