### PR TITLE
config: support filtering non-PR branches from stack summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,18 @@ Extract the archive and add the executable to your PATH.
    av init
    ```
 
+## Configuration
+
+To write stack summaries that list only branches with associated pull requests,
+enable both options in `~/.config/av/config.yaml` (or the repository's
+`.git/av/config.yaml`):
+
+```yaml
+pullRequest:
+  writeStack: true
+  writeStackOnlyPRs: true
+```
+
 # Upgrade
 
 ## macOS (Homebrew)

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -763,7 +763,32 @@ func ReadPRMetadata(body string) (PRMetadata, error) {
 	return prMeta, err
 }
 
-func walkStack(tx meta.ReadTx, stack *stackutils.StackTreeNode, branchName string) string {
+func filterStackToBranchesWithPR(
+	tx meta.ReadTx,
+	node *stackutils.StackTreeNode,
+) []*stackutils.StackTreeNode {
+	var children []*stackutils.StackTreeNode
+	for _, child := range node.Children {
+		children = append(children, filterStackToBranchesWithPR(tx, child)...)
+	}
+
+	branch, _ := tx.Branch(node.Branch.BranchName)
+	if branch.PullRequest == nil {
+		return children
+	}
+
+	return []*stackutils.StackTreeNode{{
+		Branch:   node.Branch,
+		Children: children,
+	}}
+}
+
+func walkStack(
+	tx meta.ReadTx,
+	stacks []*stackutils.StackTreeNode,
+	branchName string,
+	onlyPullRequests bool,
+) string {
 	ssb := strings.Builder{}
 
 	// For simple stacks (i.e., degenerate trees) print them top-down. For example:
@@ -781,7 +806,7 @@ func walkStack(tx meta.ReadTx, stack *stackutils.StackTreeNode, branchName strin
 
 		ssb.WriteString("* ")
 
-		if depth == 0 || bi.PullRequest == nil {
+		if (!onlyPullRequests && depth == 0) || bi.PullRequest == nil {
 			ssb.WriteString("`")
 			ssb.WriteString(node.Branch.BranchName)
 			ssb.WriteString("`")
