### PR TITLE
add slack notifications to release workflows and unbreak pre-commit

### DIFF
--- a/.github/actions/notify-deploy/action.yml
+++ b/.github/actions/notify-deploy/action.yml
@@ -1,0 +1,92 @@
+name: "Notify deploy"
+description: >
+  Post a release notification to the deploy-bot Slack channel. Handles start /
+  success / failure messaging with consistent formatting (:tada: on success,
+  :rotating_light: on failure) and an optional <!here> ping on failure.
+
+inputs:
+  state:
+    description: "One of: start, success, failure"
+    required: true
+  subject:
+    description: "Noun phrase for what's happening (e.g. 'CLI release', 'nightly release')."
+    required: false
+    default: "release"
+  version:
+    description: "Version being released. Omit when no version is meaningful."
+    required: false
+    default: ""
+  ping_at_here:
+    description: "Include <!here> on failure"
+    required: false
+    default: "false"
+  webhook_url:
+    description: "Slack incoming-webhook URL. Pass the secrets.SLACK_WEBHOOK_PROD_DEPLOY_UPDATES expression from the caller."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        STATE: ${{ inputs.state }}
+        SUBJECT: ${{ inputs.subject }}
+        VERSION: ${{ inputs.version }}
+        PING_AT_HERE: ${{ inputs.ping_at_here }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WEBHOOK_URL: ${{ inputs.webhook_url }}
+      run: |
+        # A notification is never worth failing a release over, so a missing
+        # webhook variable warns instead of erroring.
+        if [ -z "$WEBHOOK_URL" ]; then
+          echo "::warning::SLACK_WEBHOOK_PROD_DEPLOY_UPDATES is not set, skipping notification"
+          exit 0
+        fi
+
+        if [ -n "$VERSION" ]; then
+          VER_MD=" \`${VERSION}\`"
+          VER_PLAIN=" ${VERSION}"
+        else
+          VER_MD=""
+          VER_PLAIN=""
+        fi
+
+        case "$STATE" in
+          start)
+            PREFIX=""
+            HEADLINE="Starting ${SUBJECT}${VER_MD}."
+            FALLBACK="Starting ${SUBJECT}${VER_PLAIN}"
+            ;;
+          success)
+            PREFIX=":tada: "
+            HEADLINE="${SUBJECT}${VER_MD} succeeded."
+            FALLBACK="${SUBJECT}${VER_PLAIN} succeeded"
+            ;;
+          failure)
+            if [ "$PING_AT_HERE" = "true" ]; then
+              PREFIX=":rotating_light: <!here> "
+            else
+              PREFIX=":rotating_light: "
+            fi
+            HEADLINE="${SUBJECT}${VER_MD} failed."
+            FALLBACK="${SUBJECT}${VER_PLAIN} failed"
+            ;;
+          *)
+            echo "Unknown state: $STATE (expected start|success|failure)" >&2
+            exit 1
+            ;;
+        esac
+
+        BODY="${PREFIX}${HEADLINE} <${RUN_URL}|View run>"
+        PAYLOAD=$(jq -n --arg text "$FALLBACK" --arg body "$BODY" '{
+          text: $text,
+          blocks: [{ type: "section", text: { type: "mrkdwn", text: $body } }]
+        }')
+
+        if ! curl --fail --silent --show-error \
+          --connect-timeout 5 --max-time 15 \
+          -X POST -H 'Content-type: application/json' \
+          --data-binary "$PAYLOAD" \
+          "$WEBHOOK_URL"; then
+          echo "::warning::Slack notification failed"
+        fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns: ["*"]
@@ -11,6 +13,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       golang:
+        patterns: ["*"]
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      pre-commit:
         patterns: ["*"]

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -19,22 +19,26 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: "write"
     steps:
-      - uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2
-        if: inputs.aviator_deployment_id != ''
-        with:
-          url: '${{ vars.AVIATOR_API_HOST }}/api/v1/sync-deploy-github-action'
-          method: 'POST'
-          bearerToken: ${{ secrets.AVIATOR_API_TOKEN }}
-          data: '{"deployment_id": "${{ inputs.aviator_deployment_id }}", "workflow_run_id": "${{ github.run_id }}"}'
+      # Checkout has to come first: the notify-deploy steps below are a local
+      # action, so anything failing before this point reports nothing to Slack.
+      # fetch-depth 0 also brings tags, which goreleaser needs.
       - name: checkout
         uses: actions/checkout@v7
         with:
           ref: "${{ inputs.aviator_release_cut_commit_hash || github.ref }}"
           fetch-depth: 0
           persist-credentials: false
+      - uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
+        if: inputs.aviator_deployment_id != ''
+        with:
+          url: '${{ vars.AVIATOR_API_HOST }}/api/v1/sync-deploy-github-action'
+          method: 'POST'
+          bearerToken: ${{ secrets.AVIATOR_API_TOKEN }}
+          data: '{"deployment_id": "${{ inputs.aviator_deployment_id }}", "workflow_run_id": "${{ github.run_id }}"}'
       - name: fetch tags
         run: git fetch --force --tags
       - name: create nightly tag
