### PR TITLE
resolve restack state before starting the tui

### DIFF
--- a/cmd/av/commit_common.go
+++ b/cmd/av/commit_common.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"charm.land/bubbles/v2/spinner"
@@ -19,7 +20,17 @@ import (
 var nothingToRestackError = errors.Sentinel("nothing to restack")
 
 func runPostCommitRestack(repo *git.Repo, db meta.DB) error {
-	return uiutils.RunBubbleTea(&postCommitRestackViewModel{repo: repo, db: db})
+	vm := &postCommitRestackViewModel{repo: repo, db: db}
+	state, err := vm.createState()
+	if errors.Is(err, nothingToRestackError) {
+		fmt.Println(nothingToRestackError)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	vm.state = state
+	return uiutils.RunBubbleTea(vm)
 }
 
 type postCommitRestackViewModel struct {
@@ -34,11 +45,6 @@ type postCommitRestackViewModel struct {
 }
 
 func (vm *postCommitRestackViewModel) Init() tea.Cmd {
-	var err error
-	vm.state, err = vm.createState()
-	if err != nil {
-		return uiutils.ErrCmd(err)
-	}
 	vm.restackModel = sequencerui.NewRestackModel(vm.repo, vm.db, vm.state, sequencerui.RestackStateOptions{
 		OnConflict: func() tea.Cmd {
 			if err := vm.writeState(vm.state); err != nil {

--- a/cmd/av/reparent.go
+++ b/cmd/av/reparent.go
@@ -54,7 +54,13 @@ var reparentCmd = &cobra.Command{
 			reparentFlags.Parent = repo.DefaultBranch()
 		}
 
-		return uiutils.RunBubbleTea(&reparentViewModel{repo: repo, db: db})
+		vm := &reparentViewModel{repo: repo, db: db}
+		state, err := vm.createState()
+		if err != nil {
+			return err
+		}
+		vm.state = state
+		return uiutils.RunBubbleTea(vm)
 	},
 }
 
@@ -70,11 +76,6 @@ type reparentViewModel struct {
 }
 
 func (vm *reparentViewModel) Init() tea.Cmd {
-	var err error
-	vm.state, err = vm.createState()
-	if err != nil {
-		return uiutils.ErrCmd(err)
-	}
 	vm.restackModel = sequencerui.NewRestackModel(vm.repo, vm.db, vm.state, sequencerui.RestackStateOptions{
 		OnConflict: func() tea.Cmd {
 			if err := vm.writeState(vm.state); err != nil {

--- a/cmd/av/restack.go
+++ b/cmd/av/restack.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"charm.land/bubbles/v2/spinner"
@@ -42,7 +43,26 @@ var restackCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return uiutils.RunBubbleTea(&restackViewModel{repo: repo, db: db})
+		vm := &restackViewModel{repo: repo, db: db}
+		state, err := vm.readState()
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			if restackFlags.Abort || restackFlags.Continue || restackFlags.Skip {
+				return errors.New("no restack in progress")
+			}
+			state, err = vm.createState()
+			if err != nil {
+				return err
+			}
+		}
+		if state == nil {
+			fmt.Println(nothingToRestackError)
+			return nil
+		}
+		vm.state = state
+		return uiutils.RunBubbleTea(vm)
 	},
 }
 
@@ -58,23 +78,6 @@ type restackViewModel struct {
 }
 
 func (vm *restackViewModel) Init() tea.Cmd {
-	var err error
-	vm.state, err = vm.readState()
-	if err != nil {
-		return uiutils.ErrCmd(err)
-	}
-	if vm.state == nil {
-		if restackFlags.Abort || restackFlags.Continue || restackFlags.Skip {
-			return uiutils.ErrCmd(errors.New("no restack in progress"))
-		}
-		vm.state, err = vm.createState()
-		if err != nil {
-			return uiutils.ErrCmd(err)
-		}
-	}
-	if vm.state == nil {
-		return uiutils.ErrCmd(nothingToRestackError)
-	}
 	vm.restackModel = sequencerui.NewRestackModel(vm.repo, vm.db, vm.state, sequencerui.RestackStateOptions{
 		Abort:    restackFlags.Abort,
 		Continue: restackFlags.Continue,

--- a/cmd/av/sync.go
+++ b/cmd/av/sync.go
@@ -103,11 +103,20 @@ but can still be synced explicitly.
 			return err
 		}
 
-		return uiutils.RunBubbleTea(&syncViewModel{
+		vm := &syncViewModel{
 			repo:   repo,
 			db:     db,
 			client: client,
-		})
+		}
+		savedState, err := vm.readState()
+		if err != nil {
+			return err
+		}
+		if savedState == nil && (syncFlags.Abort || syncFlags.Continue || syncFlags.Skip) {
+			return errors.New("no restack in progress")
+		}
+		vm.savedState = savedState
+		return uiutils.RunBubbleTea(vm)
 	},
 }
 
@@ -128,6 +137,7 @@ type syncViewModel struct {
 	db     meta.DB
 	client *gh.Client
 
+	savedState   *savedSyncState
 	state        *syncState
 	restackState *sequencerui.RestackState
 
@@ -145,15 +155,8 @@ func (vm *syncViewModel) Init() tea.Cmd {
 }
 
 func (vm *syncViewModel) initSync() tea.Cmd {
-	state, err := vm.readState()
-	if err != nil {
-		return uiutils.ErrCmd(err)
-	}
-	if state != nil {
-		return vm.continueWithState(state)
-	}
-	if syncFlags.Abort || syncFlags.Continue || syncFlags.Skip {
-		return uiutils.ErrCmd(errors.New("no restack in progress"))
+	if vm.savedState != nil {
+		return vm.continueWithState(vm.savedState)
 	}
 
 	isTrunkBranch, err := vm.repo.IsCurrentBranchTrunk()


### PR DESCRIPTION
bubbletea v2 asks the terminal about modes 2026/2027 at startup, and commands that quit immediately (nothing to restack, no restack in progress) exit before the reply arrives, so it lands in your shell prompt as `^[[?2026;2$y`. resolving the state first means those cases never start a tui.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restack, reparent, post-commit restack, and sync commands now validate their state before opening the interactive interface.
  - Commands clearly report when there is no active restack instead of launching an empty interface.
  - Abort, continue, and skip options now return an immediate error when no restack is in progress.
  - Sync and restack operations more reliably resume from previously saved progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->