@@ -803,7 +828,7 @@ func walkStack(tx meta.ReadTx, stack *stackutils.StackTreeNode, branchName strin
 	//   - #3
 	var visitComplex func(node *stackutils.StackTreeNode, depth int)
 	visitComplex = func(node *stackutils.StackTreeNode, depth int) {
-		if depth == 0 {
+		if depth == 0 && !onlyPullRequests {
 			ssb.WriteString("* ")
 			ssb.WriteString("`")
 			ssb.WriteString(node.Branch.BranchName)
@@ -842,11 +867,20 @@ func walkStack(tx meta.ReadTx, stack *stackutils.StackTreeNode, branchName strin
 		return false
 	}
 
+	hasMultipleRoots := len(stacks) > 1
+	for _, stack := range stacks {
+		hasMultipleRoots = hasMultipleRoots || hasMultipleChildren(stack)
+	}
+
 	// Optimize navigation within a stack by making sure the output has the same shape everywhere.
-	if hasMultipleChildren(stack) {
-		visitComplex(stack, 0)
+	if hasMultipleRoots {
+		for _, stack := range stacks {
+			visitComplex(stack, 0)
+		}
 	} else {
-		visitSimple(stack, 0)
+		for _, stack := range stacks {
+			visitSimple(stack, 0)
+		}
 	}
 
 	return ssb.String()
@@ -867,12 +901,20 @@ func AddPRMetadataAndStack(
 
 	sb := strings.Builder{}
 
+	stacks := []*stackutils.StackTreeNode{}
+	if stack != nil {
+		stacks = append(stacks, stack)
+	}
+	if config.Av.PullRequest.WriteStackOnlyPRs && stack != nil {
+		stacks = filterStackToBranchesWithPR(tx, stack)
+	}
+
 	// Don't write out a stack unless there is more than one PR in it.
 	hasMultilevelStack := stack != nil && len(stack.Children) > 0 &&
 		len(stack.Children[0].Children) > 0
 	if hasMultilevelStack {
 		bi, _ := tx.Branch(branchName)
-		stackString := walkStack(tx, stack, branchName)
+		stackString := walkStack(tx, stacks, branchName, config.Av.PullRequest.WriteStackOnlyPRs)
 		sb.WriteString(PRStackCommentStart)
 
 		// Enclose this stack summary in a table for two reasons:

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -783,6 +783,21 @@ func filterStackToBranchesWithPR(
 	}}
 }
 
+func nearestParentPullRequest(tx meta.ReadTx, branch meta.Branch) *meta.PullRequest {
+	parentName := branch.Parent.Name
+	for parentName != "" {
+		parent, ok := tx.Branch(parentName)
+		if !ok {
+			return nil
+		}
+		if parent.PullRequest != nil {
+			return parent.PullRequest
+		}
+		parentName = parent.Parent.Name
+	}
+	return nil
+}
+
 func walkStack(
 	tx meta.ReadTx,
 	stacks []*stackutils.StackTreeNode,
@@ -923,10 +938,11 @@ func AddPRMetadataAndStack(
 		sb.WriteString("\n<table><tr><td>")
 		sb.WriteString("<details><summary>")
 		if !bi.Parent.Trunk {
-			parentBi, _ := tx.Branch(bi.Parent.Name)
-			sb.WriteString("<b>Depends on #")
-			sb.WriteString(strconv.FormatInt(parentBi.PullRequest.Number, 10))
-			sb.WriteString(".</b> ")
+			if parentPR := nearestParentPullRequest(tx, bi); parentPR != nil {
+				sb.WriteString("<b>Depends on #")
+				sb.WriteString(strconv.FormatInt(parentPR.Number, 10))
+				sb.WriteString(".</b> ")
+			}
 		}
 		sb.WriteString(
 			"This PR is part of a stack created with <a href=\"https://github.com/aviator-co/av\">Aviator</a>.",

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aviator-co/av/internal/actions"
+	"github.com/aviator-co/av/internal/config"
 	"github.com/aviator-co/av/internal/meta"
 	"github.com/aviator-co/av/internal/utils/maputils"
 	"github.com/aviator-co/av/internal/utils/stackutils"
@@ -244,6 +245,61 @@ This information is embedded by the av CLI when creating PRs to track the status
 `+"```"+`
 -->
 `, body1)
+}
+
+func TestPRWithStackOnlyPRs(t *testing.T) {
+	previousValue := config.Av.PullRequest.WriteStackOnlyPRs
+	config.Av.PullRequest.WriteStackOnlyPRs = true
+	t.Cleanup(func() { config.Av.PullRequest.WriteStackOnlyPRs = previousValue })
+
+	tx := fakeReadTx{
+		"base": {
+			Name: "base",
+			Parent: meta.BranchState{
+				Name:  "main",
+				Trunk: true,
+			},
+			PullRequest: &meta.PullRequest{
+				Number:    1001,
+				Permalink: "https://github.com/org/repo/pull/1001",
+			},
+		},
+		"feature": {
+			Name: "feature",
+			Parent: meta.BranchState{
+				Name: "base",
+			},
+			PullRequest: &meta.PullRequest{
+				Number:    1002,
+				Permalink: "https://github.com/org/repo/pull/1002",
+			},
+		},
+	}
+	stack := &stackutils.StackTreeNode{
+		Branch: &stackutils.StackTreeBranchInfo{BranchName: "main"},
+		Children: []*stackutils.StackTreeNode{{
+			Branch: &stackutils.StackTreeBranchInfo{BranchName: "base"},
+			Children: []*stackutils.StackTreeNode{{
+				Branch: &stackutils.StackTreeBranchInfo{BranchName: "feature"},
+				Children: []*stackutils.StackTreeNode{{
+					Branch:   &stackutils.StackTreeBranchInfo{BranchName: "unsubmitted"},
+					Children: []*stackutils.StackTreeNode{},
+				}},
+			}},
+		}},
+	}
+
+	body := actions.AddPRMetadataAndStack(
+		"PR body",
+		actions.PRMetadata{},
+		"feature",
+		stack,
+		tx,
+	)
+
+	assert.Contains(t, body, "* ➡️ **#1002**\n* **#1001**\n")
+	assert.NotContains(t, body, "`main`")
+	assert.NotContains(t, body, "`unsubmitted`")
 }
 
 type fakeReadTx map[string]meta.Branch

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -302,6 +302,60 @@ func TestPRWithStackOnlyPRs(t *testing.T) {
 	assert.NotContains(t, body, "`unsubmitted`")
 }
 
+func TestPRWithStackOnlyPRsUsesNearestParentPullRequest(t *testing.T) {
+	previousValue := config.Av.PullRequest.WriteStackOnlyPRs
+	config.Av.PullRequest.WriteStackOnlyPRs = true
+	t.Cleanup(func() { config.Av.PullRequest.WriteStackOnlyPRs = previousValue })
+
+	tx := fakeReadTx{
+		"base": {
+			Name: "base",
+			Parent: meta.BranchState{
+				Name:  "main",
+				Trunk: true,
+			},
+			PullRequest: &meta.PullRequest{Number: 1001},
+		},
+		"unsubmitted": {
+			Name: "unsubmitted",
+			Parent: meta.BranchState{
+				Name: "base",
+			},
+		},
+		"feature": {
+			Name: "feature",
+			Parent: meta.BranchState{
+				Name: "unsubmitted",
+			},
+			PullRequest: &meta.PullRequest{Number: 1002},
+		},
+	}
+	stack := &stackutils.StackTreeNode{
+		Branch: &stackutils.StackTreeBranchInfo{BranchName: "main"},
+		Children: []*stackutils.StackTreeNode{{
+			Branch: &stackutils.StackTreeBranchInfo{BranchName: "base"},
+			Children: []*stackutils.StackTreeNode{{
+				Branch: &stackutils.StackTreeBranchInfo{BranchName: "unsubmitted"},
+				Children: []*stackutils.StackTreeNode{{
+					Branch:   &stackutils.StackTreeBranchInfo{BranchName: "feature"},
+					Children: []*stackutils.StackTreeNode{},
+				}},
+			}},
+		}},
+	}
+
+	body := actions.AddPRMetadataAndStack(
+		"PR body",
+		actions.PRMetadata{},
+		"feature",
+		stack,
+		tx,
+	)
+
+	assert.Contains(t, body, "<b>Depends on #1001.</b>")
+	assert.NotContains(t, body, "`unsubmitted`")
+}
+
 type fakeReadTx map[string]meta.Branch
 
 func (tx fakeReadTx) Repository() meta.Repository {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,10 @@ type PullRequest struct {
 	// If true, the CLI will automatically add/update a comment to all PRs linking other PRs in the stack.
 	// False by default, since Aviator's MergeQueue also adds a similar comment.
 	WriteStack bool
+
+	// If true, stack summaries include only branches that have an associated pull request.
+	// This setting has no effect unless WriteStack is enabled.
+	WriteStackOnlyPRs bool
 }
 
 type Sync struct {


### PR DESCRIPTION
## Summary

Adds a `pullRequest.writeStackOnlyPRs` configuration option for stack summaries.

When enabled alongside `pullRequest.writeStack`, Aviator excludes branches without an associated pull request from the stack summary in PR descriptions.

## Changes

- Add `writeStackOnlyPRs` to pull request configuration.
- Filter non-PR branches before rendering stack summaries.
- Document the configuration in the README.
- Add coverage for filtered stack-summary rendering.

## Testing

- `go test ./...`
- Verified end-to-end in a test repository with two stacked PRs and an unsubmitted child branch. The PR summary included only the two PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to limit stack summaries to only branches that have associated pull requests when stack summaries are enabled.
  - Updated stack summary rendering to correctly handle nested/complex layouts and to resolve dependency info using the nearest ancestor pull request.
- **Documentation**
  - Added README setup instructions for enabling the filtering option in the configuration file.
- **Tests**
  - Added tests covering filtered stack output and nearest-ancestor pull request behavior when intermediate nodes lack pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->