@@ -46,6 +50,13 @@ jobs:
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git tag "v${VERSION}-nightly" 2>/dev/null || echo "Tag v${VERSION}-nightly already exists"
           git push origin "v${VERSION}-nightly" 2>/dev/null || echo "Tag v${VERSION}-nightly already on remote"
+      - name: Notify release start
+        uses: ./.github/actions/notify-deploy
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_PROD_DEPLOY_UPDATES }}
+          state: start
+          subject: "av nightly release"
+          version: "v${{ inputs.aviator_release_candidate_version }}-nightly"
       - name: configure nightly prerelease
         run: yq '.release.prerelease = true | del(.git.ignore_tags)' .goreleaser.yaml > /tmp/goreleaser-nightly.yaml
       - name: install go
@@ -63,3 +74,20 @@ jobs:
           RELEASE_ENV: nightly
           AVIATOR_CO_HOMEBREW_REPO_SSH_KEY: ${{ secrets.AVIATOR_CO_HOMEBREW_REPO_SSH_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify release success
+        uses: ./.github/actions/notify-deploy
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_PROD_DEPLOY_UPDATES }}
+          state: success
+          subject: "av nightly release"
+          version: "v${{ inputs.aviator_release_candidate_version }}-nightly"
+      - name: Notify release failure
+        # This includes cancellation.
+        if: ${{ !success() }}
+        uses: ./.github/actions/notify-deploy
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_PROD_DEPLOY_UPDATES }}
+          state: failure
+          subject: "av nightly release"
+          version: "v${{ inputs.aviator_release_candidate_version }}-nightly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,22 +23,26 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: "write"
     steps:
-      - uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2
-        if: github.event_name == 'workflow_dispatch' && inputs.aviator_deployment_id != ''
-        with:
-          url: '${{ vars.AVIATOR_API_HOST }}/api/v1/sync-deploy-github-action'
-          method: 'POST'
-          bearerToken: ${{ secrets.AVIATOR_API_TOKEN }}
-          data: '{"deployment_id": "${{ inputs.aviator_deployment_id }}", "workflow_run_id": "${{ github.run_id }}"}'
+      # Checkout has to come first: the notify-deploy steps below are a local
+      # action, so anything failing before this point reports nothing to Slack.
+      # fetch-depth 0 also brings tags, which goreleaser needs.
       - name: checkout
         uses: actions/checkout@v7
         with:
           ref: "${{ inputs.aviator_release_cut_commit_hash || github.ref }}"
           fetch-depth: 0
           persist-credentials: false
+      - uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
+        if: github.event_name == 'workflow_dispatch' && inputs.aviator_deployment_id != ''
+        with:
+          url: '${{ vars.AVIATOR_API_HOST }}/api/v1/sync-deploy-github-action'
+          method: 'POST'
+          bearerToken: ${{ secrets.AVIATOR_API_TOKEN }}
+          data: '{"deployment_id": "${{ inputs.aviator_deployment_id }}", "workflow_run_id": "${{ github.run_id }}"}'
       - name: fetch tags
         run: git fetch --force --tags
       - name: create release tag
@@ -54,6 +58,13 @@ jobs:
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin "v${VERSION}"
           echo "release_tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Notify release start
+        uses: ./.github/actions/notify-deploy
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_PROD_DEPLOY_UPDATES }}
+          state: start
+          subject: "av release"
+          version: ${{ steps.create_tag.outputs.release_tag || github.ref_name }}
       - name: install go
         uses: actions/setup-go@v6
         with:
@@ -69,3 +80,20 @@ jobs:
           AVIATOR_CO_HOMEBREW_REPO_SSH_KEY: ${{ secrets.AVIATOR_CO_HOMEBREW_REPO_SSH_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FURY_TOKEN: ${{ secrets.FURY_PUSH_TOKEN }}
+
+      - name: Notify release success
+        uses: ./.github/actions/notify-deploy
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_PROD_DEPLOY_UPDATES }}
+          state: success
+          subject: "av release"
+          version: ${{ steps.create_tag.outputs.release_tag || github.ref_name }}
+      - name: Notify release failure
+        # This includes cancellation.
+        if: ${{ !success() }}
+        uses: ./.github/actions/notify-deploy
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_PROD_DEPLOY_UPDATES }}
+          state: failure
+          subject: "av release"
+          version: ${{ steps.create_tag.outputs.release_tag || github.ref_name }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,13 +20,13 @@ repos:
         args: ['--branch', 'master']
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.33.0
+    rev: 0.37.4
     hooks:
       - id: check-dependabot
       - id: check-github-actions
       - id: check-github-workflows
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.9.0
+    rev: v1.29.0
     hooks:
       - id: zizmor


### PR DESCRIPTION
av had no release alerting and its pinned pre-commit hooks were stale enough that zizmor stopped working

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slack notifications for release and nightly deployment start, success, failure, and cancellation events.
  * Notifications include release details, versions, workflow links, and optional failure alerts.

* **Workflow Improvements**
  * Deployment status synchronization now runs with the required repository and release context.

* **Chores**
  * Added dependency update cooldowns and grouped update scheduling.
  * Updated pre-commit validation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->